### PR TITLE
Add annotation for endpoints to indicate minimum supported API version

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -91,7 +91,7 @@ def api(version):
         None
 
     Example:
-    >>> @api(version=2.3)
+    >>> @api(version="2.3")
     >>> def get(self, req_options=None):
     >>>     ...
     '''

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,6 +1,12 @@
-from .exceptions import ServerResponseError
+from .exceptions import ServerResponseError, EndpointUnavailableError
+from functools import wraps
+
 import logging
 
+try:
+    from distutils2.version import NormalizedVersion as Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 logger = logging.getLogger('tableau.endpoint')
 
@@ -69,3 +75,35 @@ class Endpoint(object):
                                   content=xml_request,
                                   auth_token=self.parent_srv.auth_token,
                                   content_type=content_type)
+
+
+def api(version):
+    '''Annotate the minimum supported version for an endpoint.
+
+    Checks the version on the server object and compares normalized versions.
+    It will raise an exception if the server version is > the version specified.
+
+    Args:
+        `version` minimum version that supports the endpoint. String.
+    Raises:
+        EndpointUnavailableError
+    Returns:
+        None
+
+    Example:
+    >>> @api(version=2.3)
+    >>> def get(self, req_options=None):
+    >>>     ...
+    '''
+    def _decorator(func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            server_version = Version(self.parent_srv.version)
+            minimum_supported = Version(version)
+            if server_version < minimum_supported:
+                error = "This endpoint is not available in API version {}. Requires {}".format(
+                    server_version, minimum_supported)
+                raise EndpointUnavailableError(error)
+            return func(self, *args, **kwargs)
+        return wrapper
+    return _decorator

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -28,3 +28,7 @@ class MissingRequiredFieldError(Exception):
 
 class ServerInfoEndpointNotFoundError(Exception):
     pass
+
+
+class EndpointUnavailableError(Exception):
+    pass


### PR DESCRIPTION
Addresses #55 

This is just the decorator, I manually tested with the `users.get` endpoint and a script.

Once we add the annotation to the actual endpoints this will get automagically covered by all existing tests. I can make a unittest that mocks everything to test this method, but that doesn't feel super useful (It'd literally be testing does `<` work).

I think I'd like to break it into two PRs, add this method first, and in the second PR add the annotations and and ensure existing tests still pass

Open to feedback on the exception name and where I put this method -- but endpoint felt like the most natural place for it

/cc @RussTheAerialist @LGraber 