### PR TITLE
Move to return to satisfy pep 479

### DIFF
--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -47,7 +47,7 @@ class Pager(object):
 
             except IndexError:
                 # The total count on Server changed while fetching exit gracefully
-                raise StopIteration
+                return
 
     def _load_next_page(self, last_pagination_item):
         next_page = last_pagination_item.page_number + 1


### PR DESCRIPTION
Small fix that works on py2 and py3, and gets rid of the last deprecation warning in our test suite.