### PR TITLE
Implement Pager for auto-paging requests

### DIFF
--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -17,37 +17,6 @@ import os.path
 import tableauserverclient as TSC
 
 
-class pagination_generator(object):
-    """ This class returns a generator that will iterate over all of the results.
-
-    server is the server object that will be used when calling the callback.  It will be passed
-    to the callback on each iteration
-
-    Callback is expected to take a server object and a request options and return two values, an array of results,
-    and the pagination item from the current call.  This will be used to build subsequent requests.
-    """
-
-    def __init__(self, fetch_more):
-        self._fetch_more = fetch_more
-
-    def __call__(self):
-        current_item_list, last_pagination_item = self._fetch_more(None)  # Prime the generator
-        count = 0
-
-        while count < last_pagination_item.total_available:
-            if len(current_item_list) == 0:
-                current_item_list, last_pagination_item = self._load_next_page(current_item_list, last_pagination_item)
-
-            yield current_item_list.pop(0)
-            count += 1
-
-    def _load_next_page(self, current_item_list, last_pagination_item):
-        next_page = last_pagination_item.page_number + 1
-        opts = TSC.RequestOptions(pagenumber=next_page, pagesize=last_pagination_item.page_size)
-        current_item_list, last_pagination_item = self._fetch_more(opts)
-        return current_item_list, last_pagination_item
-
-
 def main():
 
     parser = argparse.ArgumentParser(description='Return a list of all of the workbooks on your server')
@@ -70,10 +39,29 @@ def main():
     server = TSC.Server(args.server)
 
     with server.auth.sign_in(tableau_auth):
-        generator = pagination_generator(server.workbooks.get)
+
+        # Pager returns a generator that yields one item at a time fetching
+        # from Server only when necessary. Pager takes a server Endpoint as its
+        # first parameter. It will call 'get' on that endpoint. To get workbooks
+        # pass `server.workbooks`, to get users pass` server.users`, etc
+        # You can then loop over the generator to get the objects one at a time
+        # Here we print the workbook id for each workbook
+
         print("Your server contains the following workbooks:\n")
-        for wb in generator():
+        for wb in TSC.Pager(server.workbooks):
             print(wb.name)
+
+        # Pager can also be used in list comprehensions for compactness and easy
+        # filtering. Here we loop over the Pager and only keep workbooks where the
+        # name starts with the letter 'a'
+        # >>> [wb for wb in TSC.Pager(server.workbooks) if wb.name.startswith('a')]
+
+        # Since Pager is a generator it follows the standard conventions and can
+        # be fed to a list if you really need all the workbooks in memory at once.
+        # If you need everything, it may be faster to use a larger page size
+
+        # >>> request_options = TSC.RequestOptions(pagesize=1000)
+        # >>> all_workbooks = list(TSC.Pager(server.workbooks, request_options))
 
 if __name__ == '__main__':
     main()

--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -51,10 +51,13 @@ def main():
         for wb in TSC.Pager(server.workbooks):
             print(wb.name)
 
-        # Pager can also be used in list comprehensions for compactness and easy
-        # filtering. Here we loop over the Pager and only keep workbooks where the
-        # name starts with the letter 'a'
-        # >>> [wb for wb in TSC.Pager(server.workbooks) if wb.name.startswith('a')]
+        # Pager can also be used in list comprehensions or generator expressions
+        # for compactness and easy filtering. Generator expressions will use less
+        # memory than list comprehsnsions. Consult the Python laguage documentation for
+        # best practices on which are best for your use case. Here we loop over the
+        # Pager and only keep workbooks where the name starts with the letter 'a'
+        # >>> [wb for wb in TSC.Pager(server.workbooks) if wb.name.startswith('a')] # List Comprehension
+        # >>> (wb for wb in TSC.Pager(server.workbooks) if wb.name.startswith('a')) # Generator Expression
 
         # Since Pager is a generator it follows the standard conventions and can
         # be fed to a list if you really need all the workbooks in memory at once.

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -4,7 +4,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem
 from .server import RequestOptions, Filter, Sort, Server, ServerResponseError,\
