### PR TITLE
Cleaning up samples

### DIFF
--- a/samples/explore_datasource.py
+++ b/samples/explore_datasource.py
@@ -16,16 +16,15 @@ import logging
 import tableauserverclient as TSC
 
 
-parser = argparse.ArgumentParser(description='Explore datasource functions supported by the Server API.')
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--publish', '-p', metavar='FILEPATH', help='path to datasource to publish')
-parser.add_argument('--download', '-d', metavar='FILEPATH', help='path to save downloaded datasource')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+def main():
 
-
-if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Explore datasource functions supported by the Server API.')
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--publish', '-p', metavar='FILEPATH', help='path to datasource to publish')
+    parser.add_argument('--download', '-d', metavar='FILEPATH', help='path to save downloaded datasource')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -67,3 +66,7 @@ if __name__ == '__main__':
             print("\nConnections for {}: ".format(sample_datasource.name))
             print(["{0}({1})".format(connection.id, connection.datasource_name)
                    for connection in sample_datasource.connections])
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -17,17 +17,17 @@ import os.path
 import tableauserverclient as TSC
 
 
-parser = argparse.ArgumentParser(description='Explore workbook functions supported by the Server API.')
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--publish', '-p', metavar='FILEPATH', help='path to workbook to publish')
-parser.add_argument('--download', '-d', metavar='FILEPATH', help='path to save downloaded workbook')
-parser.add_argument('--preview-image', '-i', metavar='FILENAME',
-                    help='filename (a .png file) to save the preview image')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+def main():
 
-if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Explore workbook functions supported by the Server API.')
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--publish', '-p', metavar='FILEPATH', help='path to workbook to publish')
+    parser.add_argument('--download', '-d', metavar='FILEPATH', help='path to save downloaded workbook')
+    parser.add_argument('--preview-image', '-i', metavar='FILENAME',
+                        help='filename (a .png file) to save the preview image')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -101,3 +101,7 @@ if __name__ == '__main__':
                 with open(args.preview_image, 'wb') as f:
                     f.write(sample_workbook.preview_image)
                 print("\nDownloaded preview image of workbook to {}".format(os.path.abspath(args.preview_image)))
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -9,12 +9,13 @@
 # on top of the general operations.
 ####
 
-import tableauserverclient as TSC
-import os.path
-import copy
 import argparse
 import getpass
 import logging
+import os.path
+
+import tableauserverclient as TSC
+
 
 parser = argparse.ArgumentParser(description='Explore workbook functions supported by the Server API.')
 parser.add_argument('--server', '-s', required=True, help='server address')
@@ -25,72 +26,78 @@ parser.add_argument('--preview-image', '-i', metavar='FILENAME',
                     help='filename (a .png file) to save the preview image')
 parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                     help='desired logging level (set to error by default)')
-args = parser.parse_args()
 
-password = getpass.getpass("Password: ")
+if __name__ == '__main__':
 
-# Set logging level based on user input, or error by default
-logging_level = getattr(logging, args.logging_level.upper())
-logging.basicConfig(level=logging_level)
+    args = parser.parse_args()
 
-# SIGN IN
-tableau_auth = TSC.TableauAuth(args.username, password)
-server = TSC.Server(args.server)
-with server.auth.sign_in(tableau_auth):
+    password = getpass.getpass("Password: ")
 
-    # Publish workbook if publish flag is set (-publish, -p)
-    if args.publish:
-        all_projects, pagination_item = server.projects.get()
-        default_project = next((project for project in all_projects if project.is_default()), None)
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-        if default_project is not None:
-            new_workbook = TSC.WorkbookItem(default_project.id)
-            new_workbook = server.workbooks.publish(new_workbook, args.publish, TSC.Server.PublishMode.Overwrite)
-            print("Workbook published. ID: {}".format(new_workbook.id))
-        else:
-            print('Publish failed. Could not find the default project.')
+    # SIGN IN
+    tableau_auth = TSC.TableauAuth(args.username, password)
+    server = TSC.Server(args.server)
 
-    # Gets all workbook items
-    all_workbooks, pagination_item = server.workbooks.get()
-    print("\nThere are {} workbooks on site: ".format(pagination_item.total_available))
-    print([workbook.name for workbook in all_workbooks])
+    overwrite_true = TSC.Server.PublishMode.Overwrite
 
