### PR TITLE
Add Py3.6 to TravisCI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 # command to install dependencies
 install:


### PR DESCRIPTION
Released December 23rd, appears to work on TravisCI per issues/PRs that I read.

It's not documented yet, but as proof, this PR will pass in my fork :)