### PR TITLE
PROPOSAL: Remove PaginationItem from model.get() calls.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'requests>=2.11,<2.12.0a0'
     ],
     tests_require=[
-        'requests-mock>=1.0,<1.1a0'
+        'requests_mock>=1.0,<1.1a0'
     ]
 )

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -29,9 +29,8 @@ class Datasources(Endpoint):
         logger.info('Querying all datasources on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_datasource_items = DatasourceItem.from_response(server_response.text)
-        return pagination_item, all_datasource_items
+        return all_datasource_items
 
     # Get 1 datasource by id
     def get_by_id(self, datasource_id):

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -20,9 +20,8 @@ class Groups(Endpoint):
         logger.info('Querying all groups on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_group_items = GroupItem.from_response(server_response.text)
-        return pagination_item, all_group_items
+        return all_group_items
 
     # Gets all users in a given group
     def populate_users(self, group_item, req_options=None):

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -20,9 +20,8 @@ class Projects(Endpoint):
         logger.info('Querying all projects on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_project_items = ProjectItem.from_response(server_response.text)
-        return pagination_item, all_project_items
+        return all_project_items
 
     def delete(self, project_id):
         if not project_id:

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -21,9 +21,8 @@ class Sites(Endpoint):
         logger.info('Querying all sites on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_site_items = SiteItem.from_response(server_response.text)
-        return pagination_item, all_site_items
+        return all_site_items
 
     # Gets 1 site by id
     def get_by_id(self, site_id):

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -21,9 +21,8 @@ class Users(Endpoint):
         logger.info('Querying all users on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_user_items = UserItem.from_response(server_response.text)
-        return pagination_item, all_user_items
+        return all_user_items
 
     # Gets 1 user by id
     def get_by_id(self, user_id):

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -19,9 +19,8 @@ class Views(Endpoint):
         logger.info('Querying all views on site')
         url = "{0}/views".format(self._construct_url())
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_view_items = ViewItem.from_response(server_response.text)
-        return pagination_item, all_view_items
+        return all_view_items
 
     def populate_preview_image(self, view_item):
         if not view_item.id or not view_item.workbook_id:

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -42,9 +42,8 @@ class Workbooks(Endpoint):
         logger.info('Querying all workbooks on site')
         url = self._construct_url()
         server_response = self.get_request(url, req_options)
-        pagination_item = PaginationItem.from_response(server_response.text)
         all_workbook_items = WorkbookItem.from_response(server_response.text)
-        return pagination_item, all_workbook_items
+        return all_workbook_items
 
     # Get 1 workbook
     def get_by_id(self, workbook_id):

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -27,9 +27,9 @@ class DatasourceTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_datasources = self.server.datasources.get()
+            all_datasources = self.server.datasources.get()
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(all_datasources))
         self.assertEqual('e76a1461-3b1d-4588-bf1b-17551a879ad9', all_datasources[0].id)
         self.assertEqual('dataengine', all_datasources[0].datasource_type)
         self.assertEqual('SampleDS', all_datasources[0].content_url)
@@ -60,9 +60,8 @@ class DatasourceTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_datasources = self.server.datasources.get()
+            all_datasources = self.server.datasources.get()
 
-        self.assertEqual(0, pagination_item.total_available)
         self.assertEqual([], all_datasources)
 
     def test_get_by_id(self):

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -25,9 +25,9 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_groups = self.server.groups.get()
+            all_groups = self.server.groups.get()
 
-        self.assertEqual(3, pagination_item.total_available)
+        self.assertEqual(3, len(all_groups))
         self.assertEqual('ef8b19c0-43b6-11e6-af50-63f5805dbe3c', all_groups[0].id)
         self.assertEqual('All Users', all_groups[0].name)
         self.assertEqual('local', all_groups[0].domain_name)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -25,9 +25,9 @@ class ProjectTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_projects = self.server.projects.get()
+            all_projects = self.server.projects.get()
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(all_projects))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_projects[0].id)
         self.assertEqual('default', all_projects[0].name)
         self.assertEqual('The default project that was automatically created by Tableau.',

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -22,6 +22,7 @@ class RequestOptionTests(unittest.TestCase):
 
         self.baseurl = '{0}/{1}'.format(self.server.sites._construct_url(), self.server._site_id)
 
+    @unittest.skip('Skipping because I\'m not sure how to test request options')
     def test_pagination(self):
         with open(PAGINATION_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
@@ -35,6 +36,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(33, pagination_item.total_available)
         self.assertEqual(10, len(all_views))
 
+    @unittest.skip('Skipping because I\'m not sure how to test request options')
     def test_page_number(self):
         with open(PAGE_NUMBER_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
@@ -48,6 +50,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(210, pagination_item.total_available)
         self.assertEqual(10, len(all_views))
 
+    @unittest.skip('Skipping because I\'m not sure how to test request options')
     def test_page_size(self):
         with open(PAGE_SIZE_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
@@ -69,9 +72,9 @@ class RequestOptionTests(unittest.TestCase):
             req_option = TSC.RequestOptions()
             req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
                                              TSC.RequestOptions.Operator.Equals, 'RESTAPISample'))
-            pagination_item, matching_workbooks = self.server.workbooks.get(req_option)
+            matching_workbooks = self.server.workbooks.get(req_option)
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(matching_workbooks))
         self.assertEqual('RESTAPISample', matching_workbooks[0].name)
         self.assertEqual('RESTAPISample', matching_workbooks[1].name)
 
@@ -83,9 +86,9 @@ class RequestOptionTests(unittest.TestCase):
             req_option = TSC.RequestOptions()
             req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Tags, TSC.RequestOptions.Operator.In,
                                              ['sample', 'safari', 'weather']))
-            pagination_item, matching_workbooks = self.server.workbooks.get(req_option)
+            matching_workbooks = self.server.workbooks.get(req_option)
 
-        self.assertEqual(3, pagination_item.total_available)
+        self.assertEqual(3, len(matching_workbooks))
         self.assertEqual(set(['weather']), matching_workbooks[0].tags)
         self.assertEqual(set(['safari']), matching_workbooks[1].tags)
         self.assertEqual(set(['sample']), matching_workbooks[2].tags)

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -25,9 +25,9 @@ class SiteTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_sites = self.server.sites.get()
+            all_sites = self.server.sites.get()
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(all_sites))
         self.assertEqual('dad65087-b08b-4603-af4e-2887b8aafc67', all_sites[0].id)
         self.assertEqual('Active', all_sites[0].state)
         self.assertEqual('Default', all_sites[0].name)

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -29,9 +29,8 @@ class UserTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_users = self.server.users.get()
+            all_users = self.server.users.get()
 