-    if all_workbooks:
-        # Pick one workbook from the list
-        sample_workbook = all_workbooks[0]
+    with server.auth.sign_in(tableau_auth):
 
-        # Populate views
-        server.workbooks.populate_views(sample_workbook)
-        print("\nName of views in {}: ".format(sample_workbook.name))
-        print([view.name for view in sample_workbook.views])
+        # Publish workbook if publish flag is set (-publish, -p)
+        if args.publish:
+            all_projects, pagination_item = server.projects.get()
+            default_project = next((project for project in all_projects if project.is_default()), None)
 
-        # Populate connections
-        server.workbooks.populate_connections(sample_workbook)
-        print("\nConnections for {}: ".format(sample_workbook.name))
-        print(["{0}({1})".format(connection.id, connection.datasource_name)
-               for connection in sample_workbook.connections])
+            if default_project is not None:
+                new_workbook = TSC.WorkbookItem(default_project.id)
+                new_workbook = server.workbooks.publish(new_workbook, args.publish, overwrite_true)
+                print("Workbook published. ID: {}".format(new_workbook.id))
+            else:
+                print('Publish failed. Could not find the default project.')
 
-        # Update tags and show_tabs flag
-        original_tag_set = copy.copy(sample_workbook.tags)
-        sample_workbook.tags.update('a', 'b', 'c', 'd')
-        sample_workbook.show_tabs = True
-        server.workbooks.update(sample_workbook)
-        print("\nOld tag set: {}".format(original_tag_set))
-        print("New tag set: {}".format(sample_workbook.tags))
-        print("Workbook tabbed: {}".format(sample_workbook.show_tabs))
+        # Gets all workbook items
+        all_workbooks, pagination_item = server.workbooks.get()
+        print("\nThere are {} workbooks on site: ".format(pagination_item.total_available))
+        print([workbook.name for workbook in all_workbooks])
 
-        # Delete all tags that were added by setting tags to original
-        sample_workbook.tags = original_tag_set
-        server.workbooks.update(sample_workbook)
+        if all_workbooks:
+            # Pick one workbook from the list
+            sample_workbook = all_workbooks[0]
 
-        if args.download:
-            # Download
-            path = server.workbooks.download(sample_workbook.id, args.download)
-            print("\nDownloaded workbook to {}".format(path))
+            # Populate views
+            server.workbooks.populate_views(sample_workbook)
+            print("\nName of views in {}: ".format(sample_workbook.name))
+            print([view.name for view in sample_workbook.views])
 
-        if args.preview_image:
-            # Populate workbook preview image
-            server.workbooks.populate_preview_image(sample_workbook)
-            with open(args.preview_image, 'wb') as f:
-                f.write(sample_workbook.preview_image)
-            print("\nDownloaded preview image of workbook to {}".format(os.path.abspath(args.preview_image)))
+            # Populate connections
+            server.workbooks.populate_connections(sample_workbook)
+            print("\nConnections for {}: ".format(sample_workbook.name))
+            print(["{0}({1})".format(connection.id, connection.datasource_name)
+                   for connection in sample_workbook.connections])
+
+            # Update tags and show_tabs flag
+            original_tag_set = set(sample_workbook.tags)
+            sample_workbook.tags.update('a', 'b', 'c', 'd')
+            sample_workbook.show_tabs = True
+            server.workbooks.update(sample_workbook)
+            print("\nOld tag set: {}".format(original_tag_set))
+            print("New tag set: {}".format(sample_workbook.tags))
+            print("Workbook tabbed: {}".format(sample_workbook.show_tabs))
+
+            # Delete all tags that were added by setting tags to original
+            sample_workbook.tags = original_tag_set
+            server.workbooks.update(sample_workbook)
+
+            if args.download:
+                # Download
+                path = server.workbooks.download(sample_workbook.id, args.download)
+                print("\nDownloaded workbook to {}".format(path))
+
+            if args.preview_image:
+                # Populate workbook preview image
+                server.workbooks.populate_preview_image(sample_workbook)
+                with open(args.preview_image, 'wb') as f:
+                    f.write(sample_workbook.preview_image)
+                print("\nDownloaded preview image of workbook to {}".format(os.path.abspath(args.preview_image)))

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -7,10 +7,12 @@
 # To run the script, you must have installed Python 2.7.X or 3.3 and later.
 ####
 
