### PR TITLE
Initial implementation to address #102 and provide datetime objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   # Tests
   - python setup.py test
   # pep8 - disabled for now until we can scrub the files to make sure we pass before turning it on
-  - pycodestyle .
+  - pycodestyle tableauserverclient test

--- a/samples/initialize_server.py
+++ b/samples/initialize_server.py
@@ -10,6 +10,7 @@ import getpass
 import logging
 import glob
 
+
 def main():
     parser = argparse.ArgumentParser(description='Initialize a server with content.')
     parser.add_argument('--server', '-s', required=True, help='server address')
@@ -47,11 +48,11 @@ def main():
         # Create the site if it doesn't exist
         if existing_site is None:
             print("Site not found: {0} Creating it...").format(args.site)
-            new_site = TSC.SiteItem(name=args.site, content_url=args.site.replace(" ", ""), admin_mode=TSC.SiteItem.AdminMode.ContentAndUsers)
+            new_site = TSC.SiteItem(name=args.site, content_url=args.site.replace(" ", ""),
+                                    admin_mode=TSC.SiteItem.AdminMode.ContentAndUsers)
             server.sites.create(new_site)
         else:
             print("Site {0} exists. Moving on...").format(args.site)
-
 
     ################################################################################
     # Step 3: Sign-in to our target site
@@ -81,6 +82,7 @@ def main():
         ################################################################################
         publish_datasources_to_site(server_upload, project, args.datasources_folder)
         publish_workbooks_to_site(server_upload, project, args.workbooks_folder)
+
 
 def publish_datasources_to_site(server_object, project, folder):
     path = folder + '/*.tds*'

--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -66,5 +66,6 @@ def main():
         # >>> request_options = TSC.RequestOptions(pagesize=1000)
         # >>> all_workbooks = list(TSC.Pager(server.workbooks, request_options))
 
+
 if __name__ == '__main__':
     main()

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -28,6 +28,9 @@ TABLEAU_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def parse_datetime(date):
+    if date is None:
+        return None
+
     return datetime.datetime.strptime(date, TABLEAU_DATE_FORMAT).replace(tzinfo=utc)
 
 

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -1,0 +1,37 @@
+import datetime
+
+try:
+    from pytz import utc
+except ImportError:
+    # If pytz is not installed, let's polyfill a UTC timezone so it all just works
+    # This code below is from the python documentation for tzinfo: https://docs.python.org/2.3/lib/datetime-tzinfo.html
+    ZERO = datetime.timedelta(0)
+    HOUR = datetime.timedelta(hours=1)
+
+
+    # A UTC class.
+
+    class UTC(datetime.tzinfo):
+        """UTC"""
+
+        def utcoffset(self, dt):
+            return ZERO
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return ZERO
+
+
+    utc = UTC()
+
+TABLEAU_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def parse_datetime(date):
+    return datetime.datetime.strptime(date, TABLEAU_DATE_FORMAT).replace(tzinfo=utc)
+
+
+def format_datetime(date):
+    return date.astimezone(tz=utc).strftime(TABLEAU_DATE_FORMAT)

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -1,28 +1,25 @@
 import datetime
 
-try:
-    from pytz import utc
-except ImportError:
-    # If pytz is not installed, let's polyfill a UTC timezone so it all just works
-    # This code below is from the python documentation for tzinfo: https://docs.python.org/2.3/lib/datetime-tzinfo.html
-    ZERO = datetime.timedelta(0)
-    HOUR = datetime.timedelta(hours=1)
 
-    # A UTC class.
+# This code below is from the python documentation for tzinfo: https://docs.python.org/2.3/lib/datetime-tzinfo.html
+ZERO = datetime.timedelta(0)
+HOUR = datetime.timedelta(hours=1)
 
-    class UTC(datetime.tzinfo):
-        """UTC"""
+# A UTC class.
 
-        def utcoffset(self, dt):
-            return ZERO
+class UTC(datetime.tzinfo):
+    """UTC"""
 
-        def tzname(self, dt):
-            return "UTC"
+    def utcoffset(self, dt):
+        return ZERO
 
-        def dst(self, dt):
-            return ZERO
+    def tzname(self, dt):
+        return "UTC"
 
