### PR TITLE
Updated all _construct_url() to just @property baseurl

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -25,7 +25,6 @@ class Auth(Endpoint):
     def baseurl(self):
         return "{0}/auth".format(self.parent_srv.baseurl)
 
-
     def sign_in(self, auth_req):
         url = "{0}/{1}".format(self.baseurl, 'signin')
         signin_req = RequestFactory.Auth.signin_req(auth_req)

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -19,8 +19,12 @@ class Auth(Endpoint):
 
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/auth".format(parent_srv.baseurl)
         self.parent_srv = parent_srv
+
+    @property
+    def baseurl(self):
+        return "{0}/auth".format(self.parent_srv.baseurl)
+
 
     def sign_in(self, auth_req):
         url = "{0}/{1}".format(self.baseurl, 'signin')

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -18,16 +18,16 @@ logger = logging.getLogger('tableau.endpoint.datasources')
 class Datasources(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites/{1}/datasources"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}/datasources".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Get all datasources
     def get(self, req_options=None):
         logger.info('Querying all datasources on site')
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_datasource_items = DatasourceItem.from_response(server_response.content)
@@ -39,7 +39,7 @@ class Datasources(Endpoint):
             error = "Datasource ID undefined."
             raise ValueError(error)
         logger.info('Querying single datasource (ID: {0})'.format(datasource_id))
-        url = "{0}/{1}".format(self._construct_url(), datasource_id)
+        url = "{0}/{1}".format(self.baseurl, datasource_id)
         server_response = self.get_request(url)
         return DatasourceItem.from_response(server_response.content)[0]
 
@@ -48,7 +48,7 @@ class Datasources(Endpoint):
         if not datasource_item.id:
             error = 'Datasource item missing ID. Datasource must be retrieved from server first.'
             raise MissingRequiredFieldError(error)
-        url = '{0}/{1}/connections'.format(self._construct_url(), datasource_item.id)
+        url = '{0}/{1}/connections'.format(self.baseurl, datasource_item.id)
         server_response = self.get_request(url)
         datasource_item._set_connections(ConnectionItem.from_response(server_response.content))
         logger.info('Populated connections for datasource (ID: {0})'.format(datasource_item.id))
@@ -58,7 +58,7 @@ class Datasources(Endpoint):
         if not datasource_id:
             error = "Datasource ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}".format(self._construct_url(), datasource_id)
+        url = "{0}/{1}".format(self.baseurl, datasource_id)
         self.delete_request(url)
         logger.info('Deleted single datasource (ID: {0})'.format(datasource_id))
 
@@ -67,7 +67,7 @@ class Datasources(Endpoint):
         if not datasource_id:
             error = "Datasource ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}/content".format(self._construct_url(), datasource_id)
+        url = "{0}/{1}/content".format(self.baseurl, datasource_id)
         server_response = self.get_request(url)
         _, params = cgi.parse_header(server_response.headers['Content-Disposition'])
         filename = os.path.basename(params['filename'])
@@ -86,7 +86,7 @@ class Datasources(Endpoint):
         if not datasource_item.id:
             error = 'Datasource item missing ID. Datasource must be retrieved from server first.'
             raise MissingRequiredFieldError(error)
-        url = "{0}/{1}".format(self._construct_url(), datasource_item.id)
+        url = "{0}/{1}".format(self.baseurl, datasource_item.id)
         update_req = RequestFactory.Datasource.update_req(datasource_item)
         server_response = self.put_request(url, update_req)
         logger.info('Updated datasource item (ID: {0})'.format(datasource_item.id))
@@ -113,7 +113,7 @@ class Datasources(Endpoint):
             raise ValueError(error)
 
         # Construct the url with the defined mode
-        url = "{0}?datasourceType={1}".format(self._construct_url(), file_extension)
+        url = "{0}?datasourceType={1}".format(self.baseurl, file_extension)
         if mode == self.parent_srv.PublishMode.Overwrite or mode == self.parent_srv.PublishMode.Append:
             url += '&{0}=true'.format(mode.lower())
 

--- a/tableauserverclient/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverclient/server/endpoint/fileuploads_endpoint.py
@@ -14,15 +14,15 @@ logger = logging.getLogger('tableau.endpoint.fileuploads')
 class Fileuploads(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.base_url = "{0}/sites/{1}/fileUploads"
         self.parent_srv = parent_srv
         self.upload_id = ''
 
-    def _construct_url(self):
-        return self.base_url.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}/fileUploads".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     def initiate(self):
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.post_request(url, '')
         fileupload_item = FileuploadItem.from_response(server_response.content)
         self.upload_id = fileupload_item.upload_session_id
@@ -33,7 +33,7 @@ class Fileuploads(Endpoint):
         if not self.upload_id:
             error = "File upload session must be initiated first."
             raise MissingRequiredFieldError(error)
-        url = "{0}/{1}".format(self._construct_url(), self.upload_id)
+        url = "{0}/{1}".format(self.baseurl, self.upload_id)
         server_response = self.put_request(url, xml_request, content_type)
         logger.info('Uploading a chunk to session (ID: {0})'.format(self.upload_id))
         return FileuploadItem.from_response(server_response.content)

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -9,16 +9,16 @@ logger = logging.getLogger('tableau.endpoint.groups')
 class Groups(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites/{1}/groups"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}/groups".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Gets all groups
     def get(self, req_options=None):
         logger.info('Querying all groups on site')
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_group_items = GroupItem.from_response(server_response.content)
@@ -29,7 +29,7 @@ class Groups(Endpoint):
         if not group_item.id:
             error = "Group item missing ID. Group must be retrieved from server first."
             raise MissingRequiredFieldError(error)
-        url = "{0}/{1}/users".format(self._construct_url(), group_item.id)
+        url = "{0}/{1}/users".format(self.baseurl, group_item.id)
         server_response = self.get_request(url, req_options)
         group_item._set_users(UserItem.from_response(server_response.content))
         pagination_item = PaginationItem.from_response(server_response.content)
@@ -41,7 +41,7 @@ class Groups(Endpoint):
         if not group_id:
             error = "Group ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}".format(self._construct_url(), group_id)
+        url = "{0}/{1}".format(self.baseurl, group_id)
         self.delete_request(url)
         logger.info('Deleted single group (ID: {0})'.format(group_id))
 
@@ -54,7 +54,7 @@ class Groups(Endpoint):
         if not user_id:
             error = "User ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}/users/{2}".format(self._construct_url(), group_item.id, user_id)
+        url = "{0}/{1}/users/{2}".format(self.baseurl, group_item.id, user_id)
         self.delete_request(url)
         for user in user_set:
             if user.id == user_id:
@@ -71,7 +71,7 @@ class Groups(Endpoint):
         if not user_id:
             error = "User ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}/users".format(self._construct_url(), group_item.id)
+        url = "{0}/{1}/users".format(self.baseurl, group_item.id)
         add_req = RequestFactory.Group.add_user_req(user_id)
         server_response = self.post_request(url, add_req)
         new_user = UserItem.from_response(server_response.content).pop()

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -10,15 +10,15 @@ logger = logging.getLogger('tableau.endpoint.projects')
 class Projects(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites/{1}/projects"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}/projects".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     def get(self, req_options=None):
         logger.info('Querying all projects on site')
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_project_items = ProjectItem.from_response(server_response.content)
@@ -28,7 +28,7 @@ class Projects(Endpoint):
         if not project_id:
             error = "Project ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}".format(self._construct_url(), project_id)
+        url = "{0}/{1}".format(self.baseurl, project_id)
         self.delete_request(url)
         logger.info('Deleted single project (ID: {0})'.format(project_id))
 
@@ -37,7 +37,7 @@ class Projects(Endpoint):
             error = "Project item missing ID."
             raise MissingRequiredFieldError(error)
 
-        url = "{0}/{1}".format(self._construct_url(), project_item.id)
+        url = "{0}/{1}".format(self.baseurl, project_item.id)
         update_req = RequestFactory.Project.update_req(project_item)
         server_response = self.put_request(url, update_req)
         logger.info('Updated project item (ID: {0})'.format(project_item.id))
@@ -45,7 +45,7 @@ class Projects(Endpoint):
         return updated_project._parse_common_tags(server_response.content)
 
     def create(self, project_item):
-        url = self._construct_url()
+        url = self.baseurl
         create_req = RequestFactory.Project.create_req(project_item)
         server_response = self.post_request(url, create_req)
         new_project = ProjectItem.from_response(server_response.content)[0]

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -10,16 +10,16 @@ logger = logging.getLogger('tableau.endpoint.sites')
 class Sites(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl)
+    @property
+    def baseurl(self):
+        return "{0}/sites".format(self.parent_srv.baseurl)
 
     # Gets all sites
     def get(self, req_options=None):
         logger.info('Querying all sites on site')
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_site_items = SiteItem.from_response(server_response.content)
@@ -31,7 +31,7 @@ class Sites(Endpoint):
             error = "Site ID undefined."
             raise ValueError(error)
         logger.info('Querying single site (ID: {0})'.format(site_id))
-        url = "{0}/{1}".format(self._construct_url(), site_id)
+        url = "{0}/{1}".format(self.baseurl, site_id)
         server_response = self.get_request(url)
         return SiteItem.from_response(server_response.content)[0]
 
@@ -45,7 +45,7 @@ class Sites(Endpoint):
                 error = 'You cannot set admin_mode to ContentOnly and also set a user quota'
                 raise ValueError(error)
 
-        url = "{0}/{1}".format(self._construct_url(), site_item.id)
+        url = "{0}/{1}".format(self.baseurl, site_item.id)
         update_req = RequestFactory.Site.update_req(site_item)
         server_response = self.put_request(url, update_req)
         logger.info('Updated site item (ID: {0})'.format(site_item.id))
@@ -57,7 +57,7 @@ class Sites(Endpoint):
         if not site_id:
             error = "Site ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}".format(self._construct_url(), site_id)
+        url = "{0}/{1}".format(self.baseurl, site_id)
         self.delete_request(url)
         logger.info('Deleted single site (ID: {0})'.format(site_id))
 
@@ -68,7 +68,7 @@ class Sites(Endpoint):
                 error = 'You cannot set admin_mode to ContentOnly and also set a user quota'
                 raise ValueError(error)
 
-        url = self._construct_url()
+        url = self.baseurl
         create_req = RequestFactory.Site.create_req(site_item)
         server_response = self.post_request(url, create_req)
         new_site = SiteItem.from_response(server_response.content)[0]

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -10,16 +10,16 @@ logger = logging.getLogger('tableau.endpoint.users')
 class Users(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites/{1}/users"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}/users".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Gets all users
     def get(self, req_options=None):
         logger.info('Querying all users on site')
-        url = self._construct_url()
+        url = self.baseurl
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_user_items = UserItem.from_response(server_response.content)
@@ -31,7 +31,7 @@ class Users(Endpoint):
             error = "User ID undefined."
             raise ValueError(error)
         logger.info('Querying single user (ID: {0})'.format(user_id))
-        url = "{0}/{1}".format(self._construct_url(), user_id)
+        url = "{0}/{1}".format(self.baseurl, user_id)
         server_response = self.get_request(url)
         return UserItem.from_response(server_response.content).pop()
 
@@ -41,7 +41,7 @@ class Users(Endpoint):
             error = "User item missing ID."
             raise MissingRequiredFieldError(error)
 
-        url = "{0}/{1}".format(self._construct_url(), user_item.id)
+        url = "{0}/{1}".format(self.baseurl, user_item.id)
         update_req = RequestFactory.User.update_req(user_item)
         server_response = self.put_request(url, update_req)
         logger.info('Updated user item (ID: {0})'.format(user_item.id))
@@ -53,13 +53,13 @@ class Users(Endpoint):
         if not user_id:
             error = "User ID undefined."
             raise ValueError(error)
-        url = "{0}/{1}".format(self._construct_url(), user_id)
+        url = "{0}/{1}".format(self.baseurl, user_id)
         self.delete_request(url)
         logger.info('Removed single user (ID: {0})'.format(user_id))
 
     # Add new user to site
     def add(self, user_item):
-        url = self._construct_url()
+        url = self.baseurl
         add_req = RequestFactory.User.add_req(user_item)
         server_response = self.post_request(url, add_req)
         new_user = UserItem.from_response(server_response.content).pop()
@@ -71,7 +71,7 @@ class Users(Endpoint):
         if not user_item.id:
             error = "User item missing ID."
             raise MissingRequiredFieldError(error)
-        url = "{0}/{1}/workbooks".format(self._construct_url(), user_item.id)
+        url = "{0}/{1}/workbooks".format(self.baseurl, user_item.id)
         server_response = self.get_request(url, req_options)
         logger.info('Populated workbooks for user (ID: {0})'.format(user_item.id))
         user_item._set_workbooks(WorkbookItem.from_response(server_response.content))

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -9,15 +9,15 @@ logger = logging.getLogger('tableau.endpoint.views')
 class Views(Endpoint):
     def __init__(self, parent_srv):
         super(Endpoint, self).__init__()
-        self.baseurl = "{0}/sites/{1}"
         self.parent_srv = parent_srv
 
-    def _construct_url(self):
-        return self.baseurl.format(self.parent_srv.baseurl, self.parent_srv.site_id)
+    @property
+    def baseurl(self):
+        return "{0}/sites/{1}".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     def get(self, req_options=None):
         logger.info('Querying all views on site')
-        url = "{0}/views".format(self._construct_url())
+        url = "{0}/views".format(self.baseurl)
         server_response = self.get_request(url, req_options)
         pagination_item = PaginationItem.from_response(server_response.content)
         all_view_items = ViewItem.from_response(server_response.content)
@@ -27,7 +27,7 @@ class Views(Endpoint):
         if not view_item.id or not view_item.workbook_id:
             error = "View item missing ID or workbook ID."
             raise MissingRequiredFieldError(error)
-        url = "{0}/workbooks/{1}/views/{2}/previewImage".format(self._construct_url(),
+        url = "{0}/workbooks/{1}/views/{2}/previewImage".format(self.baseurl,
                                                                 view_item.workbook_id,
                                                                 view_item.id)
         server_response = self.get_request(url)

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -20,7 +20,7 @@ class DatasourceTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.datasources._construct_url()
+        self.baseurl = self.server.datasources.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -18,7 +18,7 @@ class GroupTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.groups._construct_url()
+        self.baseurl = self.server.groups.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -18,7 +18,7 @@ class ProjectTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.projects._construct_url()
+        self.baseurl = self.server.projects.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -20,7 +20,7 @@ class RequestOptionTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = '{0}/{1}'.format(self.server.sites._construct_url(), self.server._site_id)
+        self.baseurl = '{0}/{1}'.format(self.server.sites.baseurl, self.server._site_id)
 
     def test_pagination(self):
         with open(PAGINATION_XML, 'rb') as f:

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -18,7 +18,7 @@ class SiteTests(unittest.TestCase):
         # Fake signin
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.sites._construct_url()
+        self.baseurl = self.server.sites.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -22,7 +22,7 @@ class UserTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.users._construct_url()
+        self.baseurl = self.server.users.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -17,7 +17,7 @@ class ViewTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.views._construct_url()
+        self.baseurl = self.server.views.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -24,7 +24,7 @@ class WorkbookTests(unittest.TestCase):
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
-        self.baseurl = self.server.workbooks._construct_url()
+        self.baseurl = self.server.workbooks.baseurl
 
     def test_get(self):
         with open(GET_XML, 'rb') as f:


### PR DESCRIPTION
The root of this fix was that the auth endpoint was pre-creating the url which meant I couldn't change the version # of the api. As part of the fix, though, I standardized on @property baseurl since that is what the root Server object was using and I wanted one pattern.