### PR TITLE
Fix for issue #50 Add regex validator to content_url

### DIFF
--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -87,15 +87,15 @@ def property_is_int(range):
     return property_type_decorator
 
 
-def property_matches(regex_to_match):
+def property_matches(regex_to_match, error):
 
-    COMPILED_RE = re.compile(regex_to_match)
+    compiled_re = re.compile(regex_to_match)
 
     def wrapper(func):
         @wraps(func)
         def validate_regex_decorator(self, value):
-            if not COMPILED_RE.match(value):
-                raise ValueError("content_url can contain only ascii letters, numbers, dashes, and underscores")
+            if not compiled_re.match(value):
+                raise ValueError(error)
             return func(self, value)
         return validate_regex_decorator
     return wrapper

--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -1,3 +1,4 @@
+import re
 from functools import wraps
 
 
@@ -84,3 +85,17 @@ def property_is_int(range):
         return wrapper
 
     return property_type_decorator
+
+
+def property_matches(regex_to_match):
+
+    COMPILED_RE = re.compile(regex_to_match)
+
+    def wrapper(func):
+        @wraps(func)
+        def validate_regex_decorator(self, value):
+            if not COMPILED_RE.match(value):
+                raise ValueError("content_url can contain only ascii letters, numbers, dashes, and underscores")
+            return func(self, value)
+        return validate_regex_decorator
+    return wrapper

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -49,7 +49,7 @@ class SiteItem(object):
 
     @content_url.setter
     @property_not_nullable
-    @property_matches(VALID_CONTENT_URL_RE)
+    @property_matches(VALID_CONTENT_URL_RE, "content_url can contain only letters, numbers, dashes, and underscores")
     def content_url(self, value):
         self._content_url = value
 

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,6 +1,10 @@
 import xml.etree.ElementTree as ET
-from .property_decorators import property_is_enum, property_is_boolean, property_not_empty, property_not_nullable
+from .property_decorators import (property_is_enum, property_is_boolean, property_matches,
+                                  property_not_empty, property_not_nullable)
 from .. import NAMESPACE
+
+
+VALID_CONTENT_URL_RE = r"^[a-zA-Z0-9_\-]*$"
 
 
 class SiteItem(object):
@@ -45,6 +49,7 @@ class SiteItem(object):
 
     @content_url.setter
     @property_not_nullable
+    @property_matches(VALID_CONTENT_URL_RE)
     def content_url(self, value):
         self._content_url = value
 

--- a/test/test_site_model.py
+++ b/test/test_site_model.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import unittest
 import tableauserverclient as TSC
 
@@ -19,10 +21,21 @@ class SiteModelTests(unittest.TestCase):
             site.admin_mode = "Hello"
 
     def test_invalid_content_url(self):
-        self.assertRaises(ValueError, TSC.SiteItem, "site", None)
-        site = TSC.SiteItem("site", "url")
+
         with self.assertRaises(ValueError):
-            site.content_url = None
+            site = TSC.SiteItem(name="蚵仔煎", content_url="蚵仔煎")
+
+        with self.assertRaises(ValueError):
+            site = TSC.SiteItem(name="蚵仔煎", content_url=None)
+
+    def test_set_valid_content_url(self):
+        # Default Site
+        site = TSC.SiteItem(name="Default", content_url="")
+        self.assertEqual(site.content_url, "")
+
+        # Unicode Name and ascii content_url
+        site = TSC.SiteItem(name="蚵仔煎", content_url="omlette")
+        self.assertEqual(site.content_url, "omlette")
 
     def test_invalid_disable_subscriptions(self):
         site = TSC.SiteItem("site", "url")


### PR DESCRIPTION
Content_urls can only be alphanumeric or underscores and dashes. Fix is to validate it client side because the Server error is confusing and the client should just prevent invalid urls from going through.

* Added a generic regex validator for properties and apply it to the site_model
* Updated site_item_tests with some unicode and valid/invalid cases