### PR TITLE
Fix for issue #60

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -42,7 +42,7 @@ class Auth(Endpoint):
     def sign_out(self):
         url = "{0}/{1}".format(self.baseurl, 'signout')
         # If there are no auth tokens you're already signed out. No-op
-        if not self.parent_srv._auth_token:
+        if not self.parent_srv.is_signed_in():
             return
         self.post_request(url, '')
         self.parent_srv._clear_auth()

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -41,6 +41,9 @@ class Auth(Endpoint):
 
     def sign_out(self):
         url = "{0}/{1}".format(self.baseurl, 'signout')
+        # If there are no auth tokens you're already signed out. No-op
+        if not self.parent_srv._auth_token:
+            return
         self.post_request(url, '')
         self.parent_srv._clear_auth()
         logger.info('Signed out')

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -59,7 +59,12 @@ class Sites(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}".format(self.baseurl, site_id)
         self.delete_request(url)
-        logger.info('Deleted single site (ID: {0})'.format(site_id))
+        # Deleting the site also signs you out on the Server.
+        # Here we check that you're deleting the site you are signed in to
+        # (Which is true now but may not always be) and then clear auth tokens
+        if site_id == self.parent_srv._site_id:
+            self.parent_srv._clear_auth()
+        logger.info('Deleted single site (ID: {0}) and signed out'.format(site_id))
 
     # Create new site
     def create(self, site_item):

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -62,6 +62,7 @@ class Sites(Endpoint):
         # If we deleted the site we are logged into
         # then we are automatically logged out
         if site_id == self.parent_srv.site_id:
+            logger.info('Deleting current site and clearing auth tokens')
             self.parent_srv._clear_auth()
         logger.info('Deleted single site (ID: {0}) and signed out'.format(site_id))
 

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -59,10 +59,9 @@ class Sites(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}".format(self.baseurl, site_id)
         self.delete_request(url)
-        # Deleting the site also signs you out on the Server.
-        # Here we check that you're deleting the site you are signed in to
-        # (Which is true now but may not always be) and then clear auth tokens
-        if site_id == self.parent_srv._site_id:
+        # If we deleted the site we are logged into
+        # then we are automatically logged out
+        if site_id == self.parent_srv.site_id:
             self.parent_srv._clear_auth()
         logger.info('Deleted single site (ID: {0}) and signed out'.format(site_id))
 

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -81,3 +81,6 @@ class Server(object):
     @property
     def session(self):
         return self._session
+
+    def is_signed_in(self):
+        return self._auth_token is not None

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -17,7 +17,7 @@ class SiteTests(unittest.TestCase):
 
         # Fake signin
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
-
+        self.server._site_id = '0626857c-1def-4503-a7d8-7907c3ff9d9f'
         self.baseurl = self.server.sites.baseurl
 
     def test_get(self):


### PR DESCRIPTION
Make Sign Out a no-op when you are already signed out.

Here is a repro script that passes after and fails before the change:
```
import argparse
import getpass
import logging

import tableauserverclient as TSC


def main():

    parser = argparse.ArgumentParser(description='Publish a workbook to server.')
    parser.add_argument('--server', '-s', required=True, help='server address')
    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                        help='desired logging level (set to error by default)')

    args = parser.parse_args()

    password = getpass.getpass("Password: ")

    # Set logging level based on user input, or error by default
    logging_level = getattr(logging, args.logging_level.upper())
    logging.basicConfig(level=logging_level)

    # Step 1: Sign in to server.
    tableau_auth = TSC.TableauAuth(args.username, password)
    server = TSC.Server(args.server)

    with server.auth.sign_in(tableau_auth):
        new_site = TSC.SiteItem(name='blorp', content_url='blorp')
        yay = server.sites.create(new_site)

    tableau_auth = TSC.TableauAuth(args.username, password, site='blorp')

    with server.auth.sign_in(tableau_auth):

        sites = server.sites.get()
        print([i for i in sites])
        server.sites.delete(yay.id)

if __name__ == '__main__':
    main()
```