-import tableauserverclient as TSC
 import argparse
 import getpass
 import logging
+
+import tableauserverclient as TSC
+
 
 parser = argparse.ArgumentParser(description='Move one workbook from the default project to another.')
 parser.add_argument('--server', '-s', required=True, help='server address')
@@ -19,38 +21,42 @@ parser.add_argument('--workbook-name', '-w', required=True, help='name of workbo
 parser.add_argument('--destination-project', '-d', required=True, help='name of project to move workbook into')
 parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                     help='desired logging level (set to error by default)')
-args = parser.parse_args()
 
-password = getpass.getpass("Password: ")
+if __name__ == '__main__':
 
-# Set logging level based on user input, or error by default
-logging_level = getattr(logging, args.logging_level.upper())
-logging.basicConfig(level=logging_level)
+    args = parser.parse_args()
 
-# Step 1: Sign in to server
-tableau_auth = TSC.TableauAuth(args.username, password)
-server = TSC.Server(args.server)
-with server.auth.sign_in(tableau_auth):
-    # Step 2: Query workbook to move
-    req_option = TSC.RequestOptions()
-    req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
-                                     TSC.RequestOptions.Operator.Equals, args.workbook_name))
-    all_workbooks, pagination_item = server.workbooks.get(req_option)
+    password = getpass.getpass("Password: ")
 
-    # Step 3: Find destination project
-    all_projects, pagination_item = server.projects.get()
-    dest_project = next((project for project in all_projects if project.name == args.destination_project), None)
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-    if dest_project is not None:
-        # Step 4: Update workbook with new project id
-        if all_workbooks:
-            print("Old project: {}".format(all_workbooks[0].project_name))
-            all_workbooks[0].project_id = dest_project.id
-            target_workbook = server.workbooks.update(all_workbooks[0])
-            print("New project: {}".format(target_workbook.project_name))
+    # Step 1: Sign in to server
+    tableau_auth = TSC.TableauAuth(args.username, password)
+    server = TSC.Server(args.server)
+
+    with server.auth.sign_in(tableau_auth):
+        # Step 2: Query workbook to move
+        req_option = TSC.RequestOptions()
+        req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
+                                         TSC.RequestOptions.Operator.Equals, args.workbook_name))
+        all_workbooks, pagination_item = server.workbooks.get(req_option)
+
+        # Step 3: Find destination project
+        all_projects, pagination_item = server.projects.get()
+        dest_project = next((project for project in all_projects if project.name == args.destination_project), None)
+
+        if dest_project is not None:
+            # Step 4: Update workbook with new project id
+            if all_workbooks:
+                print("Old project: {}".format(all_workbooks[0].project_name))
+                all_workbooks[0].project_id = dest_project.id
+                target_workbook = server.workbooks.update(all_workbooks[0])
+                print("New project: {}".format(target_workbook.project_name))
+            else:
+                error = "No workbook named {} found.".format(args.workbook_name)
+                raise LookupError(error)
         else:
-            error = "No workbook named {} found.".format(args.workbook_name)
+            error = "No project named {} found.".format(args.destination_project)
             raise LookupError(error)
-    else:
-        error = "No project named {} found.".format(args.destination_project)
-        raise LookupError(error)

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -14,15 +14,15 @@ import logging
 import tableauserverclient as TSC
 
 
-parser = argparse.ArgumentParser(description='Move one workbook from the default project to another.')
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
-parser.add_argument('--destination-project', '-d', required=True, help='name of project to move workbook into')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+def main():
 
-if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Move one workbook from the default project to another.')
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
+    parser.add_argument('--destination-project', '-d', required=True, help='name of project to move workbook into')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -60,3 +60,7 @@ if __name__ == '__main__':
         else:
             error = "No project named {} found.".format(args.destination_project)
             raise LookupError(error)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -7,12 +7,14 @@
 # To run the script, you must have installed Python 2.7.X or 3.3 and later.
 ####
 
-import tableauserverclient as TSC
-import shutil
 import argparse
-import tempfile
 import getpass
 import logging
