### PR TITLE
Address unicode failures by using requests response.content

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -28,7 +28,7 @@ class Auth(Endpoint):
         server_response = self.parent_srv.session.post(url, data=signin_req,
                                                        **self.parent_srv.http_options)
         Endpoint._check_status(server_response)
-        parsed_response = ET.fromstring(server_response.text)
+        parsed_response = ET.fromstring(server_response.content)
         site_id = parsed_response.find('.//t:site', namespaces=NAMESPACE).get('id', None)
         user_id = parsed_response.find('.//t:user', namespaces=NAMESPACE).get('id', None)
         auth_token = parsed_response.find('t:credentials', namespaces=NAMESPACE).get('token', None)

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -29,8 +29,8 @@ class Datasources(Endpoint):
         logger.info('Querying all datasources on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_datasource_items = DatasourceItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_datasource_items = DatasourceItem.from_response(server_response.content)
         return pagination_item, all_datasource_items
 
     # Get 1 datasource by id
@@ -41,7 +41,7 @@ class Datasources(Endpoint):
         logger.info('Querying single datasource (ID: {0})'.format(datasource_id))
         url = "{0}/{1}".format(self._construct_url(), datasource_id)
         server_response = self.get_request(url)
-        return DatasourceItem.from_response(server_response.text)[0]
+        return DatasourceItem.from_response(server_response.content)[0]
 
     # Populate datasource item's connections
     def populate_connections(self, datasource_item):
@@ -50,7 +50,7 @@ class Datasources(Endpoint):
             raise MissingRequiredFieldError(error)
         url = '{0}/{1}/connections'.format(self._construct_url(), datasource_item.id)
         server_response = self.get_request(url)
-        datasource_item._set_connections(ConnectionItem.from_response(server_response.text))
+        datasource_item._set_connections(ConnectionItem.from_response(server_response.content))
         logger.info('Populated connections for datasource (ID: {0})'.format(datasource_item.id))
 
     # Delete 1 datasource by id
@@ -91,7 +91,7 @@ class Datasources(Endpoint):
         server_response = self.put_request(url, update_req)
         logger.info('Updated datasource item (ID: {0})'.format(datasource_item.id))
         updated_datasource = copy.copy(datasource_item)
-        return updated_datasource._parse_common_tags(server_response.text)
+        return updated_datasource._parse_common_tags(server_response.content)
 
     # Publish datasource
     def publish(self, datasource_item, file_path, mode):
@@ -131,6 +131,6 @@ class Datasources(Endpoint):
                                                                               filename,
                                                                               file_contents)
         server_response = self.post_request(url, xml_request, content_type)
-        new_datasource = DatasourceItem.from_response(server_response.text)[0]
+        new_datasource = DatasourceItem.from_response(server_response.content)[0]
         logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
         return new_datasource

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -13,7 +13,7 @@ class Endpoint(object):
     @staticmethod
     def _check_status(server_response):
         if server_response.status_code not in Success_codes:
-            raise ServerResponseError.from_response(server_response.text)
+            raise ServerResponseError.from_response(server_response.content)
 
     def get_request(self, url, request_object=None):
         if request_object is not None:
@@ -24,7 +24,7 @@ class Endpoint(object):
                                                       **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
         return server_response
 
     def delete_request(self, url):
@@ -42,7 +42,7 @@ class Endpoint(object):
                                                       **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
         return server_response
 
     def post_request(self, url, xml_request, content_type='text/xml'):
@@ -53,5 +53,5 @@ class Endpoint(object):
                                                        **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug('Server response from {0}: \n\t{1}'.format(url, server_response.text))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
         return server_response

--- a/tableauserverclient/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverclient/server/endpoint/fileuploads_endpoint.py
@@ -24,7 +24,7 @@ class Fileuploads(Endpoint):
     def initiate(self):
         url = self._construct_url()
         server_response = self.post_request(url, '')
-        fileupload_item = FileuploadItem.from_response(server_response.text)
+        fileupload_item = FileuploadItem.from_response(server_response.content)
         self.upload_id = fileupload_item.upload_session_id
         logger.info('Initiated file upload session (ID: {0})'.format(self.upload_id))
         return self.upload_id
@@ -36,7 +36,7 @@ class Fileuploads(Endpoint):
         url = "{0}/{1}".format(self._construct_url(), self.upload_id)
         server_response = self.put_request(url, xml_request, content_type)
         logger.info('Uploading a chunk to session (ID: {0})'.format(self.upload_id))
