### PR TITLE
Fix Issue #73: Plumb Password to Update User

### DIFF
--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -28,7 +28,6 @@ class UserItem(object):
         self._workbooks = None
         self.email = None
         self.fullname = None
-        self.password = None
         self.name = name
         self.site_role = site_role
         self.auth_setting = auth_setting

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -36,13 +36,13 @@ class Users(Endpoint):
         return UserItem.from_response(server_response.content).pop()
 
     # Update user
-    def update(self, user_item):
+    def update(self, user_item, password=None):
         if not user_item.id:
             error = "User item missing ID."
             raise MissingRequiredFieldError(error)
 
         url = "{0}/{1}".format(self.baseurl, user_item.id)
-        update_req = RequestFactory.User.update_req(user_item)
+        update_req = RequestFactory.User.update_req(user_item, password)
         server_response = self.put_request(url, update_req)
         logger.info('Updated user item (ID: {0})'.format(user_item.id))
         updated_item = copy.copy(user_item)

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -233,7 +233,7 @@ class TagRequest(object):
 
 
 class UserRequest(object):
-    def update_req(self, user_item, password=''):
+    def update_req(self, user_item, password):
         xml_request = ET.Element('tsRequest')
         user_element = ET.SubElement(xml_request, 'user')
         if user_item.fullname:

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -87,7 +87,6 @@ class UserTests(unittest.TestCase):
             single_user.name = 'Cassie'
             single_user.fullname = 'Cassie'
             single_user.email = 'cassie@email.com'
-            single_user.password = 'password'
             single_user = self.server.users.update(single_user)
 
         self.assertEqual('Cassie', single_user.name)


### PR DESCRIPTION
We were checking against the password parameter that wasn't accessible via the update endpoint.

This plumbs password through and optionally serializes if if it's present in the update request.

I removed all traces of password from the user model to remove any temptation to store a long lived plain text password there.

[Manual Test Screenshot Proof](https://www.dropbox.com/s/9h72u1bx2wvunns/Screenshot%202016-10-25%2009.45.50.png?dl=0)

The new signature would be:
```python
user = TSC.UserItem(name='mikepope', site_role='Publisher')
server.users.update(user, password='secret')
```
/cc @RussTheAerialist @mpope-tableau 