### PR TITLE
This workaround is no longer needed

### DIFF
--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -32,10 +32,6 @@ class Pager(object):
             self._count = 0
             self._options = RequestOptions()
 
-        # Pager assumes deterministic order but solr doesn't guarantee sort order unless specified
-        if not self._options.sort:
-            self._options.sort.add(Sort(RequestOptions.Field.Name, RequestOptions.Direction.Asc))
-
     def __iter__(self):
         # Fetch the first page
         current_item_list, last_pagination_item = self._endpoint(self._options)

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -54,7 +54,7 @@ class GroupTests(unittest.TestCase):
         with open(POPULATE_USERS, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.get(self.baseurl + '/e7833b48-c6f7-47b5-a2a7-36e7dd232758/users?pageNumber=1&pageSize=100&sort=name:asc',
+            m.get(self.baseurl + '/e7833b48-c6f7-47b5-a2a7-36e7dd232758/users?pageNumber=1&pageSize=100',
                   text=response_xml, complete_qs=True)
             single_group = TSC.GroupItem(name='Test Group')
             single_group._id = 'e7833b48-c6f7-47b5-a2a7-36e7dd232758'

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -55,10 +55,10 @@ class PagerTests(unittest.TestCase):
             page_3 = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             # Register Pager with some pages
-            m.get(self.baseurl + "?pageNumber=1&pageSize=1&sort=name:asc", complete_qs=True, text=page_1)
-            m.get(self.baseurl + "?pageNumber=2&pageSize=1&sort=name:asc", complete_qs=True, text=page_2)
-            m.get(self.baseurl + "?pageNumber=3&pageSize=1&sort=name:asc", complete_qs=True, text=page_3)
-            m.get(self.baseurl + "?pageNumber=1&pageSize=3&sort=name:asc", complete_qs=True, text=page_1)
+            m.get(self.baseurl + "?pageNumber=1&pageSize=1", complete_qs=True, text=page_1)
+            m.get(self.baseurl + "?pageNumber=2&pageSize=1", complete_qs=True, text=page_2)
+            m.get(self.baseurl + "?pageNumber=3&pageSize=1", complete_qs=True, text=page_3)
+            m.get(self.baseurl + "?pageNumber=1&pageSize=3", complete_qs=True, text=page_1)
 
             # Starting on page 2 should get 2 out of 3
             opts = TSC.RequestOptions(2, 1)


### PR DESCRIPTION
The server will sort based on the id by default so that this workaround is no longer needed.  We should add documentation
that recommends people pass in a supported sort clause manually if they are using other servers