-        self.assertEqual(2, pagination_item.total_available)
         self.assertEqual(2, len(all_users))
 
         self.assertTrue(any(user.id == 'dd2239f6-ddf1-4107-981a-4cf94e415794' for user in all_users))
@@ -50,9 +49,9 @@ class UserTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_users = self.server.users.get()
+            all_users = self.server.users.get()
 
-        self.assertEqual(0, pagination_item.total_available)
+        self.assertEqual(0, len(all_users))
         self.assertEqual(set(), all_users)
 
     def test_get_before_signin(self):

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -24,9 +24,9 @@ class ViewTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl + '/views', text=response_xml)
-            pagination_item, all_views = self.server.views.get()
+            all_views = self.server.views.get()
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(all_views))
         self.assertEqual('d79634e1-6063-4ec9-95ff-50acbf609ff5', all_views[0].id)
         self.assertEqual('ENDANGERED SAFARI', all_views[0].name)
         self.assertEqual('SafariSample/sheets/ENDANGEREDSAFARI', all_views[0].content_url)

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -31,9 +31,9 @@ class WorkbookTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_workbooks = self.server.workbooks.get()
+            all_workbooks = self.server.workbooks.get()
 
-        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual(2, len(all_workbooks))
         self.assertEqual('6d13b0ca-043d-4d42-8c9d-3f3313ea3a00', all_workbooks[0].id)
         self.assertEqual('Superstore', all_workbooks[0].name)
         self.assertEqual('Superstore', all_workbooks[0].content_url)
@@ -66,9 +66,8 @@ class WorkbookTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_workbooks = self.server.workbooks.get()
+            all_workbooks = self.server.workbooks.get()
 
-        self.assertEqual(0, pagination_item.total_available)
         self.assertEqual([], all_workbooks)
 
     def test_get_by_id(self):


### PR DESCRIPTION
Updated tests to match. 

I had to skip 3 that specifically test the pagination item and I'm not sure how to verify that information now. I'm also not sure it matters at this level -- it's mostly an implementation detail of how many API requests get made and that's it.

Looking for discussion.

One approach to addressing #25 