+import shutil
+import tempfile
+
+import tableauserverclient as TSC
+
 
 parser = argparse.ArgumentParser(description="Move one workbook from the"
                                              "default project of the default site to"
@@ -23,64 +25,68 @@ parser.add_argument('--workbook-name', '-w', required=True, help='name of workbo
 parser.add_argument('--destination-site', '-d', required=True, help='name of site to move workbook into')
 parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                     help='desired logging level (set to error by default)')
-args = parser.parse_args()
 
-password = getpass.getpass("Password: ")
+if __name__ == '__main__':
 
-# Set logging level based on user input, or error by default
-logging_level = getattr(logging, args.logging_level.upper())
-logging.basicConfig(level=logging_level)
+    args = parser.parse_args()
 
-# Step 1: Sign in to both sites on server
-tableau_auth = TSC.TableauAuth(args.username, password)
+    password = getpass.getpass("Password: ")
 
-source_server = TSC.Server(args.server)
-dest_server = TSC.Server(args.server)
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-with source_server.auth.sign_in(tableau_auth):
-    # Step 2: Query workbook to move
-    req_option = TSC.RequestOptions()
-    req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
-                                     TSC.RequestOptions.Operator.Equals, args.workbook_name))
-    all_workbooks, pagination_item = source_server.workbooks.get(req_option)
+    # Step 1: Sign in to both sites on server
+    tableau_auth = TSC.TableauAuth(args.username, password)
 
-    # Step 3: Download workbook to a temp directory
-    if len(all_workbooks) == 0:
-        print('No workbook named {} found.'.format(args.workbook_name))
-    else:
-        tmpdir = tempfile.mkdtemp()
-        try:
-            workbook_path = source_server.workbooks.download(all_workbooks[0].id, tmpdir)
+    source_server = TSC.Server(args.server)
+    dest_server = TSC.Server(args.server)
 
-            # Step 4: Check if destination site exists, then sign in to the site
-            pagination_info, all_sites = source_server.sites.get()
-            found_destination_site = any((True for site in all_sites if
-                                          args.destination_site.lower() == site.content_url.lower()))
-            if not found_destination_site:
-                error = "No site named {} found.".format(args.destination_site)
-                raise LookupError(error)
+    with source_server.auth.sign_in(tableau_auth):
+        # Step 2: Query workbook to move
+        req_option = TSC.RequestOptions()
+        req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
+                                         TSC.RequestOptions.Operator.Equals, args.workbook_name))
+        all_workbooks, pagination_item = source_server.workbooks.get(req_option)
 
-            tableau_auth.site = args.destination_site
+        # Step 3: Download workbook to a temp directory
+        if len(all_workbooks) == 0:
+            print('No workbook named {} found.'.format(args.workbook_name))
+        else:
+            tmpdir = tempfile.mkdtemp()
+            try:
+                workbook_path = source_server.workbooks.download(all_workbooks[0].id, tmpdir)
 
-            # Signing into another site requires another server object
-            # because of the different auth token and site ID.
-            with dest_server.auth.sign_in(tableau_auth):
-
-                # Step 5: Find destination site's default project
-                pagination_info, dest_projects = dest_server.projects.get()
-                target_project = next((project for project in dest_projects if project.is_default()), None)
-
-                # Step 6: If default project is found, form a new workbook item and publish.
-                if target_project is not None:
-                    new_workbook = TSC.WorkbookItem(name=args.workbook_name, project_id=target_project.id)
-                    new_workbook = dest_server.workbooks.publish(new_workbook, workbook_path,
-                                                                 mode=TSC.Server.PublishMode.Overwrite)
-                    print("Successfully moved {0} ({1})".format(new_workbook.name, new_workbook.id))
-                else:
-                    error = "The default project could not be found."
+                # Step 4: Check if destination site exists, then sign in to the site
+                pagination_info, all_sites = source_server.sites.get()
+                found_destination_site = any((True for site in all_sites if
+                                              args.destination_site.lower() == site.content_url.lower()))
+                if not found_destination_site:
+                    error = "No site named {} found.".format(args.destination_site)
                     raise LookupError(error)
 
