### PR TITLE
initial infrastructure for smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+test.junit.xml
 
 # C extensions
 *.so

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,9 @@ versionfile_build = tableauserverclient/_version.py
 tag_prefix = v
 #parentdir_prefix =
 
+[aliases]
+smoke=pytest
+
+[tool:pytest]
+testpaths = test smoke
+addopts = --junitxml=./test.junit.xml

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,14 @@ setup(
     license='MIT',
     description='A Python module for working with the Tableau Server REST API.',
     test_suite='test',
+    setup_requires=[
+        'pytest-runner>=2.11,<3.0'
+    ],
     install_requires=[
         'requests>=2.11,<2.12.0a0'
     ],
     tests_require=[
-        'requests-mock>=1.0,<1.1a0'
+        'requests-mock>=1.0,<1.1a0',
+        'pytest>=3.0,<4'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ setup(
     description='A Python module for working with the Tableau Server REST API.',
     test_suite='test',
     setup_requires=[
-        'pytest-runner>=2.11,<3.0'
+        'pytest-runner'
     ],
     install_requires=[
         'requests>=2.11,<2.12.0a0'
     ],
     tests_require=[
         'requests-mock>=1.0,<1.1a0',
-        'pytest>=3.0,<4'
+        'pytest'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'requests>=2.11,<2.12.0a0'
+        'requests>=2.11,<3.0'
     ],
     tests_require=[
-        'requests-mock>=1.0,<1.1a0',
+        'requests-mock>=1.0,<2.0',
         'pytest'
     ]
 )


### PR DESCRIPTION
This isn't complete, but an idea I'm playing with.  @t8y8 thoughts?

```
$ python setup.py test       # Used to run unit tests for the library
$ python setup.py smoke  # Used to run all the live tests against a server (with environment variables to configure)
```