-        return FileuploadItem.from_response(server_response.text)
+        return FileuploadItem.from_response(server_response.content)
 
     def read_chunks(self, file_path):
         with open(file_path, 'rb') as f:

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -20,8 +20,8 @@ class Groups(Endpoint):
         logger.info('Querying all groups on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_group_items = GroupItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_group_items = GroupItem.from_response(server_response.content)
         return pagination_item, all_group_items
 
     # Gets all users in a given group
@@ -31,8 +31,8 @@ class Groups(Endpoint):
             raise MissingRequiredFieldError(error)
         url = "{0}/{1}/users".format(self._construct_url(), group_item.id)
         server_response = self.get_request(url, req_options)
-        group_item._set_users(UserItem.from_response(server_response.text))
-        pagination_item = PaginationItem.from_response(server_response.text)
+        group_item._set_users(UserItem.from_response(server_response.content))
+        pagination_item = PaginationItem.from_response(server_response.content)
         logger.info('Populated users for group (ID: {0})'.format(group_item.id))
         return pagination_item
 
@@ -74,7 +74,7 @@ class Groups(Endpoint):
         url = "{0}/{1}/users".format(self._construct_url(), group_item.id)
         add_req = RequestFactory.Group.add_user_req(user_id)
         server_response = self.post_request(url, add_req)
-        new_user = UserItem.from_response(server_response.text).pop()
+        new_user = UserItem.from_response(server_response.content).pop()
         user_set.add(new_user)
         group_item._set_users(user_set)
         logger.info('Added user (id: {0}) to group (ID: {1})'.format(user_id, group_item.id))

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -20,8 +20,8 @@ class Projects(Endpoint):
         logger.info('Querying all projects on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_project_items = ProjectItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_project_items = ProjectItem.from_response(server_response.content)
         return pagination_item, all_project_items
 
     def delete(self, project_id):
@@ -42,13 +42,13 @@ class Projects(Endpoint):
         server_response = self.put_request(url, update_req)
         logger.info('Updated project item (ID: {0})'.format(project_item.id))
         updated_project = copy.copy(project_item)
-        return updated_project._parse_common_tags(server_response.text)
+        return updated_project._parse_common_tags(server_response.content)
 
     def create(self, project_item):
         url = self._construct_url()
         create_req = RequestFactory.Project.create_req(project_item)
         server_response = self.post_request(url, create_req)
-        new_project = ProjectItem.from_response(server_response.text)[0]
+        new_project = ProjectItem.from_response(server_response.content)[0]
         logger.info('Created new project (ID: {0})'.format(new_project.id))
         return new_project
 

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -21,8 +21,8 @@ class Sites(Endpoint):
         logger.info('Querying all sites on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_site_items = SiteItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_site_items = SiteItem.from_response(server_response.content)
         return pagination_item, all_site_items
 
     # Gets 1 site by id
@@ -33,7 +33,7 @@ class Sites(Endpoint):
         logger.info('Querying single site (ID: {0})'.format(site_id))
         url = "{0}/{1}".format(self._construct_url(), site_id)
         server_response = self.get_request(url)
-        return SiteItem.from_response(server_response.text)[0]
+        return SiteItem.from_response(server_response.content)[0]
 
     # Update site
     def update(self, site_item):
@@ -50,7 +50,7 @@ class Sites(Endpoint):
         server_response = self.put_request(url, update_req)
         logger.info('Updated site item (ID: {0})'.format(site_item.id))
         update_site = copy.copy(site_item)
-        return update_site._parse_common_tags(server_response.text)
+        return update_site._parse_common_tags(server_response.content)
 
     # Delete 1 site object
     def delete(self, site_id):
@@ -71,6 +71,6 @@ class Sites(Endpoint):
         url = self._construct_url()
         create_req = RequestFactory.Site.create_req(site_item)
         server_response = self.post_request(url, create_req)
-        new_site = SiteItem.from_response(server_response.text)[0]
+        new_site = SiteItem.from_response(server_response.content)[0]
         logger.info('Created new site (ID: {0})'.format(new_site.id))
         return new_site

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -21,8 +21,8 @@ class Users(Endpoint):
         logger.info('Querying all users on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_user_items = UserItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_user_items = UserItem.from_response(server_response.content)
         return pagination_item, all_user_items
 
     # Gets 1 user by id
@@ -33,7 +33,7 @@ class Users(Endpoint):
         logger.info('Querying single user (ID: {0})'.format(user_id))
         url = "{0}/{1}".format(self._construct_url(), user_id)
         server_response = self.get_request(url)
-        return UserItem.from_response(server_response.text).pop()
+        return UserItem.from_response(server_response.content).pop()
 
     # Update user
     def update(self, user_item):
@@ -46,7 +46,7 @@ class Users(Endpoint):
         server_response = self.put_request(url, update_req)
         logger.info('Updated user item (ID: {0})'.format(user_item.id))
         updated_item = copy.copy(user_item)
-        return updated_item._parse_common_tags(server_response.text)
+        return updated_item._parse_common_tags(server_response.content)
 
     # Delete 1 user by id
     def remove(self, user_id):
@@ -62,7 +62,7 @@ class Users(Endpoint):
         url = self._construct_url()
         add_req = RequestFactory.User.add_req(user_item)
         server_response = self.post_request(url, add_req)
-        new_user = UserItem.from_response(server_response.text).pop()
+        new_user = UserItem.from_response(server_response.content).pop()
         logger.info('Added new user (ID: {0})'.format(user_item.id))
         return new_user
 
@@ -74,8 +74,8 @@ class Users(Endpoint):
         url = "{0}/{1}/workbooks".format(self._construct_url(), user_item.id)
         server_response = self.get_request(url, req_options)
         logger.info('Populated workbooks for user (ID: {0})'.format(user_item.id))
-        user_item._set_workbooks(WorkbookItem.from_response(server_response.text))
-        pagination_item = PaginationItem.from_response(server_response.text)
+        user_item._set_workbooks(WorkbookItem.from_response(server_response.content))
+        pagination_item = PaginationItem.from_response(server_response.content)
         return pagination_item
 
     def populate_favorites(self, user_item):

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -19,8 +19,8 @@ class Views(Endpoint):
         logger.info('Querying all views on site')
         url = "{0}/views".format(self._construct_url())
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_view_items = ViewItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_view_items = ViewItem.from_response(server_response.content)
         return pagination_item, all_view_items
 
     def populate_preview_image(self, view_item):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -30,7 +30,7 @@ class Workbooks(Endpoint):
         url = "{0}/{1}/tags".format(self._construct_url(), workbook_id)
         add_req = RequestFactory.Tag.add_req(tag_set)
         server_response = self.put_request(url, add_req)
-        return TagItem.from_response(server_response.text)
+        return TagItem.from_response(server_response.content)
 
     # Delete a workbook's tag by name
     def _delete_tag(self, workbook_id, tag_name):
@@ -42,8 +42,8 @@ class Workbooks(Endpoint):
         logger.info('Querying all workbooks on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
-        all_workbook_items = WorkbookItem.from_response(server_response.text)
+        pagination_item = PaginationItem.from_response(server_response.content)
+        all_workbook_items = WorkbookItem.from_response(server_response.content)
         return pagination_item, all_workbook_items
 
     # Get 1 workbook
@@ -54,7 +54,7 @@ class Workbooks(Endpoint):
         logger.info('Querying single workbook (ID: {0})'.format(workbook_id))
         url = "{0}/{1}".format(self._construct_url(), workbook_id)
         server_response = self.get_request(url)
-        return WorkbookItem.from_response(server_response.text)[0]
+        return WorkbookItem.from_response(server_response.content)[0]
 
     # Delete 1 workbook by id
     def delete(self, workbook_id):
@@ -88,7 +88,7 @@ class Workbooks(Endpoint):
         server_response = self.put_request(url, update_req)
         logger.info('Updated workbook item (ID: {0}'.format(workbook_item.id))
         updated_workbook = copy.copy(workbook_item)
-        return updated_workbook._parse_common_tags(server_response.text)
+        return updated_workbook._parse_common_tags(server_response.content)
 
     # Download workbook contents with option of passing in filepath
     def download(self, workbook_id, filepath=None):
@@ -116,7 +116,7 @@ class Workbooks(Endpoint):
             raise MissingRequiredFieldError(error)
         url = "{0}/{1}/views".format(self._construct_url(), workbook_item.id)
         server_response = self.get_request(url)
-        workbook_item._set_views(ViewItem.from_response(server_response.text, workbook_id=workbook_item.id))
+        workbook_item._set_views(ViewItem.from_response(server_response.content, workbook_id=workbook_item.id))
         logger.info('Populated views for workbook (ID: {0}'.format(workbook_item.id))
 
     # Get all connections of workbook
@@ -126,7 +126,7 @@ class Workbooks(Endpoint):
             raise MissingRequiredFieldError(error)
         url = "{0}/{1}/connections".format(self._construct_url(), workbook_item.id)
         server_response = self.get_request(url)
-        workbook_item._set_connections(ConnectionItem.from_response(server_response.text))
+        workbook_item._set_connections(ConnectionItem.from_response(server_response.content))
         logger.info('Populated connections for workbook (ID: {0})'.format(workbook_item.id))
 
     # Get preview image of workbook
@@ -180,6 +180,6 @@ class Workbooks(Endpoint):
                                                                             filename,
                                                                             file_contents)
         server_response = self.post_request(url, xml_request, content_type)
-        new_workbook = WorkbookItem.from_response(server_response.text)[0]
+        new_workbook = WorkbookItem.from_response(server_response.content)[0]
         logger.info('Published {0} (ID: {1})'.format(filename, new_workbook.id))
         return new_workbook


### PR DESCRIPTION
ElementTree can handle encoded unicode, so we use response.content rather than response.text which tries to decode the unicode.
