### PR TITLE
Add api annotation to all current endpoints

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .. import RequestFactory, NAMESPACE
 import xml.etree.ElementTree as ET
 import logging
@@ -21,6 +21,7 @@ class Auth(Endpoint):
     def baseurl(self):
         return "{0}/auth".format(self.parent_srv.baseurl)
 
+    @api(version="2.0")
     def sign_in(self, auth_req):
         url = "{0}/{1}".format(self.baseurl, 'signin')
         signin_req = RequestFactory.Auth.signin_req(auth_req)
@@ -35,6 +36,7 @@ class Auth(Endpoint):
         logger.info('Signed into {0} as {1}'.format(self.parent_srv.server_address, auth_req.username))
         return Auth.contextmgr(self.sign_out)
 
+    @api(version="2.0")
     def sign_out(self):
         url = "{0}/{1}".format(self.baseurl, 'signout')
         # If there are no auth tokens you're already signed out. No-op

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .. import RequestFactory, DatasourceItem, PaginationItem, ConnectionItem
@@ -22,6 +22,7 @@ class Datasources(Endpoint):
         return "{0}/sites/{1}/datasources".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Get all datasources
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all datasources on site')
         url = self.baseurl
@@ -31,6 +32,7 @@ class Datasources(Endpoint):
         return all_datasource_items, pagination_item
 
     # Get 1 datasource by id
+    @api(version="2.0")
     def get_by_id(self, datasource_id):
         if not datasource_id:
             error = "Datasource ID undefined."
@@ -41,6 +43,7 @@ class Datasources(Endpoint):
         return DatasourceItem.from_response(server_response.content)[0]
 
     # Populate datasource item's connections
+    @api(version="2.0")
     def populate_connections(self, datasource_item):
         if not datasource_item.id:
             error = 'Datasource item missing ID. Datasource must be retrieved from server first.'
@@ -51,6 +54,7 @@ class Datasources(Endpoint):
         logger.info('Populated connections for datasource (ID: {0})'.format(datasource_item.id))
 
     # Delete 1 datasource by id
+    @api(version="2.0")
     def delete(self, datasource_id):
         if not datasource_id:
             error = "Datasource ID undefined."
@@ -60,6 +64,7 @@ class Datasources(Endpoint):
         logger.info('Deleted single datasource (ID: {0})'.format(datasource_id))
 
     # Download 1 datasource by id
+    @api(version="2.0")
     def download(self, datasource_id, filepath=None):
         if not datasource_id:
             error = "Datasource ID undefined."
@@ -81,6 +86,7 @@ class Datasources(Endpoint):
         return os.path.abspath(filepath)
 
     # Update datasource
+    @api(version="2.0")
     def update(self, datasource_item):
         if not datasource_item.id:
             error = 'Datasource item missing ID. Datasource must be retrieved from server first.'
@@ -93,6 +99,7 @@ class Datasources(Endpoint):
         return updated_datasource._parse_common_tags(server_response.content)
 
     # Publish datasource
