### PR TITLE
Fix PEP440 warnings in TravisCI 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'requests>=2.11,<2.12.0a0'
     ],
     tests_require=[
-        'requests-mock>=1.0,<1.1a0'
+        'requests_mock>=1.0,<1.1a0'
     ]
 )


### PR DESCRIPTION
This was happening due to bad normalization of the package name in setup.py