-    MissingRequiredFieldError, NotSignedInError
+    MissingRequiredFieldError, NotSignedInError, Pager
 
 __version__ = '0.0.1'
 __VERSION__ = __version__

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -7,5 +7,6 @@ from .. import ConnectionItem, DatasourceItem,\
     UserItem, ViewItem, WorkbookItem, NAMESPACE
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, ServerResponseError, MissingRequiredFieldError
-from .server import Server, Pager
+from .server import Server
+from .pager import Pager
 from .exceptions import NotSignedInError

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -7,5 +7,5 @@ from .. import ConnectionItem, DatasourceItem,\
     UserItem, ViewItem, WorkbookItem, NAMESPACE
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, ServerResponseError, MissingRequiredFieldError
-from .server import Server
+from .server import Server, Pager
 from .exceptions import NotSignedInError

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -1,0 +1,43 @@
+from . import RequestOptions
+
+
+class Pager(object):
+    """
+    Generator that takes an endpoint with `.get` and lazily loads items from Server.
+    Supports all `RequestOptions` including starting on any page.
+    """
+
+    def __init__(self, endpoint, request_opts=None):
+        self._endpoint = endpoint.get
+        self._options = request_opts
+
+        # If we have options we could be starting on any page, backfill the count
+        if self._options:
+            self._count = ((self._options.pagenumber - 1) * self._options.pagesize)
+        else:
+            self._count = 0
+
+    def __iter__(self):
+        # Fetch the first page
+        current_item_list, last_pagination_item = self._endpoint(self._options)
+
+        # Get the rest on demand as a generator
+        while self._count < last_pagination_item.total_available:
+            if len(current_item_list) == 0:
+                current_item_list, last_pagination_item = self._load_next_page(last_pagination_item)
+
+            try:
+                yield current_item_list.pop(0)
+                self._count += 1
+
+            except IndexError:
+                # The total count on Server changed while fetching exit gracefully
+                raise StopIteration
+
+    def _load_next_page(self, last_pagination_item):
+        next_page = last_pagination_item.page_number + 1
+        opts = RequestOptions(pagenumber=next_page, pagesize=last_pagination_item.page_size)
+        if self._options is not None:
+            opts.sort, opts.filter = self._options.sort, self._options.filter
+        current_item_list, last_pagination_item = self._endpoint(opts)
+        return current_item_list, last_pagination_item

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -1,45 +1,7 @@
 from .exceptions import NotSignedInError
 from .endpoint import Sites, Views, Users, Groups, Workbooks, Datasources, Projects, Auth, Schedules, ServerInfo
-from . import RequestOptions
 
 import requests
-
-
-class Pager(object):
-    """ This class returns a generator that will iterate over all of the results.
-
-    server is the server object that will be used when calling the callback.  It will be passed
-    to the callback on each iteration
-
-    Callback is expected to take a server object and a request options and return two values, an array of results,
-    and the pagination item from the current call.  This will be used to build subsequent requests.
-    """
-
-    def __init__(self, fetcher, opts=None):
-        self._fetcher = fetcher.get
-        self._options = opts
-
-    def __call__(self):
-        current_item_list, last_pagination_item = self._fetcher(self._options)
-        count = 0
-
-        while count < last_pagination_item.total_available:
-            if len(current_item_list) == 0:
-                current_item_list, last_pagination_item = self._load_next_page(current_item_list, last_pagination_item)
-
-            yield current_item_list.pop(0)
-            count += 1
-
-    def __iter__(self):
-        return self()
-
-    def _load_next_page(self, current_item_list, last_pagination_item):
-        next_page = last_pagination_item.page_number + 1
-        opts = RequestOptions(pagenumber=next_page, pagesize=last_pagination_item.page_size)
-        if self._options is not None:
-            opts.sort, opts.filter = self._options.sort, self._options.filter
-        current_item_list, last_pagination_item = self._fetcher(opts)
-        return current_item_list, last_pagination_item
 
 
 class Server(object):

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -1,6 +1,45 @@
 from .exceptions import NotSignedInError
 from .endpoint import Sites, Views, Users, Groups, Workbooks, Datasources, Projects, Auth, Schedules, ServerInfo
+from . import RequestOptions
+
 import requests