-            # Step 7: Delete workbook from source site and delete temp directory
-            source_server.workbooks.delete(all_workbooks[0].id)
-        finally:
-            shutil.rmtree(tmpdir)
+                tableau_auth.site = args.destination_site
+
+                # Signing into another site requires another server object
+                # because of the different auth token and site ID.
+                with dest_server.auth.sign_in(tableau_auth):
+
+                    # Step 5: Find destination site's default project
+                    pagination_info, dest_projects = dest_server.projects.get()
+                    target_project = next((project for project in dest_projects if project.is_default()), None)
+
+                    # Step 6: If default project is found, form a new workbook item and publish.
+                    if target_project is not None:
+                        new_workbook = TSC.WorkbookItem(name=args.workbook_name, project_id=target_project.id)
+                        new_workbook = dest_server.workbooks.publish(new_workbook, workbook_path,
+                                                                     mode=TSC.Server.PublishMode.Overwrite)
+                        print("Successfully moved {0} ({1})".format(new_workbook.name, new_workbook.id))
+                    else:
+                        error = "The default project could not be found."
+                        raise LookupError(error)
+
+                # Step 7: Delete workbook from source site and delete temp directory
+                source_server.workbooks.delete(all_workbooks[0].id)
+
+            finally:
+                shutil.rmtree(tmpdir)

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -16,17 +16,17 @@ import tempfile
 import tableauserverclient as TSC
 
 
-parser = argparse.ArgumentParser(description="Move one workbook from the"
-                                             "default project of the default site to"
-                                             "the default project of another site.")
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
-parser.add_argument('--destination-site', '-d', required=True, help='name of site to move workbook into')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+def main():
 
-if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Move one workbook from the"
+                                                 "default project of the default site to"
+                                                 "the default project of another site.")
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
+    parser.add_argument('--destination-site', '-d', required=True, help='name of site to move workbook into')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -90,3 +90,7 @@ if __name__ == '__main__':
 
             finally:
                 shutil.rmtree(tmpdir)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -14,10 +14,12 @@
 # To run the script, you must have installed Python 2.7.X or 3.3 and later.
 ####
 
-import tableauserverclient as TSC
 import argparse
 import getpass
 import logging
+
+import tableauserverclient as TSC
+
 
 parser = argparse.ArgumentParser(description='Publish a workbook to server.')
 parser.add_argument('--server', '-s', required=True, help='server address')
@@ -25,28 +27,34 @@ parser.add_argument('--username', '-u', required=True, help='username to sign in
 parser.add_argument('--filepath', '-f', required=True, help='filepath to the workbook to publish')
 parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                     help='desired logging level (set to error by default)')
-args = parser.parse_args()
 
-password = getpass.getpass("Password: ")
+if __name__ == '__main__':
 
-# Set logging level based on user input, or error by default
-logging_level = getattr(logging, args.logging_level.upper())
-logging.basicConfig(level=logging_level)
+    args = parser.parse_args()
 
-# Step 1: Sign in to server.
-tableau_auth = TSC.TableauAuth(args.username, password)
-server = TSC.Server(args.server)
-with server.auth.sign_in(tableau_auth):
+    password = getpass.getpass("Password: ")
 
-    # Step 2: Get all the projects on server, then look for the default one.
-    all_projects, pagination_item = server.projects.get()
-    default_project = next((project for project in all_projects if project.is_default()), None)
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-    # Step 3: If default project is found, form a new workbook item and publish.
-    if default_project is not None:
-        new_workbook = TSC.WorkbookItem(default_project.id)
-        new_workbook = server.workbooks.publish(new_workbook, args.filepath, TSC.Server.PublishMode.Overwrite)
-        print("Workbook published. ID: {0}".format(new_workbook.id))
-    else:
-        error = "The default project could not be found."
-        raise LookupError(error)
+    # Step 1: Sign in to server.
+    tableau_auth = TSC.TableauAuth(args.username, password)
+    server = TSC.Server(args.server)
+
+    overwrite_true = TSC.Server.PublishMode.Overwrite
+
+    with server.auth.sign_in(tableau_auth):
+
+        # Step 2: Get all the projects on server, then look for the default one.
+        all_projects, pagination_item = server.projects.get()
+        default_project = next((project for project in all_projects if project.is_default()), None)
+
+        # Step 3: If default project is found, form a new workbook item and publish.
+        if default_project is not None:
+            new_workbook = TSC.WorkbookItem(default_project.id)
+            new_workbook = server.workbooks.publish(new_workbook, args.filepath, overwrite_true)
+            print("Workbook published. ID: {0}".format(new_workbook.id))
+        else:
+            error = "The default project could not be found."
+            raise LookupError(error)

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -21,14 +21,14 @@ import logging
 import tableauserverclient as TSC
 
 
