### PR TITLE
Update api-ref.md

### DIFF
--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -2575,7 +2575,7 @@ server = TSC.Server('http://servername')
 
 with server.auth.sign_in(tableau_auth):
   all_workbook_items, pagination_item = server.workbooks.get()
-  print([workbook.name for workbook in all_workbooks])
+  print([workbook.name for workbook in all_workbook_items])
 
 
 


### PR DESCRIPTION
In the workbooks.get() example, the variable was declared as `all_workbook_items` and then referenced as `all_workbooks`. A minor typo that prevents the code example from running.