+    @api(version="2.0")
     def publish(self, datasource_item, file_path, mode, connection_credentials=None):
         if not os.path.isfile(file_path):
             error = "File path does not lead to an existing file."

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -98,7 +98,7 @@ def api(version):
     def _decorator(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            server_version = Version(self.parent_srv.version)
+            server_version = Version(self.parent_srv.version or "0.0")
             minimum_supported = Version(version)
             if server_version < minimum_supported:
                 error = "This endpoint is not available in API version {}. Requires {}".format(

--- a/tableauserverclient/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverclient/server/endpoint/fileuploads_endpoint.py
@@ -1,5 +1,5 @@
 from .exceptions import MissingRequiredFieldError
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .. import RequestFactory
 from ...models.fileupload_item import FileuploadItem
 import os.path
@@ -20,6 +20,7 @@ class Fileuploads(Endpoint):
     def baseurl(self):
         return "{0}/sites/{1}/fileUploads".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
+    @api(version="2.0")
     def initiate(self):
         url = self.baseurl
         server_response = self.post_request(url, '')
@@ -28,6 +29,7 @@ class Fileuploads(Endpoint):
         logger.info('Initiated file upload session (ID: {0})'.format(self.upload_id))
         return self.upload_id
 
+    @api(version="2.0")
     def append(self, xml_request, content_type):
         if not self.upload_id:
             error = "File upload session must be initiated first."

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from ...models.exceptions import UnpopulatedPropertyError
 from .. import RequestFactory, GroupItem, UserItem, PaginationItem
@@ -13,6 +13,7 @@ class Groups(Endpoint):
         return "{0}/sites/{1}/groups".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Gets all groups
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all groups on site')
         url = self.baseurl
@@ -22,6 +23,7 @@ class Groups(Endpoint):
         return all_group_items, pagination_item
 
     # Gets all users in a given group
+    @api(version="2.0")
     def populate_users(self, group_item, req_options=None):
         if not group_item.id:
             error = "Group item missing ID. Group must be retrieved from server first."
@@ -34,6 +36,7 @@ class Groups(Endpoint):
         return pagination_item
 
     # Deletes 1 group by id
+    @api(version="2.0")
     def delete(self, group_id):
         if not group_id:
             error = "Group ID undefined."
@@ -42,6 +45,8 @@ class Groups(Endpoint):
         self.delete_request(url)
         logger.info('Deleted single group (ID: {0})'.format(group_id))
 
+    # Create a 'local' Tableau group
+    @api(version="2.0")
     def create(self, group_item):
         url = self.baseurl
         create_req = RequestFactory.Group.create_req(group_item)
@@ -49,6 +54,7 @@ class Groups(Endpoint):
         return GroupItem.from_response(server_response.content)[0]
 
     # Removes 1 user from 1 group
+    @api(version="2.0")
     def remove_user(self, group_item, user_id):
         self._remove_user(group_item, user_id)
         try:
@@ -63,6 +69,7 @@ class Groups(Endpoint):
         logger.info('Removed user (id: {0}) from group (ID: {1})'.format(user_id, group_item.id))
 
     # Adds 1 user to 1 group
+    @api(version="2.0")
     def add_user(self, group_item, user_id):
         new_user = self._add_user(group_item, user_id)
         try:

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, ProjectItem, PaginationItem
 import logging
@@ -12,6 +12,7 @@ class Projects(Endpoint):
     def baseurl(self):
         return "{0}/sites/{1}/projects".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all projects on site')
         url = self.baseurl
@@ -20,6 +21,7 @@ class Projects(Endpoint):
         all_project_items = ProjectItem.from_response(server_response.content)
         return all_project_items, pagination_item
 
+    @api(version="2.0")
     def delete(self, project_id):
         if not project_id:
             error = "Project ID undefined."
@@ -28,6 +30,7 @@ class Projects(Endpoint):
         self.delete_request(url)
         logger.info('Deleted single project (ID: {0})'.format(project_id))
 
+    @api(version="2.0")
     def update(self, project_item):
         if not project_item.id:
             error = "Project item missing ID."
@@ -40,6 +43,7 @@ class Projects(Endpoint):
         updated_project = copy.copy(project_item)
         return updated_project._parse_common_tags(server_response.content)
 
+    @api(version="2.0")
     def create(self, project_item):
         url = self.baseurl
         create_req = RequestFactory.Project.create_req(project_item)

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, PaginationItem, ScheduleItem
 import logging
@@ -12,6 +12,7 @@ class Schedules(Endpoint):
     def baseurl(self):
         return "{0}/schedules".format(self.parent_srv.baseurl)
 
+    @api(version="2.3")
     def get(self, req_options=None):
         logger.info("Querying all schedules")
         url = self.baseurl
@@ -20,6 +21,7 @@ class Schedules(Endpoint):
         all_schedule_items = ScheduleItem.from_response(server_response.content)
         return all_schedule_items, pagination_item
 
+    @api(version="2.3")
     def delete(self, schedule_id):
         if not schedule_id:
             error = "Schedule ID undefined"
@@ -28,6 +30,7 @@ class Schedules(Endpoint):
         self.delete_request(url)
         logger.info("Deleted single schedule (ID: {0})".format(schedule_id))
 
+    @api(version="2.3")
     def update(self, schedule_item):
         if not schedule_item.id:
             error = "Schedule item missing ID."
@@ -43,6 +46,7 @@ class Schedules(Endpoint):
         updated_schedule = copy.copy(schedule_item)
         return updated_schedule._parse_common_tags(server_response.content)
 
+    @api(version="2.3")
     def create(self, schedule_item):
         if schedule_item.interval_item is None:
             error = "Interval item must be defined."

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import ServerResponseError, ServerInfoEndpointNotFoundError
 from ...models import ServerInfoItem
 import logging
@@ -11,6 +11,7 @@ class ServerInfo(Endpoint):
     def baseurl(self):
         return "{0}/serverInfo".format(self.parent_srv.baseurl)
 
+    @api(version="2.4")
     def get(self):
         """ Retrieve the server info for the server.  This is an unauthenticated call """
         try:

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, SiteItem, PaginationItem
 import logging
@@ -13,6 +13,7 @@ class Sites(Endpoint):
         return "{0}/sites".format(self.parent_srv.baseurl)
 
     # Gets all sites
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all sites on site')
         url = self.baseurl
@@ -22,6 +23,7 @@ class Sites(Endpoint):
         return all_site_items, pagination_item
 
     # Gets 1 site by id
+    @api(version="2.0")
     def get_by_id(self, site_id):
         if not site_id:
             error = "Site ID undefined."
@@ -32,6 +34,7 @@ class Sites(Endpoint):
         return SiteItem.from_response(server_response.content)[0]
 
     # Update site
+    @api(version="2.0")
     def update(self, site_item):
         if not site_item.id:
             error = "Site item missing ID."
@@ -49,6 +52,7 @@ class Sites(Endpoint):
         return update_site._parse_common_tags(server_response.content)
 
     # Delete 1 site object
+    @api(version="2.0")
     def delete(self, site_id):
         if not site_id:
             error = "Site ID undefined."
@@ -63,6 +67,7 @@ class Sites(Endpoint):
         logger.info('Deleted single site (ID: {0}) and signed out'.format(site_id))
 
     # Create new site
+    @api(version="2.0")
     def create(self, site_item):
         if site_item.admin_mode:
             if site_item.admin_mode == SiteItem.AdminMode.ContentOnly and site_item.user_quota:

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, UserItem, WorkbookItem, PaginationItem
 import logging
@@ -13,6 +13,7 @@ class Users(Endpoint):
         return "{0}/sites/{1}/users".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
     # Gets all users
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all users on site')
         url = self.baseurl
@@ -22,6 +23,7 @@ class Users(Endpoint):
         return all_user_items, pagination_item
 
     # Gets 1 user by id
+    @api(version="2.0")
     def get_by_id(self, user_id):
         if not user_id:
             error = "User ID undefined."
@@ -32,6 +34,7 @@ class Users(Endpoint):
         return UserItem.from_response(server_response.content).pop()
 
     # Update user
+    @api(version="2.0")
     def update(self, user_item, password=None):
         if not user_item.id:
             error = "User item missing ID."
@@ -45,6 +48,7 @@ class Users(Endpoint):
         return updated_item._parse_common_tags(server_response.content)
 
     # Delete 1 user by id
+    @api(version="2.0")
     def remove(self, user_id):
         if not user_id:
             error = "User ID undefined."
@@ -54,6 +58,7 @@ class Users(Endpoint):
         logger.info('Removed single user (ID: {0})'.format(user_id))
 
     # Add new user to site
+    @api(version="2.0")
     def add(self, user_item):
         url = self.baseurl
         add_req = RequestFactory.User.add_req(user_item)
@@ -63,6 +68,7 @@ class Users(Endpoint):
         return new_user
 
     # Get workbooks for user
+    @api(version="2.0")
     def populate_workbooks(self, user_item, req_options=None):
         if not user_item.id:
             error = "User item missing ID."

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import ViewItem, PaginationItem
 import logging
@@ -11,6 +11,7 @@ class Views(Endpoint):
     def baseurl(self):
         return "{0}/sites/{1}".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
+    @api(version="2.2")
     def get(self, req_options=None):
         logger.info('Querying all views on site')
         url = "{0}/views".format(self.baseurl)
@@ -19,6 +20,7 @@ class Views(Endpoint):
         all_view_items = ViewItem.from_response(server_response.content)
         return all_view_items, pagination_item
 
+    @api(version="2.0")
     def populate_preview_image(self, view_item):
         if not view_item.id or not view_item.workbook_id:
             error = "View item missing ID or workbook ID."

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,4 +1,4 @@
-from .endpoint import Endpoint
+from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .. import RequestFactory, WorkbookItem, ConnectionItem, ViewItem, PaginationItem
@@ -35,6 +35,7 @@ class Workbooks(Endpoint):
         self.delete_request(url)
 
     # Get all workbooks on site
+    @api(version="2.0")
     def get(self, req_options=None):
         logger.info('Querying all workbooks on site')
         url = self.baseurl
@@ -44,6 +45,7 @@ class Workbooks(Endpoint):
         return all_workbook_items, pagination_item
 
     # Get 1 workbook
+    @api(version="2.0")
     def get_by_id(self, workbook_id):
         if not workbook_id:
             error = "Workbook ID undefined."
@@ -54,6 +56,7 @@ class Workbooks(Endpoint):
         return WorkbookItem.from_response(server_response.content)[0]
 
     # Delete 1 workbook by id
+    @api(version="2.0")
     def delete(self, workbook_id):
         if not workbook_id:
             error = "Workbook ID undefined."
@@ -63,6 +66,7 @@ class Workbooks(Endpoint):
         logger.info('Deleted single workbook (ID: {0})'.format(workbook_id))
 
     # Update workbook
+    @api(version="2.0")
     def update(self, workbook_item):
         if not workbook_item.id:
             error = "Workbook item missing ID. Workbook must be retrieved from server first."
@@ -88,6 +92,7 @@ class Workbooks(Endpoint):
         return updated_workbook._parse_common_tags(server_response.content)
 
     # Download workbook contents with option of passing in filepath
+    @api(version="2.0")
     def download(self, workbook_id, filepath=None):
         if not workbook_id:
             error = "Workbook ID undefined."
@@ -109,6 +114,7 @@ class Workbooks(Endpoint):
         return os.path.abspath(filepath)
 
     # Get all views of workbook
+    @api(version="2.0")
     def populate_views(self, workbook_item):
         if not workbook_item.id:
             error = "Workbook item missing ID. Workbook must be retrieved from server first."
@@ -119,6 +125,7 @@ class Workbooks(Endpoint):
         logger.info('Populated views for workbook (ID: {0}'.format(workbook_item.id))
 
     # Get all connections of workbook
+    @api(version="2.0")
     def populate_connections(self, workbook_item):
         if not workbook_item.id:
             error = "Workbook item missing ID. Workbook must be retrieved from server first."
@@ -129,6 +136,7 @@ class Workbooks(Endpoint):
         logger.info('Populated connections for workbook (ID: {0})'.format(workbook_item.id))
 
     # Get preview image of workbook
+    @api(version="2.0")
     def populate_preview_image(self, workbook_item):
         if not workbook_item.id:
             error = "Workbook item missing ID. Workbook must be retrieved from server first."
@@ -139,6 +147,7 @@ class Workbooks(Endpoint):
         logger.info('Populated preview image for workbook (ID: {0})'.format(workbook_item.id))
 
     # Publishes workbook. Chunking method if file over 64MB
+    @api(version="2.0")
     def publish(self, workbook_item, file_path, mode, connection_credentials=None):
         if not os.path.isfile(file_path):
             error = "File path does not lead to an existing file."

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -29,7 +29,7 @@ class Server(object):
         self._session = requests.Session()
         self._http_options = dict()
 
-        self.version = 2.3
+        self.version = "2.3"
         self.auth = Auth(self)
         self.views = Views(self)
         self.users = Users(self)

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -14,12 +14,12 @@ class ServerInfoTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
         self.baseurl = self.server.server_info.baseurl
+        self.server.version = "2.4"
 
     def test_server_info_get(self):
         with open(SERVER_INFO_GET_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            self.server.version = '2.4'
             m.get(self.server.server_info.baseurl, text=response_xml)
             actual = self.server.server_info.get()
 


### PR DESCRIPTION
Part two of addressing #55 

Unittests pass and I manually tested against a live server for a simple case.

Supported versions were taken from our public documentation (and my memory) and I only had to make a few tests changes/tweaks -- though it turns out our default version was a float (2.3) and everywhere else we had a string "2.4" ... which made for the most cryptic error I've ever gotten in a unittest, but now that's fixed, and I made some tweaks to try and make error reporting better