### PR TITLE
Implement view filters on the populate* request options

### DIFF
--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -4,7 +4,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
     SubscriptionItem
-from .server import RequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
+from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -1,5 +1,5 @@
 from .request_factory import RequestFactory
-from .request_options import ImageRequestOptions, PDFRequestOptions, RequestOptions
+from .request_options import CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, RequestOptions
 from .filter import Filter
 from .sort import Sort
 from .. import ConnectionItem, DatasourceItem, JobItem, \

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -105,7 +105,7 @@ class Views(Endpoint):
     def _get_view_csv(self, view_item, req_options):
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
-        with closing(self.get_request(url, req_options)) as server_response:
+        with closing(self.get_request(url, req_options, {"s tream": True})) as server_response:
             csv = server_response.iter_content(1024)
         return csv
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -105,7 +105,7 @@ class Views(Endpoint):
     def _get_view_csv(self, view_item, req_options):
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
-        with closing(self.get_request(url, parameters={"stream": True})) as server_response:
+        with closing(self.get_request(url, req_options)) as server_response:
             csv = server_response.iter_content(1024)
         return csv
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -105,7 +105,8 @@ class Views(Endpoint):
     def _get_view_csv(self, view_item, req_options):
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
-        with closing(self.get_request(url, req_options, {"stream": True})) as server_response:
+        with closing(self.get_request(url,
+              reqquest_object=req_options, parameters={"stream": True})) as server_response:
             csv = server_response.iter_content(1024)
         return csv
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -105,8 +105,7 @@ class Views(Endpoint):
     def _get_view_csv(self, view_item, req_options):
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
-        with closing(self.get_request(url,
-              reqquest_object=req_options, parameters={"stream": True})) as server_response:
+        with closing(self.get_request(url, request_object=req_options, parameters={"stream": True})) as server_response:
             csv = server_response.iter_content(1024)
         return csv
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -105,7 +105,7 @@ class Views(Endpoint):
     def _get_view_csv(self, view_item, req_options):
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
-        with closing(self.get_request(url, req_options, {"s tream": True})) as server_response:
+        with closing(self.get_request(url, req_options, {"stream": True})) as server_response:
             csv = server_response.iter_content(1024)
         return csv
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -80,7 +80,7 @@ class _FilterOptionsBase(RequestOptionsBase):
 
 class CSVRequestOptions(_FilterOptionsBase):
     def apply_query_params(self, url):
-        params = ['Stream=True']
+        params = []
         self._append_view_filters(params)
         return "{0}?{1}".format(url, '&'.join(params))
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -62,12 +62,36 @@ class RequestOptions(RequestOptionsBase):
         return "{0}?{1}".format(url, '&'.join(params))
 
 
-class ImageRequestOptions(RequestOptionsBase):
+class _FilterOptionsBase(RequestOptionsBase):
+    def __init__(self):
+        self.view_filters = []
+
+    def apply_query_params(self, url):
+        raise NotImplementedError()
+
+    def vf(self, name, value):
+        self.view_filters.append((name, value))
+        return self
+
+    def _append_view_filters(self, params):
+        for name, value in self.view_filters:
+            params.append('vf_{}={}'.format(name, value))
+
+
+class CSVRequestOptions(_FilterOptionsBase):
+    def apply_query_params(self, url):
+        params =['Stream=True']
+        self._append_view_filters(params)
+        return "{0}?{1}".format(url, '&'.join(params))
+
+
+class ImageRequestOptions(_FilterOptionsBase):
     # if 'high' isn't specified, the REST API endpoint returns an image with standard resolution
     class Resolution:
         High = 'high'
 
     def __init__(self, imageresolution=None):
+        super(ImageRequestOptions, self).__init__()
         self.image_resolution = imageresolution
 
     def apply_query_params(self, url):
@@ -75,11 +99,12 @@ class ImageRequestOptions(RequestOptionsBase):
         if self.image_resolution:
             params.append('resolution={0}'.format(self.image_resolution))
 
+        self._append_view_filters(params)
+
         return "{0}?{1}".format(url, '&'.join(params))
 
 
-class PDFRequestOptions(RequestOptionsBase):
-    # if 'high' isn't specified, the REST API endpoint returns an image with standard resolution
+class PDFRequestOptions(_FilterOptionsBase):
     class PageType:
         A3 = "a3"
         A4 = "a4"
@@ -100,6 +125,7 @@ class PDFRequestOptions(RequestOptionsBase):
         Landscape = "landscape"
 
     def __init__(self, page_type=None, orientation=None):
+        super(PDFRequestOptions, self).__init__()
         self.page_type = page_type
         self.orientation = orientation
 
@@ -110,5 +136,7 @@ class PDFRequestOptions(RequestOptionsBase):
 
         if self.orientation:
             params.append('orientation={0}'.format(self.orientation))
+
+        self._append_view_filters(params)
 
         return "{0}?{1}".format(url, '&'.join(params))

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -63,6 +63,7 @@ class RequestOptions(RequestOptionsBase):
 
 
 class _FilterOptionsBase(RequestOptionsBase):
+    """ Provide a basic implementation of adding view filters to the url """
     def __init__(self):
         self.view_filters = []
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -80,7 +80,7 @@ class _FilterOptionsBase(RequestOptionsBase):
 
 class CSVRequestOptions(_FilterOptionsBase):
     def apply_query_params(self, url):
-        params =['Stream=True']
+        params = ['Stream=True']
         self._append_view_filters(params)
         return "{0}?{1}".format(url, '&'.join(params))
 


### PR DESCRIPTION
This is fallout from a bug I was fixing elsewhere, but we should have them.