### PR TITLE
First pass at options builder

### DIFF
--- a/samples/options_builder.py
+++ b/samples/options_builder.py
@@ -1,0 +1,7 @@
+import sys
+
+import tableauserverclient as TSC
+
+rob = TSC.RequestOptions.Builder()
+ro = rob.file("==", "MyFile").project("==", "Default")._sort("foo", "desc")._pagesize(50)._build()
+print ro.filters

--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -1,7 +1,20 @@
-from .request_options import RequestOptions
-
-
 class Filter(object):
+    class Operator:
+        Equals = 'eq'
+        GreaterThan = 'gt'
+        GreaterThanOrEqual = 'gte'
+        LessThan = 'lt'
+        LessThanOrEqual = 'lte'
+        In = 'in'
+
+        _map = {"==": Equals, ">": GreaterThan, ">=": GreaterThanOrEqual,
+                "<": LessThan, "<=": LessThanOrEqual, "in": In}
+
+        @staticmethod
+        def map(val):
+            return Filter.Operator._map[val]
+
+
     def __init__(self, field, operator, value):
         self.field = field
         self.operator = operator
@@ -20,7 +33,7 @@ class Filter(object):
 
     @value.setter
     def value(self, filter_value):
-        if isinstance(filter_value, list) and self.operator != RequestOptions.Operator.In:
+        if isinstance(filter_value, list) and self.operator != Filter.Operator.In:
             error = "Filter values can only be a list if the operator is 'in'."
             raise ValueError(error)
         else:

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -1,3 +1,6 @@
+from .filter import Filter
+from .sort import Sort
+
 class RequestOptionsBase(object):
     def apply_query_params(self, url):
         raise NotImplementedError()
@@ -24,6 +27,35 @@ class RequestOptions(RequestOptionsBase):
     class Direction:
         Desc = 'desc'
         Asc = 'asc'
+
+    class Builder:
+        def __init__(self):
+            self.__pagenumber = 1
+            self.__pagesize = 100
+            self.__filters = set()
+            self.__sorts = set()
+
+        def __getattr__(self, attr):
+            def fn(*args, **kwargs):
+                if (attr == '_sort'):
+                    self.__sorts.add(Sort(args[0], args[1]))
+                    return self
+                elif (attr == '_pagenumber'):
+                    self.__pagenumber = args[0]
+                    return self
+                elif (attr == '_pagesize'):
+                    self.__pagesize = args[0]
+                    return self
+                elif (attr == '_build'):
+                    ro = RequestOptions(self.__pagenumber, self.__pagesize)
+                    ro.filter = self.__filters
+                    ro.sort = self.__sorts
+                    return ro
+                else:
+                    self.__filters.add(Filter(attr, Filter.Operator.map(args[0]), args[1]))
+                    return self
+            return fn
+
 
     def __init__(self, pagenumber=1, pagesize=100):
         self.pagenumber = pagenumber


### PR DESCRIPTION
Not ready to actually submit this but I find our current syntax for building a filter / sort set ... yucky. I implemented a simple builder pattern. "_" prefixed methods have special meaning. For all other methods, the name is the property you are filtering on and the 2 params are an operator and value. I just accept simple strings that actually look like the operator. I imagine later I can add "_include" when we expose fields. You can see in the sample that it makes it much easier to read. All of our samples only have one filter so it isn't so bad but it would get bad quickly if you did any more