### PR TITLE
Adding get_default method to the projects endpoint

### DIFF
--- a/samples/options_builder.py
+++ b/samples/options_builder.py
@@ -1,4 +1,5 @@
 import sys
+sys.path.append("~/git/server-client-python")
 
 import tableauserverclient as TSC
 

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -41,14 +41,13 @@ def main():
     # Step 1: Sign in to server.
     tableau_auth = TSC.TableauAuth(args.username, password)
     server = TSC.Server(args.server)
+    server.use_server_version()
 
     overwrite_true = TSC.Server.PublishMode.Overwrite
 
     with server.auth.sign_in(tableau_auth):
 
-        # Step 2: Get all the projects on server, then look for the default one.
-        all_projects, pagination_item = server.projects.get()
-        default_project = next((project for project in all_projects if project.is_default()), None)
+        default_project = server.projects.get_default()
 
         # Step 3: If default project is found, form a new workbook item and publish.
         if default_project is not None:

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -3,8 +3,8 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, \
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem
-from .server import RequestOptions, ImageRequestOptions, Filter, Sort, Server, ServerResponseError,\
-    MissingRequiredFieldError, NotSignedInError, Pager
+from .server import RequestOptions, ImageRequestOptions, Filter, Sort, Pager, Server,\
+    ServerResponseError, MissingRequiredFieldError, NotSignedInError
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -5,8 +5,8 @@ from .sort import Sort
 from .. import ConnectionItem, DatasourceItem,\
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, SiteItem, TableauAuth,\
     UserItem, ViewItem, WorkbookItem, TaskItem, NAMESPACE
+from .pager import Pager
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, ServerResponseError, MissingRequiredFieldError
 from .server import Server
-from .pager import Pager
 from .exceptions import NotSignedInError


### PR DESCRIPTION
Want a quick view on this. I sent Russell a mail cause our endpoints are broken because of the default sorting that was added. Ignoring that, I added support for get_default and put an implementation for older versions so that our samples could be updated, too. I accidentally parented off of builders so I probably need to reparent. Tests are still to be done