### PR TITLE
Enable always sorting when using pager 

### DIFF
--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -23,7 +23,6 @@ class Pager(object):
         if len(self._options.sort) == 0:
             self._options.sort.add(Sort(RequestOptions.Field.Name, RequestOptions.Direction.Asc))
 
-
     def __iter__(self):
         # Fetch the first page
         current_item_list, last_pagination_item = self._endpoint(self._options)

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -1,4 +1,5 @@
 from . import RequestOptions
+from . import Sort
 
 
 class Pager(object):
@@ -16,6 +17,12 @@ class Pager(object):
             self._count = ((self._options.pagenumber - 1) * self._options.pagesize)
         else:
             self._count = 0
+            self._options = RequestOptions()
+
+        # Pager assumes deterministic order but solr doesn't guarantee sort order unless specified
+        if len(self._options.sort) == 0:
+            self._options.sort.add(Sort(RequestOptions.Field.Name, RequestOptions.Direction.Asc))
+
 
     def __iter__(self):
         # Fetch the first page

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -20,7 +20,7 @@ class Pager(object):
             self._options = RequestOptions()
 
         # Pager assumes deterministic order but solr doesn't guarantee sort order unless specified
-        if len(self._options.sort) == 0:
+        if not self._options.sort:
             self._options.sort.add(Sort(RequestOptions.Field.Name, RequestOptions.Direction.Asc))
 
     def __iter__(self):

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -55,10 +55,10 @@ class PagerTests(unittest.TestCase):
             page_3 = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             # Register Pager with some pages
-            m.get(self.baseurl + "?pageNumber=1&pageSize=1", text=page_1)
-            m.get(self.baseurl + "?pageNumber=2&pageSize=1", text=page_2)
-            m.get(self.baseurl + "?pageNumber=3&pageSize=1", text=page_3)
-            m.get(self.baseurl + "?pageNumber=1&pageSize=3", text=page_1)
+            m.get(self.baseurl + "?pageNumber=1&pageSize=1&sort=name:asc", complete_qs=True, text=page_1)
+            m.get(self.baseurl + "?pageNumber=2&pageSize=1&sort=name:asc", complete_qs=True, text=page_2)
+            m.get(self.baseurl + "?pageNumber=3&pageSize=1&sort=name:asc", complete_qs=True, text=page_3)
+            m.get(self.baseurl + "?pageNumber=1&pageSize=3&sort=name:asc", complete_qs=True, text=page_1)
 
             # Starting on page 2 should get 2 out of 3
             opts = TSC.RequestOptions(2, 1)


### PR DESCRIPTION
because queries are not currently deterministic