### PR TITLE
Multi-Credential Support in TSC

### DIFF
--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -50,13 +50,16 @@ def main():
         # Step 2: Get all the projects on server, then look for the default one.
         all_projects, pagination_item = server.projects.get()
         default_project = next((project for project in all_projects if project.is_default()), None)
-        connection2 = ConnectionItem()
-        connection2.server_address = "db2.test.tsi.lan"
-        connection2.server_port = "50000"
-        connection2.connection_credentials = ConnectionCredentials("test", "p@ssw0rd", True)
+
         connection1 = ConnectionItem()
-        connection1.server_address = "mssql.test.tsi.lan"
+        connection1.server_address = "mssql.test.com"
         connection1.connection_credentials = ConnectionCredentials("test", "password", True)
+
+        connection2 = ConnectionItem()
+        connection2.server_address = "postgres.test.com"
+        connection2.server_port = "5432"
+        connection2.connection_credentials = ConnectionCredentials("test", "password", True)
+
         all_connections = list()
         all_connections.append(connection1)
         all_connections.append(connection2)

--- a/tableauserverclient/models/connection_credentials.py
+++ b/tableauserverclient/models/connection_credentials.py
@@ -32,3 +32,15 @@ class ConnectionCredentials(object):
     @property_is_boolean
     def oauth(self, value):
         self._oauth = value
+
+    @classmethod
+    def from_xml_element(cls, parsed_response, ns):
+        connection_creds_xml = parsed_response.find('.//t:connectionCredentials', namespaces=ns)
+
+        name = connection_creds_xml.get('name', None)
+        password = connection_creds_xml.get('password', None)
+        embed = connection_creds_xml.get('embed', None)
+        oAuth = connection_creds_xml.get('oAuth', None)
+
+        connection_creds = cls(name, password, embed, oAuth)
+        return connection_creds

--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from .connection_credentials import ConnectionCredentials
 
 
 class ConnectionItem(object):
@@ -51,4 +52,33 @@ class ConnectionItem(object):
                 connection_item._datasource_id = datasource_elem.get('id', None)
                 connection_item._datasource_name = datasource_elem.get('name', None)
             all_connection_items.append(connection_item)
+        return all_connection_items
+
+    @classmethod
+    def from_xml_element(cls, parsed_response, ns):
+        '''
+        <connections>
+            <connection serverAddress="mysql.test.com">
+                <connectionCredentials embed="true" name="test" password="secret" />
+            </connection>
+            <connection serverAddress="pgsql.test.com">
+                <connectionCredentials embed="true" name="test" password="secret" />
+                </connection>
+        </connections>
+        '''
+        all_connection_items = list()
+        all_connection_xml = parsed_response.findall('.//t:connection', namespaces=ns)
+
+        for connection_xml in all_connection_xml:
+            connection_item = cls()
+
+            connection_item.server_address = connection_xml.get('serverAddress', None)
+            connection_item.server_port = connection_xml.get('serverPort', None)
+
+            connection_credentials = connection_xml.find('.//t:connectionCredentials', namespaces=ns)
+
+            if connection_credentials is not None:
+
+                connection_item.connection_credentials = ConnectionCredentials.from_xml_element(connection_credentials)
+
         return all_connection_items

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -151,7 +151,8 @@ class Datasources(Endpoint):
 
     # Publish datasource
     @api(version="2.0")
-    def publish(self, datasource_item, file_path, mode, connections=None):
+    @parameter_added_in(connections="2.8")
+    def publish(self, datasource_item, file_path, mode, connection_credentials=None, connections=None):
         if not os.path.isfile(file_path):
             error = "File path does not lead to an existing file."
             raise IOError(error)
@@ -180,6 +181,7 @@ class Datasources(Endpoint):
             upload_session_id = Fileuploads.upload_chunks(self.parent_srv, file_path)
             url = "{0}&uploadSessionId={1}".format(url, upload_session_id)
             xml_request, content_type = RequestFactory.Datasource.publish_req_chunked(datasource_item,
+                                                                                      connection_credentials,
                                                                                       connections)
         else:
             logger.info('Publishing {0} to server'.format(filename))