+
+
+class Pager(object):
+    """ This class returns a generator that will iterate over all of the results.
+
+    server is the server object that will be used when calling the callback.  It will be passed
+    to the callback on each iteration
+
+    Callback is expected to take a server object and a request options and return two values, an array of results,
+    and the pagination item from the current call.  This will be used to build subsequent requests.
+    """
+
+    def __init__(self, fetcher, opts=None):
+        self._fetcher = fetcher.get
+        self._options = opts
+
+    def __call__(self):
+        current_item_list, last_pagination_item = self._fetcher(self._options)
+        count = 0
+
+        while count < last_pagination_item.total_available:
+            if len(current_item_list) == 0:
+                current_item_list, last_pagination_item = self._load_next_page(current_item_list, last_pagination_item)
+
+            yield current_item_list.pop(0)
+            count += 1
+
+    def __iter__(self):
+        return self()
+
+    def _load_next_page(self, current_item_list, last_pagination_item):
+        next_page = last_pagination_item.page_number + 1
+        opts = RequestOptions(pagenumber=next_page, pagesize=last_pagination_item.page_size)
+        if self._options is not None:
+            opts.sort, opts.filter = self._options.sort, self._options.filter
+        current_item_list, last_pagination_item = self._fetcher(opts)
+        return current_item_list, last_pagination_item
 
 
 class Server(object):

--- a/test/assets/workbook_get_page_1.xml
+++ b/test/assets/workbook_get_page_1.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="1" pageSize="1" totalAvailable="3" />
+    <workbooks>
+        <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" name="Page1Workbook" contentUrl="Page1Workbook" showTabs="false" size="1" createdAt="2016-08-03T20:34:04Z" updatedAt="2016-08-04T17:56:41Z">
+            <project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+            <tags />
+        </workbook>
+    </workbooks>
+</tsResponse>

--- a/test/assets/workbook_get_page_2.xml
+++ b/test/assets/workbook_get_page_2.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="2" pageSize="1" totalAvailable="3" />
+    <workbooks>
+        <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" name="Page2Workbook" contentUrl="Page2Workbook" showTabs="false" size="26" createdAt="2016-07-26T20:34:56Z" updatedAt="2016-07-26T20:35:05Z">
+            <project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+            <tags>
+                <tag label="Safari" />
+                <tag label="Sample" />
+            </tags>
+        </workbook>
+    </workbooks>
+</tsResponse>

--- a/test/assets/workbook_get_page_3.xml
+++ b/test/assets/workbook_get_page_3.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="3" pageSize="1" totalAvailable="3" />
+    <workbooks>
+        <workbook id="0413f2d6-387d-4fb6-9823-370d67b1276f" name="Page3Workbook" contentUrl="Page3Workbook" showTabs="false" size="26" createdAt="2016-07-26T20:34:56Z" updatedAt="2016-07-26T20:35:05Z">
+            <project id="63ba565c-f352-41f4-87f5-ba4573fc7c2c" name="default" />
+            <owner id="299fe064-51a5-4e11-93a1-76116239f082" />
+        </workbook>
+    </workbooks>
+</tsResponse>

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -37,11 +37,10 @@ class PagerTests(unittest.TestCase):
             m.get(self.baseurl + "?pageNumber=3&pageSize=1", text=page_3)
 
             # No options should get all 3
-            workbooks = TSC.Pager(self.server.workbooks)
-            self.assertTrue(len(list(workbooks)) == 3)
+            workbooks = list(TSC.Pager(self.server.workbooks))
+            self.assertTrue(len(workbooks) == 3)
 
             # Let's check that workbook items aren't duplicates
-            workbooks = TSC.Pager(self.server.workbooks)
             wb1, wb2, wb3 = workbooks
             self.assertEqual(wb1.name, 'Page1Workbook')
             self.assertEqual(wb2.name, 'Page2Workbook')
@@ -65,6 +64,8 @@ class PagerTests(unittest.TestCase):
             opts = TSC.RequestOptions(2, 1)
             workbooks = list(TSC.Pager(self.server.workbooks, opts))
             self.assertTrue(len(workbooks) == 2)
+
+            # Check that the workbooks are the 2 we think they should be
             wb2, wb3 = workbooks
             self.assertEqual(wb2.name, 'Page2Workbook')
             self.assertEqual(wb3.name, 'Page3Workbook')

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -10,7 +10,6 @@ GET_XML_PAGE2 = os.path.join(TEST_ASSET_DIR, 'workbook_get_page_2.xml')
 GET_XML_PAGE3 = os.path.join(TEST_ASSET_DIR, 'workbook_get_page_3.xml')
 
 
-
 class PagerTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
