### PR TITLE
118 suppress insecurerequestwarning doc

### DIFF
--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-BVCN');</script>
+<!-- End Google Tag Manager -->

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -13,3 +13,5 @@
 
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+
+{% if jekyll.environment == "production" %}{% include analytics.html %}{% endif %}

--- a/docs/docs/sign-in-out.md
+++ b/docs/docs/sign-in-out.md
@@ -53,12 +53,17 @@ C:\Program Files (x86)\Python35-32\lib\site-packages\requests\packages\urllib3\c
 InsecureRequestWarning)
 ```
 
-These warnings can be disabled with the following line:
+These warnings can be disabled by adding the following lines to your script:
 ```py
-requests.packages.urllib3.disable_warnings(InsecureRequestWa‌​rning)
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 ```
 
 ### A better way to avoid certificate warnings
-Instead of disabling warnings or certificate verification when using self-signed certificates, we recommend using a Certificate Authority (CA) signed certificate.
+Instead of disabling warnings or certificate verification to avoid issues with self-signed certificates, the best practice is to use a certificate signed by a Certificate Authority.
 
-In addition to standard Certificate Authorities, [Let's Encrypt](https://letsencrypt.org/) is an automated and open Certificate Authority that can be used for absolutely free. Please note that no official Windows client currently exists, and so certificates must be signed using a Linux machine or using a third-party Windows client.
+If you have the ability to do so, we recommend the following Certificate Authorities:
+* [GlobalSign](https://www.globalsign.com/en/)
+* [Let's Encrypt](https://letsencrypt.org/) - a free, automated, and open Certificate Authority
+* [SSL.com](https://www.ssl.com/)

--- a/docs/docs/sign-in-out.md
+++ b/docs/docs/sign-in-out.md
@@ -2,8 +2,21 @@
 title: Sign In and Out
 layout: docs
 ---
+## Signing in and out
+To sign in and out of Tableau Server, simply call `Auth.sign_in` as follows:
+```py
+import tableauserverclient as TSC
 
-To sign in and out of Tableau Server, call the `Auth.sign_in` and `Auth.sign_out` functions like so:
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+server = TSC.Server('http://SERVER_URL')
+
+with server.auth.sign_in(tableau_auth):
+    # Do awesome things here!   
+
+# The Auth context manager will automatically call 'Auth.sign_out' on exiting the with block
+```
+
+Alternatively, call both `Auth.sign_in` and `Auth.sign_out` functions explicitly like so:
 
 ```py
 import tableauserverclient as TSC
@@ -23,22 +36,8 @@ server.auth.sign_out()
     limited by the maximum session length (of four hours) on Tableau Server.
 </div>
 
-
-Alternatively, for short programs, consider using a `with` block:
-
-```py
-import tableauserverclient as TSC
-
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
-server = TSC.Server('http://SERVER_URL')
-
-with server.auth.sign_in(tableau_auth):
-    # Do awesome things here!
-```
-
-The TSC library signs you out of Tableau Server when you exit out of the `with` block.
-
-If a self-signed certificate is used, certificate verification can be disabled using ```add_http_options```:
+### Disabling certificate verification and warnings
+If a self-signed certificate is used, certificate verification can be disabled with ```add_http_options```:
 
 ```py
 import tableauserverclient as TSC
@@ -59,4 +58,7 @@ These warnings can be disabled with the following line:
 requests.packages.urllib3.disable_warnings(InsecureRequestWa‌​rning)
 ```
 
