### PR TITLE
Making the user list operations a no-op userlist not populated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name='tableauserverclient',
-    version='0.1',
+    version='0.2.dev0',
     author='Tableau',
     author_email='github@tableau.com',
     url='https://github.com/tableau/server-client-python',

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -1,5 +1,6 @@
 from .endpoint import Endpoint
 from .exceptions import MissingRequiredFieldError
+from ...models.exceptions import UnpopulatedPropertyError
 from .. import RequestFactory, GroupItem, UserItem, PaginationItem
 import logging
 
@@ -47,7 +48,31 @@ class Groups(Endpoint):
 
     # Removes 1 user from 1 group
     def remove_user(self, group_item, user_id):
-        user_set = group_item.users
+        self._remove_user(group_item, user_id)
+        try:
+            user_set = group_item.users
+            for user in user_set:
+                if user.id == user_id:
+                    user_set.remove(user)
+                    break
+        except UnpopulatedPropertyError:
+            # If we aren't populated, do nothing to the user list
+            pass
+        logger.info('Removed user (id: {0}) from group (ID: {1})'.format(user_id, group_item.id))
+
+    # Adds 1 user to 1 group
+    def add_user(self, group_item, user_id):
+        new_user = self._add_user(group_item, user_id)
+        try:
+            user_set = group_item.users
+            user_set.add(new_user)
+            group_item._set_users(user_set)
+        except UnpopulatedPropertyError:
+            # If we aren't populated, do nothing to the user list
+            pass
+        logger.info('Added user (id: {0}) to group (ID: {1})'.format(user_id, group_item.id))
+
+    def _remove_user(self, group_item, user_id):
         if not group_item.id:
             error = "Group item missing ID."
             raise MissingRequiredFieldError(error)
@@ -56,15 +81,8 @@ class Groups(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}/users/{2}".format(self.baseurl, group_item.id, user_id)
         self.delete_request(url)
-        for user in user_set:
-            if user.id == user_id:
-                user_set.remove(user)
-                break
-        logger.info('Removed user (id: {0}) from group (ID: {1})'.format(user_id, group_item.id))
 
-    # Adds 1 user to 1 group
-    def add_user(self, group_item, user_id):
-        user_set = group_item.users
+    def _add_user(self, group_item, user_id):
         if not group_item.id:
             error = "Group item missing ID."
             raise MissingRequiredFieldError(error)
@@ -74,7 +92,4 @@ class Groups(Endpoint):
         url = "{0}/{1}/users".format(self.baseurl, group_item.id)
         add_req = RequestFactory.Group.add_user_req(user_id)
         server_response = self.post_request(url, add_req)
-        new_user = UserItem.from_response(server_response.content).pop()
-        user_set.add(new_user)
-        group_item._set_users(user_set)
-        logger.info('Added user (id: {0}) to group (ID: {1})'.format(user_id, group_item.id))
+        return UserItem.from_response(server_response.content).pop()

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -98,9 +98,17 @@ class GroupTests(unittest.TestCase):
         self.assertEqual('ServerAdministrator', user.site_role)
 
     def test_add_user_before_populating(self):
-        single_group = TSC.GroupItem('test')
-        self.assertRaises(TSC.UnpopulatedPropertyError, self.server.groups.add_user, single_group,
-                          '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
+        with open(GET_XML, 'rb') as f:
+            get_xml_response = f.read().decode('utf-8')
+        with open(ADD_USER, 'rb') as f:
+            add_user_response = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=get_xml_response)
+            m.post('http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/groups/ef8b19c0-43b6-11e6-af50'
+                   '-63f5805dbe3c/users', text=add_user_response)
+            all_groups, pagination_item = self.server.groups.get()
+            single_group = all_groups[0]
+            self.server.groups.add_user(single_group, '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
 
     def test_add_user_missing_user_id(self):
         with open(POPULATE_USERS, 'rb') as f:
@@ -120,9 +128,16 @@ class GroupTests(unittest.TestCase):
                           '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
 
     def test_remove_user_before_populating(self):
-        single_group = TSC.GroupItem('test')
-        self.assertRaises(TSC.UnpopulatedPropertyError, self.server.groups.remove_user, single_group,
-                          '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
+        with open(GET_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=response_xml)
+            m.delete('http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/groups/ef8b19c0-43b6-11e6-af50'
+                     '-63f5805dbe3c/users/5de011f8-5aa9-4d5b-b991-f462c8dd6bb7',
+                     text='ok')
+            all_groups, pagination_item = self.server.groups.get()
+            single_group = all_groups[0]
+            self.server.groups.remove_user(single_group, '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
 
     def test_remove_user_missing_user_id(self):
         with open(POPULATE_USERS, 'rb') as f:


### PR DESCRIPTION
Refactored the calls to the endpoint and added the user list manipulation into a try/catch for the unpopulated error.