@@ -48,8 +47,6 @@ class PagerTests(unittest.TestCase):
             self.assertEqual(wb2.name, 'Page2Workbook')
             self.assertEqual(wb3.name, 'Page3Workbook')
 
-
-
     def test_pager_with_options(self):
         with open(GET_XML_PAGE1, 'rb') as f:
             page_1 = f.read().decode('utf-8')
@@ -67,24 +64,25 @@ class PagerTests(unittest.TestCase):
             m.get(self.baseurl + "?pageNumber=3&pageSize=1", text=page_3)
             m.get(self.baseurl + "?pageNumber=1&pageSize=3", text=page_1)
 
-
             # Starting on page 2 should get 2 out of 3
-            opts = TSC.RequestOptions(2,1)
-            workbooks = TSC.Pager(self.server.workbooks, opts)
-            self.assertTrue(len(list(workbooks)) == 2)
+            opts = TSC.RequestOptions(2, 1)
+            workbooks = list(TSC.Pager(self.server.workbooks, opts))
+            self.assertTrue(len(workbooks) == 2)
+            wb2, wb3 = workbooks
+            self.assertEqual(wb2.name, 'Page2Workbook')
+            self.assertEqual(wb3.name, 'Page3Workbook')
 
             # Starting on 1 with pagesize of 3 should get all 3
-            opts = TSC.RequestOptions(1,3)
-            workbooks = TSC.Pager(self.server.workbooks, opts)
-            self.assertTrue(len(list(workbooks)) == 3)
+            opts = TSC.RequestOptions(1, 3)
+            workbooks = list(TSC.Pager(self.server.workbooks, opts))
+            self.assertTrue(len(workbooks) == 3)
+            wb1, wb2, wb3 = workbooks
+            self.assertEqual(wb1.name, 'Page1Workbook')
+            self.assertEqual(wb2.name, 'Page2Workbook')
+            self.assertEqual(wb3.name, 'Page3Workbook')
 
             # Starting on 3 with pagesize of 1 should get the last item
-            opts = TSC.RequestOptions(3,1)
-            workbooks = TSC.Pager(self.server.workbooks, opts)
-            self.assertTrue(len(list(workbooks)) == 1)
-
-            # Starting on 3 with pagesize of 1 should get the last item
-            opts = TSC.RequestOptions(3,1)
+            opts = TSC.RequestOptions(3, 1)
             workbooks = list(TSC.Pager(self.server.workbooks, opts))
             self.assertTrue(len(workbooks) == 1)
             # Should have the last workbook

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -1,0 +1,92 @@
+import unittest
+import os
+import requests_mock
+import tableauserverclient as TSC
+
+TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
+
+GET_XML_PAGE1 = os.path.join(TEST_ASSET_DIR, 'workbook_get_page_1.xml')
+GET_XML_PAGE2 = os.path.join(TEST_ASSET_DIR, 'workbook_get_page_2.xml')
+GET_XML_PAGE3 = os.path.join(TEST_ASSET_DIR, 'workbook_get_page_3.xml')
+
+
+
+class PagerTests(unittest.TestCase):
+    def setUp(self):
+        self.server = TSC.Server('http://test')
+
+        # Fake sign in
+        self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
+        self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
+
+        self.baseurl = self.server.workbooks.baseurl
+
+    def test_pager_with_no_options(self):
+        with open(GET_XML_PAGE1, 'rb') as f:
+            page_1 = f.read().decode('utf-8')
+        with open(GET_XML_PAGE2, 'rb') as f:
+            page_2 = f.read().decode('utf-8')
+        with open(GET_XML_PAGE3, 'rb') as f:
+            page_3 = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            # Register Pager with default request options
+            m.get(self.baseurl, text=page_1)
+
+            # Register Pager with some pages
+            m.get(self.baseurl + "?pageNumber=1&pageSize=1", text=page_1)
+            m.get(self.baseurl + "?pageNumber=2&pageSize=1", text=page_2)
+            m.get(self.baseurl + "?pageNumber=3&pageSize=1", text=page_3)
+
+            # No options should get all 3
+            workbooks = TSC.Pager(self.server.workbooks)
+            self.assertTrue(len(list(workbooks)) == 3)
+
+            # Let's check that workbook items aren't duplicates
+            workbooks = TSC.Pager(self.server.workbooks)
+            wb1, wb2, wb3 = workbooks
+            self.assertEqual(wb1.name, 'Page1Workbook')
+            self.assertEqual(wb2.name, 'Page2Workbook')
+            self.assertEqual(wb3.name, 'Page3Workbook')
+
+
+
+    def test_pager_with_options(self):
+        with open(GET_XML_PAGE1, 'rb') as f:
+            page_1 = f.read().decode('utf-8')
+        with open(GET_XML_PAGE2, 'rb') as f:
+            page_2 = f.read().decode('utf-8')
+        with open(GET_XML_PAGE3, 'rb') as f:
+            page_3 = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            # Register Pager with default request options
+            m.get(self.baseurl, text=page_1)
+
+            # Register Pager with some pages
+            m.get(self.baseurl + "?pageNumber=1&pageSize=1", text=page_1)
+            m.get(self.baseurl + "?pageNumber=2&pageSize=1", text=page_2)
+            m.get(self.baseurl + "?pageNumber=3&pageSize=1", text=page_3)
+            m.get(self.baseurl + "?pageNumber=1&pageSize=3", text=page_1)
+
+
+            # Starting on page 2 should get 2 out of 3
+            opts = TSC.RequestOptions(2,1)
+            workbooks = TSC.Pager(self.server.workbooks, opts)
+            self.assertTrue(len(list(workbooks)) == 2)
+
+            # Starting on 1 with pagesize of 3 should get all 3
+            opts = TSC.RequestOptions(1,3)
+            workbooks = TSC.Pager(self.server.workbooks, opts)
+            self.assertTrue(len(list(workbooks)) == 3)
+
+            # Starting on 3 with pagesize of 1 should get the last item
+            opts = TSC.RequestOptions(3,1)
+            workbooks = TSC.Pager(self.server.workbooks, opts)
+            self.assertTrue(len(list(workbooks)) == 1)
+
+            # Starting on 3 with pagesize of 1 should get the last item
+            opts = TSC.RequestOptions(3,1)
+            workbooks = list(TSC.Pager(self.server.workbooks, opts))
+            self.assertTrue(len(workbooks) == 1)
+            # Should have the last workbook
+            wb3 = workbooks.pop()
+            self.assertEqual(wb3.name, 'Page3Workbook')

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -55,9 +55,6 @@ class PagerTests(unittest.TestCase):
         with open(GET_XML_PAGE3, 'rb') as f:
             page_3 = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            # Register Pager with default request options
