### PR TITLE
call the detect in the auth endpoint in case we aren't detecting

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -28,6 +28,7 @@ class Auth(Endpoint):
         signin_req = RequestFactory.Auth.signin_req(auth_req)
         server_response = self.parent_srv.session.post(url, data=signin_req,
                                                        **self.parent_srv.http_options)
+        self.parent_srv._namespace.detect(server_response.content)
         self._check_status(server_response)
         parsed_response = ET.fromstring(server_response.content)
         site_id = parsed_response.find('.//t:site', namespaces=self.parent_srv.namespace).get('id', None)


### PR DESCRIPTION
The auth flow doesn't use the _make_requests call in the base object.  Accidentally pushed to upstream rather than my own fork.