-    utc = UTC()
+    def dst(self, dt):
+        return ZERO
+
+utc = UTC()
 
 TABLEAU_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -7,6 +7,7 @@ HOUR = datetime.timedelta(hours=1)
 
 # A UTC class.
 
+
 class UTC(datetime.tzinfo):
     """UTC"""
 
@@ -18,6 +19,7 @@ class UTC(datetime.tzinfo):
 
     def dst(self, dt):
         return ZERO
+
 
 utc = UTC()
 

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -8,7 +8,6 @@ except ImportError:
     ZERO = datetime.timedelta(0)
     HOUR = datetime.timedelta(hours=1)
 
-
     # A UTC class.
 
     class UTC(datetime.tzinfo):
@@ -22,7 +21,6 @@ except ImportError:
 
         def dst(self, dt):
             return ZERO
-
 
     utc = UTC()
 

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,8 +1,9 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
-from .property_decorators import property_not_nullable, property_is_datetime
+from .property_decorators import property_not_nullable
 from .tag_item import TagItem
 from .. import NAMESPACE
+from ..datetime_helpers import parse_datetime
 
 
 class DatasourceItem(object):
@@ -33,11 +34,6 @@ class DatasourceItem(object):
     @property
     def created_at(self):
         return self._created_at
-
-    @created_at.setter
-    @property_is_datetime
-    def created_at(self, value):
-        self._created_at = value
 
     @property
     def id(self):
@@ -123,8 +119,8 @@ class DatasourceItem(object):
         name = datasource_xml.get('name', None)
         datasource_type = datasource_xml.get('type', None)
         content_url = datasource_xml.get('contentUrl', None)
-        created_at = datasource_xml.get('createdAt', None)
-        updated_at = datasource_xml.get('updatedAt', None)
+        created_at = parse_datetime(datasource_xml.get('createdAt', None))
+        updated_at = parse_datetime(datasource_xml.get('updatedAt', None))
 
         tags = None
         tags_elem = datasource_xml.find('.//t:tags', namespaces=NAMESPACE)

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
-from .property_decorators import property_not_nullable
+from .property_decorators import property_not_nullable, property_is_datetime
 from .tag_item import TagItem
 from .. import NAMESPACE
 
@@ -33,6 +33,11 @@ class DatasourceItem(object):
     @property
     def created_at(self):
         return self._created_at
+
+    @created_at.setter
+    @property_is_datetime
+    def created_at(self, value):
+        self._created_at = value
 
     @property
     def id(self):

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -2,8 +2,9 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 
 from .interval_item import IntervalItem, HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval
-from .property_decorators import property_is_enum, property_not_nullable, property_is_int, property_is_datetime
+from .property_decorators import property_is_enum, property_not_nullable, property_is_int
 from .. import NAMESPACE
+from ..datetime_helpers import parse_datetime
 
 
 class ScheduleItem(object):
@@ -35,11 +36,6 @@ class ScheduleItem(object):
     @property
     def created_at(self):
         return self._created_at
-
-    @created_at.setter
-    @property_is_datetime
-    def created_at(self, value):
-        self._created_at = value
 
     @property
     def end_schedule_at(self):
@@ -102,11 +98,6 @@ class ScheduleItem(object):
     @property
     def updated_at(self):
         return self._updated_at
-
-    @updated_at.setter
-    @property_is_datetime
-    def updated_at(self, value):
-        self._updated_at = value
 
     def _parse_common_tags(self, schedule_xml):
         if not isinstance(schedule_xml, ET.Element):
@@ -218,12 +209,12 @@ class ScheduleItem(object):
         id = schedule_xml.get('id', None)
         name = schedule_xml.get('name', None)
         state = schedule_xml.get('state', None)
-        created_at = schedule_xml.get('createdAt', None)
-        updated_at = schedule_xml.get('updatedAt', None)
+        created_at = parse_datetime(schedule_xml.get('createdAt', None))
+        updated_at = parse_datetime(schedule_xml.get('updatedAt', None))
         schedule_type = schedule_xml.get('type', None)
         frequency = schedule_xml.get('frequency', None)