-            m.get(self.baseurl, text=page_1)
-
             # Register Pager with some pages
             m.get(self.baseurl + "?pageNumber=1&pageSize=1", text=page_1)
             m.get(self.baseurl + "?pageNumber=2&pageSize=1", text=page_2)


### PR DESCRIPTION
Here's a first draft based on @RussTheAerialist's code in `pagination_sample.py`.

Currently it:
- Takes an endpoint as its argument instead of a `get` function, this is because these calls only apply to `get` anyway, so let's keep it clean.
- Takes an options object and seeds the filters/sorts with it, as well as the initial page size
- Can be used as an iterator

I would like it to:

- Not do everything in the `__call__` method. I _think_ we can move that to a helper or to `__init__`
    - We would make the first page call on instantiation, which populates some properties that could be useful (like `__len__`)
- Since we know the `total_avaliable` we might be able to implement `__len__`. This gives users the ability to check the length to see if they really want to iterate over it or not.
- I need to read more to see if I need to worry about `__next__` or not.
- Add tests

This script works (tested manually):
```python
import tableauserverclient as TSC

auth_stuff = TSC.TableauAuth(username='USERNAME', password='PASSWORD')

server = TSC.Server("http://SERVER")
server.auth.sign_in(auth_stuff)

options = TSC.RequestOptions()
options.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
                                         TSC.RequestOptions.Operator.Equals,
                                         "WORKBOOKNAME"))

# Call with a filter
wbs = TSC.server.Pager(server.workbooks, options)
print(len([i for i in wbs[)) # prints 1

# Get them all!
wbs = TSC.server.Pager(server.workbooks)
print(len([i for i in wbs])) # prints 1086 on my test server, that's all of em!
server.auth.sign_out()
```

Open Questions:

1. Where should it live? I'm not sure Server is the right place
2. Thoughts on implementing `__len__`?
3. Thoughts on implementing the primary logic somewhere other than `__call__`? It might just be me who thinks it's weird.

/cc @RussTheAerialist @LGraber 