-parser = argparse.ArgumentParser(description='Publish a workbook to server.')
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--filepath', '-f', required=True, help='filepath to the workbook to publish')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+def main():
 
-if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Publish a workbook to server.')
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--filepath', '-f', required=True, help='filepath to the workbook to publish')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -58,3 +58,7 @@ if __name__ == '__main__':
         else:
             error = "The default project could not be found."
             raise LookupError(error)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/set_http_options.py
+++ b/samples/set_http_options.py
@@ -5,35 +5,39 @@
 # To run the script, you must have installed Python 2.7.X or 3.3 and later.
 ####
 
-import tableauserverclient as TSC
 import argparse
 import getpass
 import logging
+
+import tableauserverclient as TSC
 
 parser = argparse.ArgumentParser(description='List workbooks on site, with option set to ignore SSL verification.')
 parser.add_argument('--server', '-s', required=True, help='server address')
 parser.add_argument('--username', '-u', required=True, help='username to sign into server')
 parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                     help='desired logging level (set to error by default)')
-args = parser.parse_args()
 
-password = getpass.getpass("Password: ")
+if __name__ == '__main__':
 
-# Set logging level based on user input, or error by default
-logging_level = getattr(logging, args.logging_level.upper())
-logging.basicConfig(level=logging_level)
+    args = parser.parse_args()
 
-# Step 1: Create required objects for sign in
-tableau_auth = TSC.TableauAuth(args.username, password)
-server = TSC.Server(args.server)
+    password = getpass.getpass("Password: ")
 
-# Step 2: Set http options to disable verifying SSL
-server.add_http_options({'verify': False})
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-with server.auth.sign_in(tableau_auth):
+    # Step 1: Create required objects for sign in
+    tableau_auth = TSC.TableauAuth(args.username, password)
+    server = TSC.Server(args.server)
 
-    # Step 3: Query all workbooks and list them
-    all_workbooks, pagination_item = server.workbooks.get()
-    print('{0} workbooks found. Showing {1}:'.format(pagination_item.total_available, pagination_item.page_size))
-    for workbook in all_workbooks:
-        print('\t{0} (ID: {1})'.format(workbook.name, workbook.id))
+    # Step 2: Set http options to disable verifying SSL
+    server.add_http_options({'verify': False})
+
+    with server.auth.sign_in(tableau_auth):
+
+        # Step 3: Query all workbooks and list them
+        all_workbooks, pagination_item = server.workbooks.get()
+        print('{0} workbooks found. Showing {1}:'.format(pagination_item.total_available, pagination_item.page_size))
+        for workbook in all_workbooks:
+            print('\t{0} (ID: {1})'.format(workbook.name, workbook.id))

--- a/samples/set_http_options.py
+++ b/samples/set_http_options.py
@@ -11,13 +11,14 @@ import logging
 
 import tableauserverclient as TSC
 
-parser = argparse.ArgumentParser(description='List workbooks on site, with option set to ignore SSL verification.')
-parser.add_argument('--server', '-s', required=True, help='server address')
-parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
 
-if __name__ == '__main__':
+def main():
+
+    parser = argparse.ArgumentParser(description='List workbooks on site, with option set to ignore SSL verification.')
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
 
@@ -41,3 +42,7 @@ if __name__ == '__main__':
         print('{0} workbooks found. Showing {1}:'.format(pagination_item.total_available, pagination_item.page_size))
         for workbook in all_workbooks:
             print('\t{0} (ID: {1})'.format(workbook.name, workbook.id))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Though not required, I moved all of the samples code to be wrapped in `if __name__ == "__main__"` blocks since that's best practice for command line scripts.

I also cleaned up imports to match pep8, and removed one or two that were unused.

I think we can refactor some of the really long lines a bit more to make them more readable -- especially with respect to the Filter/Sort options, but that can come in a later checkin.

