### PR TITLE
Refactoring multipart requests and chunking operations

### DIFF
--- a/tableauserverapi/server/endpoint/endpoint.py
+++ b/tableauserverapi/server/endpoint/endpoint.py
@@ -5,6 +5,7 @@ logger = logging.getLogger('tableau.endpoint')
 
 Success_codes = [200, 201, 204]
 
+
 class Endpoint(object):
     def __init__(self):
         self.parent_srv = None
@@ -33,21 +34,9 @@ class Endpoint(object):
                                                          **self.parent_srv.http_options)
         self._check_status(server_response)
 
-    def put_request(self, url, xml_request):
+    def put_request(self, url, xml_request, content_type='text/xml'):
         auth_token = self.parent_srv.auth_token
-        logger.debug('Sending request to {0}: \n\t{1}'.format(url, xml_request))
         server_response = self.parent_srv.session.put(url, data=xml_request,
-                                                      headers={'x-tableau-auth': auth_token},
-                                                      **self.parent_srv.http_options)
-        self._check_status(server_response)
-
-        if server_response.encoding:
-            logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
-        return server_response
-
-    def put_multipart_request(self, url, req_body, content_type):
-        auth_token = self.parent_srv.auth_token
-        server_response = self.parent_srv.session.put(url, data=req_body,
                                                       headers={'x-tableau-auth': auth_token,
                                                                'content-type': content_type},
                                                       **self.parent_srv.http_options)
@@ -56,21 +45,9 @@ class Endpoint(object):
             logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
         return server_response
 
-    def post_request(self, url, xml_request):
+    def post_request(self, url, xml_request, content_type='text/xml'):
         auth_token = self.parent_srv.auth_token
-        logger.debug('Sending request to {0}: \n\t{1}'.format(url, xml_request))
         server_response = self.parent_srv.session.post(url, data=xml_request,
-                                                       headers={'x-tableau-auth': auth_token},
-                                                       **self.parent_srv.http_options)
-        self._check_status(server_response)
-        if server_response.encoding:
-            logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
-        return server_response
-
-    def post_multipart_request(self, url, req_body, content_type='text/xml'):
-        # Get rid of above
-        auth_token = self.parent_srv.auth_token
-        server_response = self.parent_srv.session.post(url, data=req_body,
                                                        headers={'x-tableau-auth': auth_token,
                                                                 'content-type': content_type},
                                                        **self.parent_srv.http_options)

--- a/tableauserverapi/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverapi/server/endpoint/fileuploads_endpoint.py
@@ -1,7 +1,12 @@
 from endpoint import Endpoint
 from exceptions import MissingRequiredFieldError
+from .. import RequestFactory
 from ...models.fileupload_item import FileuploadItem
+import os.path
 import logging
+
+# For when a datasource is over 64MB, break it into 5MB(standard chunk size) chunks
+CHUNK_SIZE = 1024 * 1024 * 5  # 5MB
 
 logger = logging.getLogger('tableau.endpoint.fileuploads')
 
@@ -24,11 +29,32 @@ class Fileuploads(Endpoint):
         logger.info('Initiated file upload session (ID: {0})'.format(self.upload_id))
         return self.upload_id
 
-    def append(self, req_body, content_type):
+    def append(self, xml_request, content_type):
         if not self.upload_id:
             error = "File upload session must be initiated first."
             raise MissingRequiredFieldError(error)
         url = "{0}/{1}".format(self._construct_url(), self.upload_id)
-        server_response = self.put_multipart_request(url, req_body, content_type)
+        server_response = self.put_request(url, xml_request, content_type)
         logger.info('Uploading a chunk to session (ID: {0})'.format(self.upload_id))
         return FileuploadItem.from_response(server_response.text)
+
+    def read_chunks(self, file_path):
+        with open(file_path, 'rb') as f:
+            while True:
+                chunked_content = f.read(CHUNK_SIZE)
+                if not chunked_content:
+                    break
+                yield chunked_content
+
+    @classmethod
+    def upload_chunks(cls, parent_srv, file_path):
+        file_uploader = cls(parent_srv)
+        upload_id = file_uploader.initiate()
+        chunks = file_uploader.read_chunks(file_path)
+        for chunk in chunks:
+            xml_request, content_type = RequestFactory.Fileupload.chunk_req(chunk)
+            fileupload_item = file_uploader.append(xml_request, content_type)
+            logger.info("\tPublished {0}MB of {1}".format(fileupload_item.file_size,
+                                                          os.path.basename(file_path)))
+        logger.info("\tCommitting file upload...")
+        return upload_id

--- a/tableauserverapi/server/request_factory.py
+++ b/tableauserverapi/server/request_factory.py
@@ -62,6 +62,8 @@ class DatasourceRequest(object):
         parts = {'request_payload': ('', xml_request, 'text/xml')}
         return _add_multipart(parts)
 
+
+class FileuploadRequest(object):
     def chunk_req(self, chunk):
         parts = {'request_payload': ('', '', 'text/xml'),
                  'tableau_file': ('file', chunk, 'application/octet-stream')}
@@ -239,15 +241,11 @@ class WorkbookRequest(object):
         parts = {'request_payload': ('', xml_request, 'text/xml')}
         return _add_multipart(parts)
 
-    def chunk_req(self, chunk):
-        parts = {'request_payload': ('', '', 'text/xml'),
-                 'tableau_file': ('file', chunk, 'application/octet-stream')}
-        return _add_multipart(parts)
-
 
 class RequestFactory(object):
     Auth = AuthRequest()
     Datasource = DatasourceRequest()
+    Fileupload = FileuploadRequest()
     Group = GroupRequest()
     Permission = PermissionRequest()
     Project = ProjectRequest()


### PR DESCRIPTION
Refactored the separate functions for multipart put and post requests in endpoint.py.
Chunking operations that were included in both workbooks_endpoint and datasources_endpoint are moved to fileuploads_endpoint.
