### PR TITLE
Site can now be queried by name

### DIFF
--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -33,6 +33,17 @@ class Sites(Endpoint):
         server_response = self.get_request(url)
         return SiteItem.from_response(server_response.content)[0]
 
+    # Gets 1 site by name
+    @api(version="2.0")
+    def get_by_name(self, site_name):
+        if not site_name:
+            error = "Site Name undefined."
+            raise ValueError(error)
+        logger.info('Querying single site (Name: {0})'.format(site_name))
+        url = "{0}/{1}?key=name".format(self.baseurl, site_name)
+        server_response = self.get_request(url)
+        return SiteItem.from_response(server_response.content)[0]
+
     # Update site
     @api(version="2.0")
     def update(self, site_item):

--- a/test/assets/site_get_by_name.xml
+++ b/test/assets/site_get_by_name.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <site id="dad65087-b08b-4603-af4e-2887b8aafc67" name="testsite" contentUrl="testsite"
+          adminMode="ContentOnly" disableSubscriptions="false" state="Active" revisionHistoryEnabled="false" subscribeOthersEnabled="true" />
+</tsResponse>

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -7,6 +7,7 @@ TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
 GET_XML = os.path.join(TEST_ASSET_DIR, 'site_get.xml')
 GET_BY_ID_XML = os.path.join(TEST_ASSET_DIR, 'site_get_by_id.xml')
+GET_BY_NAME_XML = os.path.join(TEST_ASSET_DIR, 'site_get_by_name.xml')
 UPDATE_XML = os.path.join(TEST_ASSET_DIR, 'site_update.xml')
 CREATE_XML = os.path.join(TEST_ASSET_DIR, 'site_create.xml')
 
@@ -63,6 +64,24 @@ class SiteTests(unittest.TestCase):
 
     def test_get_by_id_missing_id(self):
         self.assertRaises(ValueError, self.server.sites.get_by_id, '')
+
+    def test_get_by_name(self):
+        with open(GET_BY_NAME_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/testsite?key=name', text=response_xml)
+            single_site = self.server.sites.get_by_name('testsite')
+
+        self.assertEqual('dad65087-b08b-4603-af4e-2887b8aafc67', single_site.id)
+        self.assertEqual('Active', single_site.state)
+        self.assertEqual('testsite', single_site.name)
+        self.assertEqual('ContentOnly', single_site.admin_mode)
+        self.assertEqual(False, single_site.revision_history_enabled)
+        self.assertEqual(True, single_site.subscribe_others_enabled)
+        self.assertEqual(False, single_site.disable_subscriptions)
+
+    def test_get_by_name_missing_name(self):
+        self.assertRaises(ValueError, self.server.sites.get_by_name, '')
 
     def test_update(self):
         with open(UPDATE_XML, 'rb') as f:


### PR DESCRIPTION
Related to #151 

This is a method to add site by name as the Filter/Sort approach mentioned in #49 is not available to use yet (or is it?).