### PR TITLE
reversed the order of return variables for all .get() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tableau_auth = tableauserverclient.TableauAuth('USERNAME', 'PASSWORD')
 server = tableauserverclient.Server('SERVER')
 
 with server.auth.sign_in(tableau_auth):
-    pagination_info, all_workbooks = server.workbooks.get()
+    all_workbooks, pagination_item = server.workbooks.get()
 ```
 
 ###Server Client Samples

--- a/samples/explore_datasource.py
+++ b/samples/explore_datasource.py
@@ -36,7 +36,7 @@ tableau_auth = TSC.TableauAuth(args.username, password)
 server = TSC.Server(args.server)
 with server.auth.sign_in(tableau_auth):
     # Query projects for use when demonstrating publishing and updating
-    pagination_item, all_projects = server.projects.get()
+    all_projects, pagination_item = server.projects.get()
     default_project = next((project for project in all_projects if project.is_default()), None)
 
     # Publish datasource if publish flag is set (-publish, -p)
@@ -49,7 +49,7 @@ with server.auth.sign_in(tableau_auth):
             print("Publish failed. Could not find the default project.")
 
     # Gets all datasource items
-    pagination_item, all_datasources = server.datasources.get()
+    all_datasources, pagination_item = server.datasources.get()
     print("\nThere are {} datasources on site: ".format(pagination_item.total_available))
     print([datasource.name for datasource in all_datasources])
 

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -40,7 +40,7 @@ with server.auth.sign_in(tableau_auth):
 
     # Publish workbook if publish flag is set (-publish, -p)
     if args.publish:
-        pagination_info, all_projects = server.projects.get()
+        all_projects, pagination_item = server.projects.get()
         default_project = next((project for project in all_projects if project.is_default()), None)
 
         if default_project is not None:
@@ -51,7 +51,7 @@ with server.auth.sign_in(tableau_auth):
             print('Publish failed. Could not find the default project.')
 
     # Gets all workbook items
-    pagination_item, all_workbooks = server.workbooks.get()
+    all_workbooks, pagination_item = server.workbooks.get()
     print("\nThere are {} workbooks on site: ".format(pagination_item.total_available))
     print([workbook.name for workbook in all_workbooks])
 

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -35,10 +35,10 @@ with server.auth.sign_in(tableau_auth):
     req_option = TSC.RequestOptions()
     req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
                                      TSC.RequestOptions.Operator.Equals, args.workbook_name))
-    pagination_info, all_workbooks = server.workbooks.get(req_option)
+    all_workbooks, pagination_item = server.workbooks.get(req_option)
 
     # Step 3: Find destination project
-    pagination_info, all_projects = server.projects.get()
+    all_projects, pagination_item = server.projects.get()
     dest_project = next((project for project in all_projects if project.name == args.destination_project), None)
 
     if dest_project is not None:

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -42,7 +42,7 @@ with source_server.auth.sign_in(tableau_auth):
     req_option = TSC.RequestOptions()
     req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
                                      TSC.RequestOptions.Operator.Equals, args.workbook_name))
-    pagination_info, all_workbooks = source_server.workbooks.get(req_option)
+    all_workbooks, pagination_item = source_server.workbooks.get(req_option)
 
     # Step 3: Download workbook to a temp directory
     if len(all_workbooks) == 0:

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -39,7 +39,7 @@ server = TSC.Server(args.server)
 with server.auth.sign_in(tableau_auth):
 
     # Step 2: Get all the projects on server, then look for the default one.
-    pagination_info, all_projects = server.projects.get()
+    all_projects, pagination_item = server.projects.get()
     default_project = next((project for project in all_projects if project.is_default()), None)
 
     # Step 3: If default project is found, form a new workbook item and publish.

--- a/samples/set_http_options.py
+++ b/samples/set_http_options.py
@@ -36,7 +36,7 @@ server.add_http_options({'verify': False})
 with server.auth.sign_in(tableau_auth):
 
     # Step 3: Query all workbooks and list them
-    pagination_info, all_workbooks = server.workbooks.get()
-    print('{0} workbooks found. Showing {1}:'.format(pagination_info.total_available, pagination_info.page_size))
+    all_workbooks, pagination_item = server.workbooks.get()
+    print('{0} workbooks found. Showing {1}:'.format(pagination_item.total_available, pagination_item.page_size))
     for workbook in all_workbooks:
         print('\t{0} (ID: {1})'.format(workbook.name, workbook.id))

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -31,7 +31,7 @@ class Datasources(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_datasource_items = DatasourceItem.from_response(server_response.content)
-        return pagination_item, all_datasource_items
+        return all_datasource_items, pagination_item
 
     # Get 1 datasource by id
     def get_by_id(self, datasource_id):

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -24,7 +24,8 @@ class Endpoint(object):
                                                       **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(
+                url, server_response.content.decode(server_response.encoding)))
         return server_response
 
     def delete_request(self, url):
@@ -42,7 +43,8 @@ class Endpoint(object):
                                                       **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(
+                url, server_response.content.decode(server_response.encoding)))
         return server_response
 
     def post_request(self, url, xml_request, content_type='text/xml'):
@@ -53,5 +55,6 @@ class Endpoint(object):
                                                        **self.parent_srv.http_options)
         self._check_status(server_response)
         if server_response.encoding:
-            logger.debug(u'Server response from {0}: \n\t{1}'.format(url, server_response.content.decode(server_response.encoding)))
+            logger.debug(u'Server response from {0}: \n\t{1}'.format(
+                url, server_response.content.decode(server_response.encoding)))
         return server_response

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -22,7 +22,7 @@ class Groups(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_group_items = GroupItem.from_response(server_response.content)
-        return pagination_item, all_group_items
+        return all_group_items, pagination_item
 
     # Gets all users in a given group
     def populate_users(self, group_item, req_options=None):

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -22,7 +22,7 @@ class Projects(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_project_items = ProjectItem.from_response(server_response.content)
-        return pagination_item, all_project_items
+        return all_project_items, pagination_item
 
     def delete(self, project_id):
         if not project_id:

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -23,7 +23,7 @@ class Sites(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_site_items = SiteItem.from_response(server_response.content)
-        return pagination_item, all_site_items
+        return all_site_items, pagination_item
 
     # Gets 1 site by id
     def get_by_id(self, site_id):

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -23,7 +23,7 @@ class Users(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_user_items = UserItem.from_response(server_response.content)
-        return pagination_item, all_user_items
+        return all_user_items, pagination_item
 
     # Gets 1 user by id
     def get_by_id(self, user_id):

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -21,7 +21,7 @@ class Views(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_view_items = ViewItem.from_response(server_response.content)
-        return pagination_item, all_view_items
+        return all_view_items, pagination_item
 
     def populate_preview_image(self, view_item):
         if not view_item.id or not view_item.workbook_id:

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -44,7 +44,7 @@ class Workbooks(Endpoint):
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_workbook_items = WorkbookItem.from_response(server_response.content)
-        return pagination_item, all_workbook_items
+        return all_workbook_items, pagination_item
 
     # Get 1 workbook
     def get_by_id(self, workbook_id):

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -27,7 +27,7 @@ class DatasourceTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_datasources = self.server.datasources.get()
+            all_datasources, pagination_item = self.server.datasources.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('e76a1461-3b1d-4588-bf1b-17551a879ad9', all_datasources[0].id)
@@ -60,7 +60,7 @@ class DatasourceTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_datasources = self.server.datasources.get()
+            all_datasources, pagination_item = self.server.datasources.get()
 
         self.assertEqual(0, pagination_item.total_available)
         self.assertEqual([], all_datasources)

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -25,7 +25,7 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_groups = self.server.groups.get()
+            all_groups, pagination_item = self.server.groups.get()
 
         self.assertEqual(3, pagination_item.total_available)
         self.assertEqual('ef8b19c0-43b6-11e6-af50-63f5805dbe3c', all_groups[0].id)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -25,7 +25,7 @@ class ProjectTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_projects = self.server.projects.get()
+            all_projects, pagination_item = self.server.projects.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_projects[0].id)

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -28,7 +28,7 @@ class RequestOptionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(self.baseurl + '/views?pageNumber=1&pageSize=10', text=response_xml)
             req_option = TSC.RequestOptions().page_size(10)
-            pagination_item, all_views = self.server.views.get(req_option)
+            all_views, pagination_item = self.server.views.get(req_option)
 
         self.assertEqual(1, pagination_item.page_number)
         self.assertEqual(10, pagination_item.page_size)
@@ -41,7 +41,7 @@ class RequestOptionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(self.baseurl + '/views?pageNumber=3', text=response_xml)
             req_option = TSC.RequestOptions().page_number(3)
-            pagination_item, all_views = self.server.views.get(req_option)
+            all_views, pagination_item = self.server.views.get(req_option)
 
         self.assertEqual(3, pagination_item.page_number)
         self.assertEqual(100, pagination_item.page_size)
@@ -54,7 +54,7 @@ class RequestOptionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(self.baseurl + '/views?pageSize=5', text=response_xml)
             req_option = TSC.RequestOptions().page_size(5)
-            pagination_item, all_views = self.server.views.get(req_option)
+            all_views, pagination_item = self.server.views.get(req_option)
 
         self.assertEqual(1, pagination_item.page_number)
         self.assertEqual(5, pagination_item.page_size)
@@ -69,7 +69,7 @@ class RequestOptionTests(unittest.TestCase):
             req_option = TSC.RequestOptions()
             req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
                                              TSC.RequestOptions.Operator.Equals, 'RESTAPISample'))
-            pagination_item, matching_workbooks = self.server.workbooks.get(req_option)
+            matching_workbooks, pagination_item = self.server.workbooks.get(req_option)
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('RESTAPISample', matching_workbooks[0].name)
@@ -83,7 +83,7 @@ class RequestOptionTests(unittest.TestCase):
             req_option = TSC.RequestOptions()
             req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Tags, TSC.RequestOptions.Operator.In,
                                              ['sample', 'safari', 'weather']))
-            pagination_item, matching_workbooks = self.server.workbooks.get(req_option)
+            matching_workbooks, pagination_item = self.server.workbooks.get(req_option)
 
         self.assertEqual(3, pagination_item.total_available)
         self.assertEqual(set(['weather']), matching_workbooks[0].tags)

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -25,7 +25,7 @@ class SiteTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_sites = self.server.sites.get()
+            all_sites, pagination_item = self.server.sites.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('dad65087-b08b-4603-af4e-2887b8aafc67', all_sites[0].id)

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -29,7 +29,7 @@ class UserTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_users = self.server.users.get()
+            all_users, pagination_item = self.server.users.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual(2, len(all_users))
@@ -50,7 +50,7 @@ class UserTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_users = self.server.users.get()
+            all_users, pagination_item = self.server.users.get()
 
         self.assertEqual(0, pagination_item.total_available)
         self.assertEqual(set(), all_users)

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -24,7 +24,7 @@ class ViewTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl + '/views', text=response_xml)
-            pagination_item, all_views = self.server.views.get()
+            all_views, pagination_item = self.server.views.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('d79634e1-6063-4ec9-95ff-50acbf609ff5', all_views[0].id)

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -31,7 +31,7 @@ class WorkbookTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_workbooks = self.server.workbooks.get()
+            all_workbooks, pagination_item = self.server.workbooks.get()
 
         self.assertEqual(2, pagination_item.total_available)
         self.assertEqual('6d13b0ca-043d-4d42-8c9d-3f3313ea3a00', all_workbooks[0].id)
@@ -66,7 +66,7 @@ class WorkbookTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            pagination_item, all_workbooks = self.server.workbooks.get()
+            all_workbooks, pagination_item = self.server.workbooks.get()
 
         self.assertEqual(0, pagination_item.total_available)
         self.assertEqual([], all_workbooks)


### PR DESCRIPTION
Prepping for release: Pagination item is now returned as the second variable and Travis passes