### PR TITLE
Fix for 162

### DIFF
--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -58,10 +58,10 @@ class Groups(Endpoint):
     def remove_user(self, group_item, user_id):
         self._remove_user(group_item, user_id)
         try:
-            user_set = group_item.users
-            for user in user_set:
+            users = group_item.users
+            for user in users:
                 if user.id == user_id:
-                    user_set.remove(user)
+                    users.remove(user)
                     break
         except UnpopulatedPropertyError:
             # If we aren't populated, do nothing to the user list
@@ -73,9 +73,9 @@ class Groups(Endpoint):
     def add_user(self, group_item, user_id):
         new_user = self._add_user(group_item, user_id)
         try:
-            user_set = group_item.users
-            user_set.add(new_user)
-            group_item._set_users(user_set)
+            users = group_item.users
+            users.append(new_user)
+            group_item._set_users(users)
         except UnpopulatedPropertyError:
             # If we aren't populated, do nothing to the user list
             pass

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -92,7 +92,7 @@ class GroupTests(unittest.TestCase):
             m.post(self.baseurl + '/e7833b48-c6f7-47b5-a2a7-36e7dd232758/users', text=response_xml)
             single_group = TSC.GroupItem('test')
             single_group._id = 'e7833b48-c6f7-47b5-a2a7-36e7dd232758'
-            single_group._users = set()
+            single_group._users = []
             self.server.groups.add_user(single_group, '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
 
         self.assertEqual(1, len(single_group.users))


### PR DESCRIPTION
Addresses #162 

I also did a search and the only remaining `set()` calls are tags or filters, places where we actually do use tags.

Note that this could go away once we decide on the final pattern for internal paging (like maybe we stop keeping models in sync with the Server), but this is a minimal fix that doesn't change the world in the mean time.

/cc @tagyoureit (can you try with this patch and see if it resolves your issue)