### PR TITLE
Suggestion for Workbook Update Connection

### DIFF
--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-BVCN');</script>
+<!-- End Google Tag Manager -->

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -13,3 +13,5 @@
 
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+
+{% if jekyll.environment == "production" %}{% include analytics.html %}{% endif %}

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -180,6 +180,14 @@ Modifies a workbook. The workbook item object must include the workbook ID and o
 Workbooks.update(wb_item_object)
 ```
 
+### Update workbook connection
+
+Updates a workbook connection string. The workbook connections must be populated before they strings can be updated. 
+
+```py
+Workbooks.update_conn(workbook, workbook.connections[i]
+```
+
 ### Delete Workbook
 
 Deletes a workbook with the given ID.

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -185,7 +185,7 @@ Workbooks.update(wb_item_object)
 Updates a workbook connection string. The workbook connections must be populated before they strings can be updated. 
 
 ```py
-Workbooks.update_conn(workbook, workbook.connections[i]
+Workbooks.update_conn(workbook, workbook.connections[0])
 ```
 
 ### Delete Workbook

--- a/docs/docs/populate-connections-views.md
+++ b/docs/docs/populate-connections-views.md
@@ -34,6 +34,14 @@ server.workbooks.populate_connections(workbook)
 print([connection.datasource_name for connection in workbook.connections])
 ```
 
+## Update connections for workbooks
+
+```py
+server.workbooks.populate_connections(workbook)
+workbook.connections[i].server_address = 'new_endpoint'
+server.workbooks.update_conn(workbook, workbook.connections[i])
+```
+
 ## Populate connections for data sources
 
 ```py

--- a/docs/docs/populate-connections-views.md
+++ b/docs/docs/populate-connections-views.md
@@ -43,7 +43,7 @@ conn_to_update.server_address = 'new_address'
 conn_to_update.server_port = 1234
 conn_to_update.username = 'username'
 conn_to_update.password = 'password'
-conn_to_update.embed_password = TRUE/FALSE
+conn_to_update.embed_password = True/False
 server.workbooks.update_conn(workbook, conn_to_update)
 ```
 

--- a/docs/docs/populate-connections-views.md
+++ b/docs/docs/populate-connections-views.md
@@ -38,8 +38,13 @@ print([connection.datasource_name for connection in workbook.connections])
 
 ```py
 server.workbooks.populate_connections(workbook)
-workbook.connections[i].server_address = 'new_endpoint'
-server.workbooks.update_conn(workbook, workbook.connections[i])
+conn_to_update = workbook.connections[0]
+conn_to_update.server_address = 'new_address'
+conn_to_update.server_port = 1234
+conn_to_update.username = 'username'
+conn_to_update.password = 'password'
+conn_to_update.embed_password = TRUE/FALSE
+server.workbooks.update_conn(workbook, conn_to_update)
 ```
 
 ## Populate connections for data sources

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -89,9 +89,7 @@ class Workbooks(Endpoint):
 
     # Update workbook_connection
     def update_conn(self, workbook_item, connection_item):
-        
-        # Update the workbook connection
-        url = "{0}/{1}/connections/{2}".format(self.baseurl, workbook_item.id, connection_item.id)     
+        url = "{0}/{1}/connections/{2}".format(self.baseurl, workbook_item.id, connection_item.id)
         update_req = RequestFactory.WorkbookConnection.update_req(connection_item)
         server_response = self.put_request(url, update_req)
         logger.info('Updated workbook item (ID: {0} & connection item {1}'.format(workbook_item.id, connection_item.id))

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -87,6 +87,15 @@ class Workbooks(Endpoint):
         updated_workbook = copy.copy(workbook_item)
         return updated_workbook._parse_common_tags(server_response.content)
 
+    # Update workbook_connection
+    def update_conn(self, workbook_item, connection_item):
+        
+        # Update the workbook connection
+        url = "{0}/{1}/connections/{2}".format(self.baseurl, workbook_item.id, connection_item.id)     
+        update_req = RequestFactory.WorkbookConnection.update_req(connection_item)
+        server_response = self.put_request(url, update_req)
+        logger.info('Updated workbook item (ID: {0} & connection item {1}'.format(workbook_item.id, connection_item.id))
+
     # Download workbook contents with option of passing in filepath
     def download(self, workbook_id, filepath=None):
         if not workbook_id:

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -15,7 +15,6 @@ def _add_multipart(parts):
     content_type = ''.join(('multipart/mixed',) + content_type.partition(';')[1:])
     return xml_request, content_type
 
-
 class AuthRequest(object):
     def signin_req(self, auth_item):
         xml_request = ET.Element('tsRequest')
@@ -313,6 +312,13 @@ class WorkbookRequest(object):
         parts = {'request_payload': ('', xml_request, 'text/xml')}
         return _add_multipart(parts)
 
+class WorkbookConnection(object):
+    def update_req(self, connection_item):
+        xml_request = ET.Element('tsRequest')
+        connection_element = ET.SubElement(xml_request, 'connection')
+        connection_element.attrib['serverAddress'] = connection_item.server_address.lower()        
+        return ET.tostring(xml_request)
+
 
 class RequestFactory(object):
     Auth = AuthRequest()
@@ -326,3 +332,4 @@ class RequestFactory(object):
     Tag = TagRequest()
     User = UserRequest()
     Workbook = WorkbookRequest()
+    WorkbookConnection = WorkbookConnection()

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -316,9 +316,17 @@ class WorkbookConnection(object):
     def update_req(self, connection_item):
         xml_request = ET.Element('tsRequest')
         connection_element = ET.SubElement(xml_request, 'connection')
-        connection_element.attrib['serverAddress'] = connection_item.server_address.lower()        
+        if connection_item.server_address:
+            connection_element.attrib['serverAddress'] = connection_item.server_address.lower()
+        if connection_item.server_port:
+            connection_element.attrib['port'] = connection_item.server_address
+        if connection_item.username:
+            connection_element.attrib['userName'] = connection_item.username
+        if connection_item.password:
+            connection_element.attrib['password'] = connection_item.password
+        if connection_item.embed_password:
+            connection_element.attrib['embedPassword'] = connection_item.embed_password
         return ET.tostring(xml_request)
-
 
 class RequestFactory(object):
     Auth = AuthRequest()

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -15,6 +15,7 @@ def _add_multipart(parts):
     content_type = ''.join(('multipart/mixed',) + content_type.partition(';')[1:])
     return xml_request, content_type
 
+
 class AuthRequest(object):
     def signin_req(self, auth_item):
         xml_request = ET.Element('tsRequest')
@@ -312,7 +313,8 @@ class WorkbookRequest(object):
         parts = {'request_payload': ('', xml_request, 'text/xml')}
         return _add_multipart(parts)
 
-class WorkbookConnection(object):
+
+    class WorkbookConnection(object):
     def update_req(self, connection_item):
         xml_request = ET.Element('tsRequest')
         connection_element = ET.SubElement(xml_request, 'connection')
@@ -327,6 +329,7 @@ class WorkbookConnection(object):
         if connection_item.embed_password:
             connection_element.attrib['embedPassword'] = connection_item.embed_password
         return ET.tostring(xml_request)
+
 
 class RequestFactory(object):
     Auth = AuthRequest()

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -314,7 +314,7 @@ class WorkbookRequest(object):
         return _add_multipart(parts)
 
 
-    class WorkbookConnection(object):
+class WorkbookConnection(object):
     def update_req(self, connection_item):
         xml_request = ET.Element('tsRequest')
         connection_element = ET.SubElement(xml_request, 'connection')

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -321,7 +321,7 @@ class WorkbookRequest(object):
         if connection_item.server_address:
             connection_element.attrib['serverAddress'] = connection_item.server_address.lower()
         if connection_item.server_port:
-            connection_element.attrib['port'] = connection_item.server_address
+            connection_element.attrib['port'] = str(connection_item.server_port)
         if connection_item.username:
             connection_element.attrib['userName'] = connection_item.username
         if connection_item.password:


### PR DESCRIPTION
Per #148, an option for updating workbook connections. Having to iterate over each connection individually is sub-optimal, but core REST API only allows one connection update at a time. 

This only accounts for connection string updates and not ports, username, or password changes. 

Use case is DB migration. 

Also - I'm not sure why the two HTML files were included. No edits were made after the fork.