### PR TITLE
Implement call to move to highest supported REST API version

### DIFF
--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -1,7 +1,7 @@
 from .auth_endpoint import Auth
 from .datasources_endpoint import Datasources
 from .endpoint import Endpoint
-from .exceptions import ServerResponseError, MissingRequiredFieldError
+from .exceptions import ServerResponseError, MissingRequiredFieldError, ServerInfoEndpointNotFoundError
 from .groups_endpoint import Groups
 from .projects_endpoint import Projects
 from .schedules_endpoint import Schedules

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -24,3 +24,7 @@ class ServerResponseError(Exception):
 
 class MissingRequiredFieldError(Exception):
     pass
+
+
+class ServerInfoEndpointNotFoundError(Exception):
+    pass

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -1,4 +1,5 @@
 from .endpoint import Endpoint
+from .exceptions import ServerResponseError, ServerInfoEndpointNotFoundError
 from ...models import ServerInfoItem
 import logging
 
@@ -12,6 +13,11 @@ class ServerInfo(Endpoint):
 
     def get(self):
         """ Retrieve the server info for the server.  This is an unauthenticated call """
-        server_response = self.get_unauthenticated_request(self.baseurl)
+        try:
+            server_response = self.get_unauthenticated_request(self.baseurl)
+        except ServerResponseError as e:
+            if e.code == "404003":
+                raise ServerInfoEndpointNotFoundError
+
         server_info = ServerInfoItem.from_response(server_response.content)
         return server_info

--- a/test/assets/server_info_404.xml
+++ b/test/assets/server_info_404.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <error code="404003">
+    <summary>Resource Not Found</summary>
+    <detail>Unknown resource '/2.4/serverInfo' specified in URI.</detail>
+  </error>
+</tsResponse>

--- a/test/assets/server_info_auth_info.xml
+++ b/test/assets/server_info_auth_info.xml
@@ -1,0 +1,12 @@
+<authinfo>
+<version version="0.31">
+<api_version>0.31</api_version>
+<server_api_version>0.31</server_api_version>
+<document_version>9.2</document_version>
+<product_version>9.3</product_version>
+<external_version>9.3.4</external_version>
+<build>hello.16.1106.2025</build>
+<publishing_method>unrestricted</publishing_method>
+<mobile_api_version>2.6</mobile_api_version>
+</version>
+</authinfo>

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -6,21 +6,48 @@ import tableauserverclient as TSC
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
 SERVER_INFO_GET_XML = os.path.join(TEST_ASSET_DIR, 'server_info_get.xml')
+SERVER_INFO_404 = os.path.join(TEST_ASSET_DIR, 'server_info_404.xml')
+SERVER_INFO_AUTH_INFO_XML = os.path.join(TEST_ASSET_DIR, 'server_info_auth_info.xml')
 
 
 class ServerInfoTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
-        self.server.version = '2.4'
         self.baseurl = self.server.server_info.baseurl
 
     def test_server_info_get(self):
         with open(SERVER_INFO_GET_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.get(self.baseurl, text=response_xml)
+            self.server.version = '2.4'
+            m.get(self.server.server_info.baseurl, text=response_xml)
             actual = self.server.server_info.get()
 
             self.assertEqual('10.1.0', actual.product_version)
             self.assertEqual('10100.16.1024.2100', actual.build_number)
             self.assertEqual('2.4', actual.rest_api_version)
+
+    def test_server_info_use_highest_version_downgrades(self):
+        with open(SERVER_INFO_AUTH_INFO_XML, 'rb') as f:
+            # This is the auth.xml endpoint present back to 9.0 Servers
+            auth_response_xml = f.read().decode('utf-8')
+        with open(SERVER_INFO_404, 'rb') as f:
+            # 10.1 serverInfo response
+            si_response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            # Return a 404 for serverInfo so we can pretend this is an old Server
+            m.get(self.server.server_address + "/api/2.4/serverInfo", text=si_response_xml, status_code=404)
+            m.get(self.server.server_address + "/auth?format=xml", text=auth_response_xml)
+            self.server.use_highest_version()
+            self.assertEqual(self.server.version, '2.2')
+
+    def test_server_info_use_highest_version_upgrades(self):
+        with open(SERVER_INFO_GET_XML, 'rb') as f:
+            si_response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.server.server_address + "/api/2.4/serverInfo", text=si_response_xml)
+            # Pretend we're old
+            self.server.version = '2.0'
+            self.server.use_highest_version()
+            # Did we upgrade to 2.4?
+            self.assertEqual(self.server.version, '2.4')


### PR DESCRIPTION
Implemented during TC16 Hackathon!

Today, by default we sign in as '2.3' hard coded as our API version.

Now users can call `server.use_highest_version()` and it will negotiate the highest-supported API version for the current Server.