### PR TITLE
Fix large downloads (#105)

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -6,6 +6,7 @@ import os
 import logging
 import copy
 import cgi
+from contextlib import closing
 
 # The maximum size of a file that can be published in a single request is 64MB
 FILESIZE_LIMIT = 1024 * 1024 * 64   # 64MB
@@ -64,16 +65,18 @@ class Datasources(Endpoint):
             error = "Datasource ID undefined."
             raise ValueError(error)
         url = "{0}/{1}/content".format(self.baseurl, datasource_id)
-        server_response = self.get_request(url)
-        _, params = cgi.parse_header(server_response.headers['Content-Disposition'])
-        filename = os.path.basename(params['filename'])
-        if filepath is None:
-            filepath = filename
-        elif os.path.isdir(filepath):
-            filepath = os.path.join(filepath, filename)
+        with closing(self.get_request(url, parameters={'stream': True})) as server_response:
+            _, params = cgi.parse_header(server_response.headers['Content-Disposition'])
+            filename = os.path.basename(params['filename'])
+            if filepath is None:
+                filepath = filename
+            elif os.path.isdir(filepath):
+                filepath = os.path.join(filepath, filename)
 
-        with open(filepath, 'wb') as f:
-            f.write(server_response.content)
+            with open(filepath, 'wb') as f:
+                for chunk in server_response.iter_content(1024):  # 1KB
+                    f.write(chunk)
+
         logger.info('Downloaded datasource to {0} (ID: {1})'.format(filepath, datasource_id))
         return os.path.abspath(filepath)
 

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -21,10 +21,11 @@ class Endpoint(object):
 
         return headers
 
-    def _make_request(self, method, url, content=None, request_object=None, auth_token=None, content_type=None):
+    def _make_request(self, method, url, content=None, request_object=None,
+                      auth_token=None, content_type=None, parameters=None):
         if request_object is not None:
             url = request_object.apply_query_params(url)
-        parameters = {}
+        parameters = parameters or {}
         parameters.update(self.parent_srv.http_options)
         parameters['headers'] = Endpoint._make_common_headers(auth_token, content_type)
 
@@ -49,9 +50,9 @@ class Endpoint(object):
     def get_unauthenticated_request(self, url, request_object=None):
         return self._make_request(self.parent_srv.session.get, url, request_object=request_object)
 
-    def get_request(self, url, request_object=None):
+    def get_request(self, url, request_object=None, parameters=None):
         return self._make_request(self.parent_srv.session.get, url, auth_token=self.parent_srv.auth_token,
-                                  request_object=request_object)
+                                  request_object=request_object, parameters=parameters)
 
     def delete_request(self, url):
         # We don't return anything for a delete


### PR DESCRIPTION
I've got a working solution for #105 

Requests provides a way to just get the response headers back and then iterating over the content in chunks. This lets us stream to disk instead of trying to hold large workbooks in memory.

(See http://docs.python-requests.org/en/master/api/#requests.Response.iter_content and http://docs.python-requests.org/en/master/user/advanced/#body-content-workflow)

As a proof of concept I extended our wrapper methods to allow per-call http options (because we don't need to stream every request) and then tested it on workbook download with the script below.

If this approach works, I can clean it up and add it to data source download as well.

But a few questions:
1. Are we ok with the way I extended our request-get-wrapper function? An alternative is to have a special `get_download_request` instead
2. I need to make sure the response always gets closed once we use `stream=True` I think I'm right but may want to just wrap it all in a context manager or try/except
3. Preferences on a chunk size? (I did 4MB because it's usually safe)

```python
import tableauserverclient as TSC

authz = TSC.TableauAuth('user', 'pass')
server = TSC.Server("http://server")

server.auth.sign_in(authz)
print("Signed in: " + server.auth_token)

#workbooks = TSC.Pager(server.workbooks)

big_wb = "FIND ONE OR USE CODE TO FIND ONE"

print("Downloading workbook: " + big_wb)

server.workbooks.download(big_wb)

print("DONE")
```