-Instead of disabling warnings or certificate verification, we recommend using a Certificate Authority (CA) signed certificate. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that can be used, although please note that no official Windows client currently exists.
+### A better way to avoid certificate warnings
+Instead of disabling warnings or certificate verification when using self-signed certificates, we recommend using a Certificate Authority (CA) signed certificate.
+
+In addition to standard Certificate Authorities, [Let's Encrypt](https://letsencrypt.org/) is an automated and open Certificate Authority that can be used for absolutely free. Please note that no official Windows client currently exists, and so certificates must be signed using a Linux machine or using a third-party Windows client.

--- a/docs/docs/sign-in-out.md
+++ b/docs/docs/sign-in-out.md
@@ -37,3 +37,26 @@ with server.auth.sign_in(tableau_auth):
 ```
 
 The TSC library signs you out of Tableau Server when you exit out of the `with` block.
+
+If a self-signed certificate is used, certificate verification can be disabled using ```add_http_options```:
+
+```py
+import tableauserverclient as TSC
+
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+server = TSC.Server('http://SERVER_URL')
+server.add_http_options({'verify': False})
+```
+
+However, each subsequent REST API call will print an ```InsecureRequestWarning```:
+```
+C:\Program Files (x86)\Python35-32\lib\site-packages\requests\packages\urllib3\connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
+InsecureRequestWarning)
+```
+
+These warnings can be disabled with the following line:
+```py
+requests.packages.urllib3.disable_warnings(InsecureRequestWa‌​rning)
+```
+
+Instead of disabling warnings or certificate verification, we recommend using a Certificate Authority (CA) signed certificate. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that can be used, although please note that no official Windows client currently exists.

--- a/docs/docs/sign-in-out.md
+++ b/docs/docs/sign-in-out.md
@@ -3,20 +3,7 @@ title: Sign In and Out
 layout: docs
 ---
 ## Signing in and out
-To sign in and out of Tableau Server, simply call `Auth.sign_in` as follows:
-```py
-import tableauserverclient as TSC
-
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
-server = TSC.Server('http://SERVER_URL')
-
-with server.auth.sign_in(tableau_auth):
-    # Do awesome things here!   
-
-# The Auth context manager will automatically call 'Auth.sign_out' on exiting the with block
-```
-
-Alternatively, call both `Auth.sign_in` and `Auth.sign_out` functions explicitly like so:
+To sign in and out of Tableau Server, call the `Auth.sign_in` and `Auth.sign_out` functions like so:
 
 ```py
 import tableauserverclient as TSC
@@ -31,13 +18,27 @@ server.auth.sign_in(tableau_auth)
 server.auth.sign_out()
 ```
 
+Alternatively, for short programs, consider using a `with` block:
+
+```py
+import tableauserverclient as TSC
+
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+server = TSC.Server('http://SERVER_URL')
+
+with server.auth.sign_in(tableau_auth):
+    # Do awesome things here!
+
+# No need to call auth.sign_out() as the Auth context manager will handle that on exiting the with block
+```
+
 <div class="alert alert-info">
     <b>Note:</b> When you sign in, the TSC library manages the authenticated session for you, however it is still
     limited by the maximum session length (of four hours) on Tableau Server.
 </div>
 
 ### Disabling certificate verification and warnings
-If a self-signed certificate is used, certificate verification can be disabled with ```add_http_options```:
+Certain environments may throw errors related to SSL configuration, such as self-signed certificates or expired certificates. These errors can be avoided by disabling certificate verification with ```add_http_options```:
 
 ```py
 import tableauserverclient as TSC
@@ -49,7 +50,7 @@ server.add_http_options({'verify': False})
 
 However, each subsequent REST API call will print an ```InsecureRequestWarning```:
 ```
-C:\Program Files (x86)\Python35-32\lib\site-packages\requests\packages\urllib3\connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
+InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
 InsecureRequestWarning)
 ```
 
@@ -61,7 +62,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 ```
 
 ### A better way to avoid certificate warnings
-Instead of disabling warnings or certificate verification to avoid issues with self-signed certificates, the best practice is to use a certificate signed by a Certificate Authority.
+Instead of disabling warnings and certificate verification to workaround issues with untrusted certificates, the best practice is to use a certificate signed by a Certificate Authority.
 
 If you have the ability to do so, we recommend the following Certificate Authorities:
 * [GlobalSign](https://www.globalsign.com/en/)


### PR DESCRIPTION
Okay, so I might have changed more than required here, so bear with me and feel free to reject with prejudice.

- Using `with` statements is idiomatic Python, so really it should be the first example that we provide rather than the second
- I added a section header to break up the page when introducing the topic of disabling certificate verification and warnings
- The last section title "A better way to avoid certificate warnings" is not amazing, so alternative suggestions are welcome