-        next_run_at = schedule_xml.get('nextRunAt', None)
-        end_schedule_at = schedule_xml.get('endScheduleAt', None)
+        next_run_at = parse_datetime(schedule_xml.get('nextRunAt', None))
+        end_schedule_at = parse_datetime(schedule_xml.get('endScheduleAt', None))
         execution_order = schedule_xml.get('executionOrder', None)
 
         priority = schedule_xml.get('priority', None)

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 
 from .interval_item import IntervalItem, HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval
-from .property_decorators import property_is_enum, property_not_nullable, property_is_int
+from .property_decorators import property_is_enum, property_not_nullable, property_is_int, property_is_datetime
 from .. import NAMESPACE
 
 
@@ -35,6 +35,11 @@ class ScheduleItem(object):
     @property
     def created_at(self):
         return self._created_at
+
+    @created_at.setter
+    @property_is_datetime
+    def created_at(self, value):
+        self._created_at = value
 
     @property
     def end_schedule_at(self):
@@ -97,6 +102,11 @@ class ScheduleItem(object):
     @property
     def updated_at(self):
         return self._updated_at
+
+    @updated_at.setter
+    @property_is_datetime
+    def updated_at(self, value):
+        self._updated_at = value
 
     def _parse_common_tags(self, schedule_xml):
         if not isinstance(schedule_xml, ET.Element):

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_is_enum, property_not_empty, property_not_nullable
 from .. import NAMESPACE
+from ..datetime_helpers import parse_datetime
 
 
 class UserItem(object):
@@ -135,7 +136,7 @@ class UserItem(object):
         id = user_xml.get('id', None)
         name = user_xml.get('name', None)
         site_role = user_xml.get('siteRole', None)
-        last_login = user_xml.get('lastLogin', None)
+        last_login = parse_datetime(user_xml.get('lastLogin', None))
         external_auth_user_id = user_xml.get('externalAuthUserId', None)
         fullname = user_xml.get('fullName', None)
         email = user_xml.get('email', None)

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,9 +1,10 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
-from .property_decorators import property_not_nullable, property_is_boolean, property_is_datetime
+from .property_decorators import property_not_nullable, property_is_boolean
 from .tag_item import TagItem
 from .view_item import ViewItem
 from .. import NAMESPACE
+from ..datetime_helpers import parse_datetime
 import copy
 
 
@@ -39,11 +40,6 @@ class WorkbookItem(object):
     @property
     def created_at(self):
         return self._created_at
-
-    @created_at.setter
-    @property_is_datetime
-    def created_at(self, value):
-        self._created_at = value
 
     @property
     def id(self):
@@ -85,11 +81,6 @@ class WorkbookItem(object):
     @property
     def updated_at(self):
         return self._updated_at
-
-    @updated_at.setter
-    @property_is_datetime
-    def updated_at(self, value):
-        self._updated_at = value
 
     @property
     def views(self):
@@ -173,8 +164,8 @@ class WorkbookItem(object):
         id = workbook_xml.get('id', None)
         name = workbook_xml.get('name', None)
         content_url = workbook_xml.get('contentUrl', None)
-        created_at = workbook_xml.get('createdAt', None)
-        updated_at = workbook_xml.get('updatedAt', None)
+        created_at = parse_datetime(workbook_xml.get('createdAt', None))
+        updated_at = parse_datetime(workbook_xml.get('updatedAt', None))
 
         size = workbook_xml.get('size', None)
         if size:

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
-from .property_decorators import property_not_nullable, property_is_boolean
+from .property_decorators import property_not_nullable, property_is_boolean, property_is_datetime
 from .tag_item import TagItem
 from .view_item import ViewItem
 from .. import NAMESPACE
@@ -39,6 +39,11 @@ class WorkbookItem(object):
     @property
     def created_at(self):
         return self._created_at
+
+    @created_at.setter
+    @property_is_datetime
+    def created_at(self, value):
+        self._created_at = value
 
     @property
     def id(self):
@@ -80,6 +85,11 @@ class WorkbookItem(object):
     @property
     def updated_at(self):
         return self._updated_at
+
+    @updated_at.setter
+    @property_is_datetime
+    def updated_at(self, value):
+        self._updated_at = value
 
     @property
     def views(self):

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1,3 +1,4 @@
+from ..datetime_helpers import format_datetime
 import xml.etree.ElementTree as ET
 
 from requests.packages.urllib3.fields import RequestField

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
@@ -33,8 +34,8 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('e76a1461-3b1d-4588-bf1b-17551a879ad9', all_datasources[0].id)
         self.assertEqual('dataengine', all_datasources[0].datasource_type)
         self.assertEqual('SampleDS', all_datasources[0].content_url)
