### PR TITLE
Updates to Group Documentation and user pagination options

### DIFF
--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -256,44 +256,34 @@ Source files: server/endpoint/datasources_endpoint.py, models/datasource_item.py
 Source files: server/endpoint/users_endpoint.py, models/user_item.py
 
 ## Groups
+Groups class contains following attributes: id, name, domain_name, and users. All but users can be accessed directly from Group class.
 
 Get Groups
 
 ```
-groups = server.groups.get()
-```
-Returns two objects - the groups and the pagination item. To access info about groups
-
-```
-group_list = groups[0]
+groups, _ = server.groups.get()
 ```
 
-The group object contains the same information as the standard XML from REST API. For Sites with more than one group, you can access each individual group like this.
-
-```
-#To see the attributes
-dir(group_list[i])
-
-#use these attributes (domain_name, id, name, users)
-group_list[i].attribute
-
-```
-
-Users is a special case, and cannot be populated without an additional step
+Viewing group attributes 
 
 ```
 
 #Get the group ID
-id = group_list[i].id
+id = groups[i].id
+
+```
+Accessing all users in a group requires an additional step
+
+```
 
 #Then you can populate the user list, with an optional page size
-server.groups.populate_users(publisher_id,200)
+server.groups.populate_users(id,200)
 
 #To see how many uses are in the group, to right-size your request
-server.groups.populate_users(publisher_id,200).total_available
+server.groups.populate_users(id,200).total_available
 
 #Now you can take that same group and see the user objects
-group_list[i].users
+group[i].users
 
 #These can be iterated over just like the groups, and you can query attributes the same way (auth_setting, domain_name, email, external_auth_user_id, from_response, fullname, id, last_login, name, site_role, workbooks)
 group_list[i].users[#].attribute

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -289,6 +289,9 @@ id = group_list[i].id
 #Then you can populate the user list, with an optional page size
 server.groups.populate_users(publisher_id,200)
 
+#To see how many uses are in the group, to right-size your request
+server.groups.populate_users(publisher_id,200).total_available
+
 #Now you can take that same group and see the user objects
 group_list[i].users
 

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -257,5 +257,42 @@ Source files: server/endpoint/users_endpoint.py, models/user_item.py
 
 ## Groups
 
-Source files: server/endpoint/groups_endpoint.py, models/group_item.py,
+Get Groups
 
+```
+groups = server.groups.get()
+```
+Returns two objects - the groups and the pagination item. To access info about groups
+
+```
+group_list = groups[0]
+```
+
+The group object contains the same information as the standard XML from REST API. For Sites with more than one group, you can access each individual group like this.
+
+```
+#To see the attributes
+dir(group_list[i])
+
+#use these attributes (domain_name, id, name, users)
+group_list[i].attribute
+
+```
+
+Users is a special case, and cannot be populated without an additional step
+
+```
+
+#Get the group ID
+id = group_list[i].id
+
+#Then you can populate the user list, with an optional page size
+server.groups.populate_users(publisher_id,200)
+
+#Now you can take that same group and see the user objects
+group_list[i].users
+
+#These can be iterated over just like the groups, and you can query attributes the same way (auth_setting, domain_name, email, external_auth_user_id, from_response, fullname, id, last_login, name, site_role, workbooks)
+group_list[i].users[#].attribute
+ 
+```

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -22,11 +22,11 @@ class Groups(Endpoint):
         return all_group_items, pagination_item
 
     # Gets all users in a given group
-    def populate_users(self, group_item, req_options=None):
+    def populate_users(self, group_item,page_size,req_options=None):
         if not group_item.id:
             error = "Group item missing ID. Group must be retrieved from server first."
             raise MissingRequiredFieldError(error)
-        url = "{0}/{1}/users".format(self.baseurl, group_item.id)
+        url = "{0}/{1}/users?pageSize={2}".format(self.baseurl, group_item.id,page_size)
         server_response = self.get_request(url, req_options)
         group_item._set_users(UserItem.from_response(server_response.content))
         pagination_item = PaginationItem.from_response(server_response.content)


### PR DESCRIPTION
Per #141, adding a pagination object to groups.populate_users solved the problem. There is still no way to know how many users are in a group, without actually running populate_users and pulling total_available.

I also added documentation so others will be able to walk through group interaction.