### PR TITLE
Add a simple static method to strip non-XML responses from debug log

### DIFF
--- a/samples/download_view_image.py
+++ b/samples/download_view_image.py
@@ -43,7 +43,7 @@ def main():
     tableau_auth = TSC.TableauAuth(args.username, password, site_id=site_id)
     server = TSC.Server(args.server)
     # The new endpoint was introduced in Version 2.5
-    server.version = 2.5
+    server.version = "2.5"
 
     with server.auth.sign_in(tableau_auth):
         # Step 2: Query for the view that we want an image of

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -27,6 +27,17 @@ class Endpoint(object):
 
         return headers
 
+    @staticmethod
+    def _safe_to_log(server_response):
+        '''Checks if the server_response content is not xml (eg binary image or zip)
+        and and replaces it with a constant
+        '''
+        ALLOWED_CONTENT_TYPES = ('application/xml',)
+        if server_response.headers.get('Content-Type', None) not in ALLOWED_CONTENT_TYPES:
+            return '[Truncated File Contents]'
+        else:
+            return server_response.content
+
     def _make_request(self, method, url, content=None, request_object=None,
                       auth_token=None, content_type=None, parameters=None):
         if request_object is not None:
@@ -50,7 +61,7 @@ class Endpoint(object):
         return server_response
 
     def _check_status(self, server_response):
-        logger.debug(server_response.content)
+        logger.debug(self._safe_to_log(server_response))
         if server_response.status_code not in Success_codes:
             raise ServerResponseError.from_response(server_response.content, self.parent_srv.namespace)
 

--- a/test/test_regression_tests.py
+++ b/test/test_regression_tests.py
@@ -1,8 +1,23 @@
 import unittest
 import tableauserverclient.server.request_factory as factory
+from tableauserverclient.server.endpoint import Endpoint
 
 
 class BugFix257(unittest.TestCase):
     def test_empty_request_works(self):
         result = factory.EmptyRequest().empty_req()
         self.assertEqual(b'<tsRequest />', result)
+
+
+class BugFix273(unittest.TestCase):
+    def test_binary_log_truncated(self):
+
+        class FakeResponse(object):
+
+            headers = {'Content-Type': 'application/octet-stream'}
+            content = b'\x1337' * 1000
+            status_code = 200
+
+        server_response = FakeResponse()
+
+        self.assertEqual(Endpoint._safe_to_log(server_response), '[Truncated File Contents]')


### PR DESCRIPTION
We could add other types (like JSON) in the future, or if I missed any in the CR I can fix them up, it's a simple fix.

The more complicated approaches, that I abandoned, were to try and grab some chunk of the file and find a safe way to encode it to utf8 for either file or stdout streams -- but that didn't seem worth it :)

Fixes #273 