-        self.assertEqual('2016-08-11T21:22:40Z', all_datasources[0].created_at)
-        self.assertEqual('2016-08-11T21:34:17Z', all_datasources[0].updated_at)
+        self.assertEqual('2016-08-11T21:22:40Z', format_datetime(all_datasources[0].created_at))
+        self.assertEqual('2016-08-11T21:34:17Z', format_datetime(all_datasources[0].updated_at))
         self.assertEqual('default', all_datasources[0].project_name)
         self.assertEqual('SampleDS', all_datasources[0].name)
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_datasources[0].project_id)
@@ -43,8 +44,8 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('9dbd2263-16b5-46e1-9c43-a76bb8ab65fb', all_datasources[1].id)
         self.assertEqual('dataengine', all_datasources[1].datasource_type)
         self.assertEqual('Sampledatasource', all_datasources[1].content_url)
-        self.assertEqual('2016-08-04T21:31:55Z', all_datasources[1].created_at)
-        self.assertEqual('2016-08-04T21:31:55Z', all_datasources[1].updated_at)
+        self.assertEqual('2016-08-04T21:31:55Z', format_datetime(all_datasources[1].created_at))
+        self.assertEqual('2016-08-04T21:31:55Z', format_datetime(all_datasources[1].updated_at))
         self.assertEqual('default', all_datasources[1].project_name)
         self.assertEqual('Sample datasource', all_datasources[1].name)
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_datasources[1].project_id)
@@ -75,8 +76,8 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('9dbd2263-16b5-46e1-9c43-a76bb8ab65fb', single_datasource.id)
         self.assertEqual('dataengine', single_datasource.datasource_type)
         self.assertEqual('Sampledatasource', single_datasource.content_url)
-        self.assertEqual('2016-08-04T21:31:55Z', single_datasource.created_at)
-        self.assertEqual('2016-08-04T21:31:55Z', single_datasource.updated_at)
+        self.assertEqual('2016-08-04T21:31:55Z', format_datetime(single_datasource.created_at))
+        self.assertEqual('2016-08-04T21:31:55Z', format_datetime(single_datasource.updated_at))
         self.assertEqual('default', single_datasource.project_name)
         self.assertEqual('Sample datasource', single_datasource.name)
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', single_datasource.project_id)
@@ -125,8 +126,8 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('SampleDS', new_datasource.name)
         self.assertEqual('SampleDS', new_datasource.content_url)
         self.assertEqual('dataengine', new_datasource.datasource_type)