@@ -188,6 +190,7 @@ class Datasources(Endpoint):
             xml_request, content_type = RequestFactory.Datasource.publish_req(datasource_item,
                                                                               filename,
                                                                               file_contents,
+                                                                              connection_credentials,
                                                                               connections)
         server_response = self.post_request(url, xml_request, content_type)
         new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -151,7 +151,7 @@ class Datasources(Endpoint):
 
     # Publish datasource
     @api(version="2.0")
-    @parameter_added_in(connections="2.8")
+    @parameter_added_in(connections="99.99")
     def publish(self, datasource_item, file_path, mode, connection_credentials=None, connections=None):
         if not os.path.isfile(file_path):
             error = "File path does not lead to an existing file."

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -32,11 +32,12 @@ class Endpoint(object):
         '''Checks if the server_response content is not xml (eg binary image or zip)
         and and replaces it with a constant
         '''
-        ALLOWED_CONTENT_TYPES = ('application/xml',)
+        ALLOWED_CONTENT_TYPES = ('application/xml', 'application/xml;charset=utf-8')
         if server_response.headers.get('Content-Type', None) not in ALLOWED_CONTENT_TYPES:
+            print(server_response.headers)
             return '[Truncated File Contents]'
         else:
-            return server_response.content
+            return server_response.content[:300]
 
     def _make_request(self, method, url, content=None, request_object=None,
                       auth_token=None, content_type=None, parameters=None):

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -34,7 +34,6 @@ class Endpoint(object):
         '''
         ALLOWED_CONTENT_TYPES = ('application/xml', 'application/xml;charset=utf-8')
         if server_response.headers.get('Content-Type', None) not in ALLOWED_CONTENT_TYPES:
-            print(server_response.headers)
             return '[Truncated File Contents]'
         else:
             return server_response.content[:300]

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -36,7 +36,7 @@ class Endpoint(object):
         if server_response.headers.get('Content-Type', None) not in ALLOWED_CONTENT_TYPES:
             return '[Truncated File Contents]'
         else:
-            return server_response.content[:300]
+            return server_response.content
 
     def _make_request(self, method, url, content=None, request_object=None,
                       auth_token=None, content_type=None, parameters=None):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -204,8 +204,7 @@ class Workbooks(Endpoint):
 
         if connection_credentials is not None:
             import warnings
-            warnings.warn("connection_credentials is being deprecated. Use connections instead, " + \
-            "see https://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Publish_Workbook",
+            warnings.warn("connection_credentials is being deprecated. Use connections instead",
                           DeprecationWarning)
 
         if not os.path.isfile(file_path):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -246,7 +246,9 @@ class Workbooks(Endpoint):
             xml_request, content_type = RequestFactory.Workbook.publish_req(workbook_item,
                                                                             filename,
                                                                             file_contents,
-                                                                            connections=connections)
+                                                                            connections=connections,
+                                                                            connection_credentials=connection_credentials)
+        logger.debug('Request xml: {0} '.format(xml_request[:1000]))
         server_response = self.post_request(url, xml_request, content_type)
         new_workbook = WorkbookItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Published {0} (ID: {1})'.format(filename, new_workbook.id))

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -204,7 +204,8 @@ class Workbooks(Endpoint):
 
         if connection_credentials is not None:
             import warnings
-            warnings.warn("connection_credendials is being deprecated. Use connections instead, see http://...",
+            warnings.warn("connection_credentials is being deprecated. Use connections instead, " + \
+            "see https://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Publish_Workbook",
                           DeprecationWarning)
 
         if not os.path.isfile(file_path):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -237,7 +237,9 @@ class Workbooks(Endpoint):
             logger.info('Publishing {0} to server with chunking method (workbook over 64MB)'.format(filename))
             upload_session_id = Fileuploads.upload_chunks(self.parent_srv, file_path)
             url = "{0}&uploadSessionId={1}".format(url, upload_session_id)
+            conn_creds = connection_credentials
             xml_request, content_type = RequestFactory.Workbook.publish_req_chunked(workbook_item,
+                                                                                    connection_credentials=conn_creds,
                                                                                     connections=connections)
         else:
             logger.info('Publishing {0} to server'.format(filename))

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -199,7 +199,7 @@ class Workbooks(Endpoint):
 
     # Publishes workbook. Chunking method if file over 64MB
     @api(version="2.0")
-    # @parameter_added_in(connections='2.8')
+    @parameter_added_in(connections='2.8')
     def publish(self, workbook_item, file_path, mode, connection_credentials=None, connections=None):
 
         if connection_credentials is not None:
@@ -243,11 +243,12 @@ class Workbooks(Endpoint):
             logger.info('Publishing {0} to server'.format(filename))
             with open(file_path, 'rb') as f:
                 file_contents = f.read()
+            conn_creds = connection_credentials
             xml_request, content_type = RequestFactory.Workbook.publish_req(workbook_item,
                                                                             filename,
                                                                             file_contents,
-                                                                            connections=connections,
-                                                                            connection_credentials=connection_credentials)
+                                                                            connection_credentials=conn_creds,
+                                                                            connections=connections)
         logger.debug('Request xml: {0} '.format(xml_request[:1000]))
         server_response = self.post_request(url, xml_request, content_type)
         new_workbook = WorkbookItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -32,7 +32,7 @@ def _add_connections_element(connections_element, connection):
         connection_element.attrib['serverPort'] = connection.server_port
     if connection.connection_credentials:
         connection_credentials = connection.connection_credentials
-        self._add_credentials_element(connection_element, connection_credentials)
+        _add_credentials_element(connection_element, connection_credentials)
 
 
 def _add_credentials_element(parent_element, connection_credentials):
@@ -65,15 +65,7 @@ class DatasourceRequest(object):
         datasource_element.attrib['name'] = datasource_item.name
         project_element = ET.SubElement(datasource_element, 'project')
         project_element.attrib['id'] = datasource_item.project_id
-        # if connection_credentials:
-        #     credentials_element = ET.SubElement(datasource_element, 'connectionCredentials')
-        #     credentials_element.attrib['name'] = connection_credentials.name
-        #     credentials_element.attrib['password'] = connection_credentials.password
-        #     credentials_element.attrib['embed'] = 'true' if connection_credentials.embed else 'false'
 
-        #     if connection_credentials.oauth:
-        #         credentials_element.attrib['oAuth'] = 'true'
-        # return ET.tostring(xml_request)
         if connection_credentials is not None and connections is not None:
             raise RuntimeError('You cannot set both `connections` and `connection_credentials`')
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -313,7 +313,7 @@ class UserRequest(object):
 
 
 class WorkbookRequest(object):
-    def _generate_xml(self, workbook_item, connections=None, connection_credentials=None):
+    def _generate_xml(self, workbook_item, connection_credentials=None, connections=None):
         xml_request = ET.Element('tsRequest')
         workbook_element = ET.SubElement(xml_request, 'workbook')
         workbook_element.attrib['name'] = workbook_item.name
@@ -322,36 +322,28 @@ class WorkbookRequest(object):
         project_element = ET.SubElement(workbook_element, 'project')
         project_element.attrib['id'] = workbook_item.project_id
 
-        if connection_credentials is not None:
-            if connections is not Nont:
-                raise RuntimeError("Can't have both set.")
+        if connection_credentials is not None and connections is not None:
+            raise RuntimeError('You cannot set both `connections` and `connection_credentials`')
 
-            import warnings
-            warnings.warn('Probably not a good idea')
-
-            connections = [connection_credentials]
+            if connection_credentials is not None:
+                self._add_credentials_element(workbook_element, connection_credentials)
 
         if connections is not None:
-
-            if len(connections) == 1: #  If this is only one, use the back-compact safe bare connCreds
-                self._make_credentials_element(workbook_element, connection_credentials)
-
-            else:
-                connections_element = ET.SubElement(workbook_element, 'connections')
-                for connection in connections:
-                    self._make_connections_element(connections_element, connection)
+            connections_element = ET.SubElement(workbook_element, 'connections')
+            for connection in connections:
+                self._add_connections_element(connections_element, connection)
         return ET.tostring(xml_request)
 
-    def _make_connections_element(self, connections_element, connection):
+    def _add_connections_element(self, connections_element, connection):
         connection_element = ET.SubElement(connections_element, 'connection')
         connection_element.attrib['serverAddress'] = connection.server_address
         if connection.server_port:
             connection_element.attrib['serverPort'] = connection.server_port
         if connection.connection_credentials:
             connection_credentials = connection.connection_credentials
-            self._make_credentials_element(connection_element, connection_credentials)
+            self._add_credentials_element(connection_element, connection_credentials)
 
-    def _make_credentials_element(self, parent_element, connection_credentials):
+    def _add_credentials_element(self, parent_element, connection_credentials):
         credentials_element = ET.SubElement(parent_element, 'connectionCredentials')
         credentials_element.attrib['name'] = connection_credentials.name
         credentials_element.attrib['password'] = connection_credentials.password
@@ -373,7 +365,8 @@ class WorkbookRequest(object):
         return ET.tostring(xml_request)
 
     def publish_req(self, workbook_item, filename, file_contents, connection_credentials=None, connections=None):
-        xml_request = self._generate_xml(workbook_item, connections, connection_credentials)
+        xml_request = self._generate_xml(workbook_item, connection_credentials=connection_credentials,
+                                         connections=connections)
 
         parts = {'request_payload': ('', xml_request, 'text/xml'),
                  'tableau_workbook': (filename, file_contents, 'application/octet-stream')}

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -254,8 +254,9 @@ class DatasourceTests(unittest.TestCase):
         connection2.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
 
         response = RequestFactory.Datasource._generate_xml(new_datasource, connections=[connection1, connection2])
-        connection_results = ET.fromstring(response).findall('.//connection') #  Can't use ConnectionItem parser due to xml namespace problems
-        
+        # Can't use ConnectionItem parser due to xml namespace problems
+        connection_results = ET.fromstring(response).findall('.//connection')
+
         self.assertEqual(connection_results[0].get('serverAddress', None), 'mysql.test.com')
         self.assertEqual(connection_results[0].find('connectionCredentials').get('name', None), 'test')
         self.assertEqual(connection_results[1].get('serverAddress', None), 'pgsql.test.com')
@@ -266,7 +267,9 @@ class DatasourceTests(unittest.TestCase):
         connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
 
         response = RequestFactory.Datasource._generate_xml(new_datasource, connection_credentials=connection_creds)
-        credentials = ET.fromstring(response).findall('.//connectionCredentials') #  Can't use ConnectionItem parser due to xml namespace problems
+        #  Can't use ConnectionItem parser due to xml namespace problems
+        credentials = ET.fromstring(response).findall('.//connectionCredentials')
+
         self.assertEqual(len(credentials), 1)
         self.assertEqual(credentials[0].get('name', None), 'test')
         self.assertEqual(credentials[0].get('password', None), 'secret')
@@ -274,12 +277,14 @@ class DatasourceTests(unittest.TestCase):
 
     def test_credentials_and_multi_connect_raises_exception(self):
         new_datasource = TSC.DatasourceItem(name='Sample', project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
-        
+
         connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
-        
+
         connection1 = TSC.ConnectionItem()
         connection1.server_address = 'mysql.test.com'
         connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
-        
+
         with self.assertRaises(RuntimeError):
-            response = RequestFactory.Datasource._generate_xml(new_datasource, connection_credentials=connection_creds, connections=[connection1])
+            response = RequestFactory.Datasource._generate_xml(new_datasource,
+                                                               connection_credentials=connection_creds,
+                                                               connections=[connection1])

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -1,8 +1,10 @@
 import unittest
 import os
 import requests_mock
+import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
+from tableauserverclient.server.request_factory import RequestFactory
 from ._utils import read_xml_asset, read_xml_assets, asset
 
 ADD_TAGS_XML = 'datasource_add_tags.xml'
@@ -241,3 +243,43 @@ class DatasourceTests(unittest.TestCase):
         new_datasource = TSC.DatasourceItem('test', 'ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
         self.assertRaises(ValueError, self.server.datasources.publish, new_datasource,
                           asset('SampleWB.twbx'), self.server.PublishMode.Append)
+
+    def test_publish_multi_connection(self):
+        new_datasource = TSC.DatasourceItem(name='Sample', project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        connection1 = TSC.ConnectionItem()
+        connection1.server_address = 'mysql.test.com'
+        connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+        connection2 = TSC.ConnectionItem()
+        connection2.server_address = 'pgsql.test.com'
+        connection2.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+
+        response = RequestFactory.Datasource._generate_xml(new_datasource, connections=[connection1, connection2])
+        connection_results = ET.fromstring(response).findall('.//connection') #  Can't use ConnectionItem parser due to xml namespace problems
+        
+        self.assertEqual(connection_results[0].get('serverAddress', None), 'mysql.test.com')
+        self.assertEqual(connection_results[0].find('connectionCredentials').get('name', None), 'test')
+        self.assertEqual(connection_results[1].get('serverAddress', None), 'pgsql.test.com')
+        self.assertEqual(connection_results[1].find('connectionCredentials').get('password', None), 'secret')
+
+    def test_publish_single_connection(self):
+        new_datasource = TSC.DatasourceItem(name='Sample', project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
+
+        response = RequestFactory.Datasource._generate_xml(new_datasource, connection_credentials=connection_creds)
+        credentials = ET.fromstring(response).findall('.//connectionCredentials') #  Can't use ConnectionItem parser due to xml namespace problems
+        self.assertEqual(len(credentials), 1)
+        self.assertEqual(credentials[0].get('name', None), 'test')
+        self.assertEqual(credentials[0].get('password', None), 'secret')
+        self.assertEqual(credentials[0].get('embed', None), 'true')
+
+    def test_credentials_and_multi_connect_raises_exception(self):
+        new_datasource = TSC.DatasourceItem(name='Sample', project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        
+        connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
+        
+        connection1 = TSC.ConnectionItem()
+        connection1.server_address = 'mysql.test.com'
+        connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+        
+        with self.assertRaises(RuntimeError):
+            response = RequestFactory.Datasource._generate_xml(new_datasource, connection_credentials=connection_creds, connections=[connection1])

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -329,8 +329,9 @@ class WorkbookTests(unittest.TestCase):
         connection2.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
 
         response = RequestFactory.Workbook._generate_xml(new_workbook, connections=[connection1, connection2])
-        connection_results = ET.fromstring(response).findall('.//connection') #  Can't use ConnectionItem parser due to xml namespace problems
-        
+        # Can't use ConnectionItem parser due to xml namespace problems
+        connection_results = ET.fromstring(response).findall('.//connection')
+
         self.assertEqual(connection_results[0].get('serverAddress', None), 'mysql.test.com')
         self.assertEqual(connection_results[0].find('connectionCredentials').get('name', None), 'test')
         self.assertEqual(connection_results[1].get('serverAddress', None), 'pgsql.test.com')
@@ -342,7 +343,8 @@ class WorkbookTests(unittest.TestCase):
         connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
 
         response = RequestFactory.Workbook._generate_xml(new_workbook, connection_credentials=connection_creds)
-        credentials = ET.fromstring(response).findall('.//connectionCredentials') #  Can't use ConnectionItem parser due to xml namespace problems
+        # Can't use ConnectionItem parser due to xml namespace problems
+        credentials = ET.fromstring(response).findall('.//connectionCredentials')
         self.assertEqual(len(credentials), 1)
         self.assertEqual(credentials[0].get('name', None), 'test')
         self.assertEqual(credentials[0].get('password', None), 'secret')
@@ -351,12 +353,14 @@ class WorkbookTests(unittest.TestCase):
     def test_credentials_and_multi_connect_raises_exception(self):
         new_workbook = TSC.WorkbookItem(name='Sample', show_tabs=False,
                                         project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
-        
+
         connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
-        
+
         connection1 = TSC.ConnectionItem()
         connection1.server_address = 'mysql.test.com'
         connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
-        
+
         with self.assertRaises(RuntimeError):
-            response = RequestFactory.Workbook._generate_xml(new_workbook, connection_credentials=connection_creds, connections=[connection1])
+            response = RequestFactory.Workbook._generate_xml(new_workbook,
+                                                             connection_credentials=connection_creds,
+                                                             connections=[connection1])

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -2,7 +2,10 @@ import unittest
 import os
 import requests_mock
 import tableauserverclient as TSC
+import xml.etree.ElementTree as ET
+
 from tableauserverclient.datetime_helpers import format_datetime
+from tableauserverclient.server.request_factory import RequestFactory
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
@@ -314,3 +317,46 @@ class WorkbookTests(unittest.TestCase):
         self.assertRaises(ValueError, self.server.workbooks.publish,
                           new_workbook, os.path.join(TEST_ASSET_DIR, 'SampleDS.tds'),
                           self.server.PublishMode.CreateNew)
+
+    def test_publish_multi_connection(self):
+        new_workbook = TSC.WorkbookItem(name='Sample', show_tabs=False,
+                                        project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        connection1 = TSC.ConnectionItem()
+        connection1.server_address = 'mysql.test.com'
+        connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+        connection2 = TSC.ConnectionItem()
+        connection2.server_address = 'pgsql.test.com'
+        connection2.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+
+        response = RequestFactory.Workbook._generate_xml(new_workbook, connections=[connection1, connection2])
+        connection_results = ET.fromstring(response).findall('.//connection') #  Can't use ConnectionItem parser due to xml namespace problems
+        
+        self.assertEqual(connection_results[0].get('serverAddress', None), 'mysql.test.com')
+        self.assertEqual(connection_results[0].find('connectionCredentials').get('name', None), 'test')
+        self.assertEqual(connection_results[1].get('serverAddress', None), 'pgsql.test.com')
+        self.assertEqual(connection_results[1].find('connectionCredentials').get('password', None), 'secret')
+
+    def test_publish_single_connection(self):
+        new_workbook = TSC.WorkbookItem(name='Sample', show_tabs=False,
+                                        project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
+
+        response = RequestFactory.Workbook._generate_xml(new_workbook, connection_credentials=connection_creds)
+        credentials = ET.fromstring(response).findall('.//connectionCredentials') #  Can't use ConnectionItem parser due to xml namespace problems
+        self.assertEqual(len(credentials), 1)
+        self.assertEqual(credentials[0].get('name', None), 'test')
+        self.assertEqual(credentials[0].get('password', None), 'secret')
+        self.assertEqual(credentials[0].get('embed', None), 'true')
+
+    def test_credentials_and_multi_connect_raises_exception(self):
+        new_workbook = TSC.WorkbookItem(name='Sample', show_tabs=False,
+                                        project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+        
+        connection_creds = TSC.ConnectionCredentials('test', 'secret', True)
+        
+        connection1 = TSC.ConnectionItem()
+        connection1.server_address = 'mysql.test.com'
+        connection1.connection_credentials = TSC.ConnectionCredentials('test', 'secret', True)
+        
+        with self.assertRaises(RuntimeError):
+            response = RequestFactory.Workbook._generate_xml(new_workbook, connection_credentials=connection_creds, connections=[connection1])


### PR DESCRIPTION
Following on from @marianotn's work, I rebased on top of the latest Development and reorganized a few things for readability and back-compat.

Still need to update tests, I'm probably going to test `RequestFactory.Workbook.publish_req` specifically, which would be one of the few serializer tests, but I think it's worth the coverage.

Thoughts on the approach? I tried to make it so connections would work older than 2.8, but it was getting really nasty.

I also need to add support to Data Sources too.