-        self.assertEqual('2016-08-11T21:22:40Z', new_datasource.created_at)
-        self.assertEqual('2016-08-17T23:37:08Z', new_datasource.updated_at)
+        self.assertEqual('2016-08-11T21:22:40Z', format_datetime(new_datasource.created_at))
+        self.assertEqual('2016-08-17T23:37:08Z', format_datetime(new_datasource.updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', new_datasource.project_id)
         self.assertEqual('default', new_datasource.project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', new_datasource.owner_id)

--- a/test/test_datasource_model.py
+++ b/test/test_datasource_model.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import tableauserverclient as TSC
 
@@ -8,3 +9,34 @@ class DatasourceModelTests(unittest.TestCase):
         datasource = TSC.DatasourceItem("10")
         with self.assertRaises(ValueError):
             datasource.project_id = None
+
+    def test_datetime_conversion(self):
+        datasource = TSC.DatasourceItem("10")
+        datasource.created_at = "2016-08-18T19:25:36Z"
+        actual = datasource.created_at
+        self.assertIsInstance(actual, datetime.datetime)
+        self.assertEquals(actual.year, 2016)
+        self.assertEquals(actual.month, 8)
+        self.assertEquals(actual.day, 18)
+        self.assertEquals(actual.hour, 19)
+        self.assertEquals(actual.minute, 25)
+        self.assertEquals(actual.second, 36)
+
+    def test_datetime_conversion_allows_datetime_passthrough(self):
+        datasource = TSC.DatasourceItem("10")
+        now = datetime.datetime.utcnow()
+        datasource.created_at = now
+        self.assertEquals(datasource.created_at, now)
+
+    def test_datetime_conversion_is_timezone_aware(self):
+        datasource = TSC.DatasourceItem("10")
+        datasource.created_at = "2016-08-18T19:25:36Z"
+        actual = datasource.created_at
+        self.assertEquals(actual.utcoffset().seconds, 0)
+
+    def test_datetime_conversion_rejects_things_that_cannot_be_converted(self):
+        datasource = TSC.DatasourceItem("10")
+        with self.assertRaises(ValueError):
+            datasource.created_at = object()
+        with self.assertRaises(ValueError):
+            datasource.created_at = "This is so not a datetime"

--- a/test/test_datasource_model.py
+++ b/test/test_datasource_model.py
@@ -9,34 +9,3 @@ class DatasourceModelTests(unittest.TestCase):
         datasource = TSC.DatasourceItem("10")
         with self.assertRaises(ValueError):
             datasource.project_id = None
-
-    def test_datetime_conversion(self):
-        datasource = TSC.DatasourceItem("10")
-        datasource.created_at = "2016-08-18T19:25:36Z"
-        actual = datasource.created_at
-        self.assertIsInstance(actual, datetime.datetime)
-        self.assertEquals(actual.year, 2016)
-        self.assertEquals(actual.month, 8)
-        self.assertEquals(actual.day, 18)
-        self.assertEquals(actual.hour, 19)
-        self.assertEquals(actual.minute, 25)
-        self.assertEquals(actual.second, 36)
-
-    def test_datetime_conversion_allows_datetime_passthrough(self):
-        datasource = TSC.DatasourceItem("10")
-        now = datetime.datetime.utcnow()
-        datasource.created_at = now
-        self.assertEquals(datasource.created_at, now)
-
-    def test_datetime_conversion_is_timezone_aware(self):
-        datasource = TSC.DatasourceItem("10")
-        datasource.created_at = "2016-08-18T19:25:36Z"
-        actual = datasource.created_at
-        self.assertEquals(actual.utcoffset().seconds, 0)
-
-    def test_datetime_conversion_rejects_things_that_cannot_be_converted(self):
-        datasource = TSC.DatasourceItem("10")
-        with self.assertRaises(ValueError):
-            datasource.created_at = object()
-        with self.assertRaises(ValueError):
-            datasource.created_at = "This is so not a datetime"

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
@@ -61,7 +62,7 @@ class GroupTests(unittest.TestCase):
         self.assertEqual('dd2239f6-ddf1-4107-981a-4cf94e415794', user.id)
         self.assertEqual('alice', user.name)
         self.assertEqual('Publisher', user.site_role)
-        self.assertEqual('2016-08-16T23:17:06Z', user.last_login)
+        self.assertEqual('2016-08-16T23:17:06Z', format_datetime(user.last_login))
 
     def test_delete(self):
         with requests_mock.mock() as m:

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -28,9 +28,9 @@ class RequestTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEquals(resp.request.query, 'pagenumber=13&pagesize=13')
-            self.assertEquals(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')
-            self.assertEquals(resp.request.headers['content-type'], 'text/xml')
+            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13')
+            self.assertEqual(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')
+            self.assertEqual(resp.request.headers['content-type'], 'text/xml')
 
     def test_make_post_request(self):
         with requests_mock.mock() as m:
@@ -42,6 +42,6 @@ class RequestTests(unittest.TestCase):
                                                        request_object=None,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='multipart/mixed')
-            self.assertEquals(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')
-            self.assertEquals(resp.request.headers['content-type'], 'multipart/mixed')
-            self.assertEquals(resp.request.body, b'1337')
+            self.assertEqual(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')
+            self.assertEqual(resp.request.headers['content-type'], 'multipart/mixed')
+            self.assertEqual(resp.request.body, b'1337')

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1,8 +1,9 @@
+from datetime import time
 import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
-from datetime import time
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 
@@ -37,19 +38,19 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("Weekday early mornings", all_schedules[0].name)
         self.assertEqual("Active", all_schedules[0].state)
         self.assertEqual(50, all_schedules[0].priority)
-        self.assertEqual("2016-07-06T20:19:00Z", all_schedules[0].created_at)
-        self.assertEqual("2016-09-13T11:00:32Z", all_schedules[0].updated_at)
+        self.assertEqual("2016-07-06T20:19:00Z", format_datetime(all_schedules[0].created_at))
+        self.assertEqual("2016-09-13T11:00:32Z", format_datetime(all_schedules[0].updated_at))
         self.assertEqual("Extract", all_schedules[0].schedule_type)
-        self.assertEqual("2016-09-14T11:00:00Z", all_schedules[0].next_run_at)
+        self.assertEqual("2016-09-14T11:00:00Z", format_datetime(all_schedules[0].next_run_at))
 
         self.assertEqual("bcb79d07-6e47-472f-8a65-d7f51f40c36c", all_schedules[1].id)
         self.assertEqual("Saturday night", all_schedules[1].name)
         self.assertEqual("Active", all_schedules[1].state)
         self.assertEqual(80, all_schedules[1].priority)
-        self.assertEqual("2016-07-07T20:19:00Z", all_schedules[1].created_at)
-        self.assertEqual("2016-09-12T16:39:38Z", all_schedules[1].updated_at)
+        self.assertEqual("2016-07-07T20:19:00Z", format_datetime(all_schedules[1].created_at))
+        self.assertEqual("2016-09-12T16:39:38Z", format_datetime(all_schedules[1].updated_at))
         self.assertEqual("Subscription", all_schedules[1].schedule_type)
-        self.assertEqual("2016-09-18T06:00:00Z", all_schedules[1].next_run_at)
+        self.assertEqual("2016-09-18T06:00:00Z", format_datetime(all_schedules[1].next_run_at))
 
     def test_get_empty(self):
         with open(GET_EMPTY_XML, "rb") as f:
@@ -82,10 +83,10 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("hourly-schedule-1", new_schedule.name)
         self.assertEqual("Active", new_schedule.state)
         self.assertEqual(50, new_schedule.priority)
-        self.assertEqual("2016-09-15T20:47:33Z", new_schedule.created_at)
-        self.assertEqual("2016-09-15T20:47:33Z", new_schedule.updated_at)
+        self.assertEqual("2016-09-15T20:47:33Z", format_datetime(new_schedule.created_at))
+        self.assertEqual("2016-09-15T20:47:33Z", format_datetime(new_schedule.updated_at))
         self.assertEqual(TSC.ScheduleItem.Type.Extract, new_schedule.schedule_type)
-        self.assertEqual("2016-09-16T01:30:00Z", new_schedule.next_run_at)
+        self.assertEqual("2016-09-16T01:30:00Z", format_datetime(new_schedule.next_run_at))
         self.assertEqual(TSC.ScheduleItem.ExecutionOrder.Parallel, new_schedule.execution_order)
         self.assertEqual(time(2, 30), new_schedule.interval_item.start_time)
         self.assertEqual(time(23), new_schedule.interval_item.end_time)
@@ -105,10 +106,10 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("daily-schedule-1", new_schedule.name)
         self.assertEqual("Active", new_schedule.state)
         self.assertEqual(90, new_schedule.priority)
-        self.assertEqual("2016-09-15T21:01:09Z", new_schedule.created_at)
-        self.assertEqual("2016-09-15T21:01:09Z", new_schedule.updated_at)
+        self.assertEqual("2016-09-15T21:01:09Z", format_datetime(new_schedule.created_at))
+        self.assertEqual("2016-09-15T21:01:09Z", format_datetime(new_schedule.updated_at))
         self.assertEqual(TSC.ScheduleItem.Type.Subscription, new_schedule.schedule_type)
-        self.assertEqual("2016-09-16T11:45:00Z", new_schedule.next_run_at)
+        self.assertEqual("2016-09-16T11:45:00Z", format_datetime(new_schedule.next_run_at))
         self.assertEqual(TSC.ScheduleItem.ExecutionOrder.Serial, new_schedule.execution_order)
         self.assertEqual(time(4, 45), new_schedule.interval_item.start_time)
 
@@ -128,10 +129,10 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("weekly-schedule-1", new_schedule.name)
         self.assertEqual("Active", new_schedule.state)
         self.assertEqual(80, new_schedule.priority)
-        self.assertEqual("2016-09-15T21:12:50Z", new_schedule.created_at)
-        self.assertEqual("2016-09-15T21:12:50Z", new_schedule.updated_at)
+        self.assertEqual("2016-09-15T21:12:50Z", format_datetime(new_schedule.created_at))
+        self.assertEqual("2016-09-15T21:12:50Z", format_datetime(new_schedule.updated_at))
         self.assertEqual(TSC.ScheduleItem.Type.Extract, new_schedule.schedule_type)
-        self.assertEqual("2016-09-16T16:15:00Z", new_schedule.next_run_at)
+        self.assertEqual("2016-09-16T16:15:00Z", format_datetime(new_schedule.next_run_at))
         self.assertEqual(TSC.ScheduleItem.ExecutionOrder.Parallel, new_schedule.execution_order)
         self.assertEqual(time(9, 15), new_schedule.interval_item.start_time)
         self.assertEqual(("Monday", "Wednesday", "Friday"),
@@ -151,10 +152,10 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("monthly-schedule-1", new_schedule.name)
         self.assertEqual("Active", new_schedule.state)
         self.assertEqual(20, new_schedule.priority)
-        self.assertEqual("2016-09-15T21:16:56Z", new_schedule.created_at)
-        self.assertEqual("2016-09-15T21:16:56Z", new_schedule.updated_at)
+        self.assertEqual("2016-09-15T21:16:56Z", format_datetime(new_schedule.created_at))
+        self.assertEqual("2016-09-15T21:16:56Z", format_datetime(new_schedule.updated_at))
         self.assertEqual(TSC.ScheduleItem.Type.Extract, new_schedule.schedule_type)
-        self.assertEqual("2016-10-12T14:00:00Z", new_schedule.next_run_at)
+        self.assertEqual("2016-10-12T14:00:00Z", format_datetime(new_schedule.next_run_at))
         self.assertEqual(TSC.ScheduleItem.ExecutionOrder.Serial, new_schedule.execution_order)
         self.assertEqual(time(7), new_schedule.interval_item.start_time)
         self.assertEqual("12", new_schedule.interval_item.interval)
@@ -174,9 +175,9 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual("7bea1766-1543-4052-9753-9d224bc069b5", single_schedule.id)
         self.assertEqual("weekly-schedule-1", single_schedule.name)
         self.assertEqual(90, single_schedule.priority)
-        self.assertEqual("2016-09-15T23:50:02Z", single_schedule.updated_at)
+        self.assertEqual("2016-09-15T23:50:02Z", format_datetime(single_schedule.updated_at))
         self.assertEqual(TSC.ScheduleItem.Type.Extract, single_schedule.schedule_type)
-        self.assertEqual("2016-09-16T14:00:00Z", single_schedule.next_run_at)
+        self.assertEqual("2016-09-16T14:00:00Z", format_datetime(single_schedule.next_run_at))
         self.assertEqual(TSC.ScheduleItem.ExecutionOrder.Parallel, single_schedule.execution_order)
         self.assertEqual(time(7), single_schedule.interval_item.start_time)
         self.assertEqual(("Monday", "Friday"),

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
@@ -38,7 +39,7 @@ class UserTests(unittest.TestCase):
         single_user = next(user for user in all_users if user.id == 'dd2239f6-ddf1-4107-981a-4cf94e415794')
         self.assertEqual('alice', single_user.name)
         self.assertEqual('Publisher', single_user.site_role)
-        self.assertEqual('2016-08-16T23:17:06Z', single_user.last_login)
+        self.assertEqual('2016-08-16T23:17:06Z', format_datetime(single_user.last_login))
 
         self.assertTrue(any(user.id == '2a47bbf8-8900-4ebb-b0a4-2723bd7c46c3' for user in all_users))
         single_user = next(user for user in all_users if user.id == '2a47bbf8-8900-4ebb-b0a4-2723bd7c46c3')
@@ -71,7 +72,7 @@ class UserTests(unittest.TestCase):
         self.assertEqual('Alice', single_user.fullname)
         self.assertEqual('Publisher', single_user.site_role)
         self.assertEqual('ServerDefault', single_user.auth_setting)
-        self.assertEqual('2016-08-16T23:17:06Z', single_user.last_login)
+        self.assertEqual('2016-08-16T23:17:06Z', format_datetime(single_user.last_login))
         self.assertEqual('local', single_user.domain_name)
 
     def test_get_by_id_missing_id(self):
@@ -136,8 +137,8 @@ class UserTests(unittest.TestCase):
         self.assertEqual('SafariSample', workbook_list[0].content_url)
         self.assertEqual(False, workbook_list[0].show_tabs)
         self.assertEqual(26, workbook_list[0].size)
-        self.assertEqual('2016-07-26T20:34:56Z', workbook_list[0].created_at)
-        self.assertEqual('2016-07-26T20:35:05Z', workbook_list[0].updated_at)
+        self.assertEqual('2016-07-26T20:34:56Z', format_datetime(workbook_list[0].created_at))
+        self.assertEqual('2016-07-26T20:35:05Z', format_datetime(workbook_list[0].updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', workbook_list[0].project_id)
         self.assertEqual('default', workbook_list[0].project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', workbook_list[0].owner_id)

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
@@ -39,8 +40,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual('Superstore', all_workbooks[0].content_url)
         self.assertEqual(False, all_workbooks[0].show_tabs)
         self.assertEqual(1, all_workbooks[0].size)
-        self.assertEqual('2016-08-03T20:34:04Z', all_workbooks[0].created_at)
-        self.assertEqual('2016-08-04T17:56:41Z', all_workbooks[0].updated_at)
+        self.assertEqual('2016-08-03T20:34:04Z', format_datetime(all_workbooks[0].created_at))
+        self.assertEqual('2016-08-04T17:56:41Z', format_datetime(all_workbooks[0].updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_workbooks[0].project_id)
         self.assertEqual('default', all_workbooks[0].project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_workbooks[0].owner_id)
@@ -50,8 +51,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual('SafariSample', all_workbooks[1].content_url)
         self.assertEqual(False, all_workbooks[1].show_tabs)
         self.assertEqual(26, all_workbooks[1].size)
-        self.assertEqual('2016-07-26T20:34:56Z', all_workbooks[1].created_at)
-        self.assertEqual('2016-07-26T20:35:05Z', all_workbooks[1].updated_at)
+        self.assertEqual('2016-07-26T20:34:56Z', format_datetime(all_workbooks[1].created_at))
+        self.assertEqual('2016-07-26T20:35:05Z', format_datetime(all_workbooks[1].updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_workbooks[1].project_id)
         self.assertEqual('default', all_workbooks[1].project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_workbooks[1].owner_id)
@@ -83,8 +84,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual('SafariSample', single_workbook.content_url)
         self.assertEqual(False, single_workbook.show_tabs)
         self.assertEqual(26, single_workbook.size)
-        self.assertEqual('2016-07-26T20:34:56Z', single_workbook.created_at)
-        self.assertEqual('2016-07-26T20:35:05Z', single_workbook.updated_at)
+        self.assertEqual('2016-07-26T20:34:56Z', format_datetime(single_workbook.created_at))
+        self.assertEqual('2016-07-26T20:35:05Z', format_datetime(single_workbook.updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', single_workbook.project_id)
         self.assertEqual('default', single_workbook.project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', single_workbook.owner_id)
@@ -250,8 +251,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual('RESTAPISample_0', new_workbook.content_url)
         self.assertEqual(False, new_workbook.show_tabs)
         self.assertEqual(1, new_workbook.size)
-        self.assertEqual('2016-08-18T18:33:24Z', new_workbook.created_at)
-        self.assertEqual('2016-08-18T20:31:34Z', new_workbook.updated_at)
+        self.assertEqual('2016-08-18T18:33:24Z', format_datetime(new_workbook.created_at))
+        self.assertEqual('2016-08-18T20:31:34Z', format_datetime(new_workbook.updated_at))
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', new_workbook.project_id)
         self.assertEqual('default', new_workbook.project_name)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', new_workbook.owner_id)


### PR DESCRIPTION
I'm a little conflicted on this implementation.  created_at and updated_at are not user settable, but I went down the "use it as a property" route for coercing to the datetime object, so I wanted to get other opinions on it.  The other option would be to change the _set_values functions to call the parse_datetime function instead of using the property.

Thoughts?