### PR TITLE
Add ability to rename workbook using the 'update workbook' endpoint

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -334,6 +334,8 @@ class WorkbookRequest(object):
     def update_req(self, workbook_item):
         xml_request = ET.Element('tsRequest')
         workbook_element = ET.SubElement(xml_request, 'workbook')
+        if workbook_item.name:
+            workbook_element.attrib['name'] = workbook_item.name
         if workbook_item.show_tabs:
             workbook_element.attrib['showTabs'] = str(workbook_item.show_tabs).lower()
         if workbook_item.project_id:

--- a/test/assets/workbook_update.xml
+++ b/test/assets/workbook_update.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-    <workbook id="1f951daf-4061-451a-9df1-69a8062664f2" name="RESTAPISample" contentUrl="RESTAPISample" showTabs="true" size="1" createdAt="2016-08-18T18:25:36Z" updatedAt="2016-08-18T18:29:36Z">
+    <workbook id="1f951daf-4061-451a-9df1-69a8062664f2" name="renamedWorkbook" contentUrl="RESTAPISample" showTabs="true" size="1" createdAt="2016-08-18T18:25:36Z" updatedAt="2016-08-18T18:29:36Z">
         <project id="1d0304cd-3796-429f-b815-7258370b9b74" name="Tableau" />
         <owner id="dd2239f6-ddf1-4107-981a-4cf94e415794" />
         <tags />

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -114,12 +114,14 @@ class WorkbookTests(unittest.TestCase):
             single_workbook = TSC.WorkbookItem('1d0304cd-3796-429f-b815-7258370b9b74', show_tabs=True)
             single_workbook._id = '1f951daf-4061-451a-9df1-69a8062664f2'
             single_workbook.owner_id = 'dd2239f6-ddf1-4107-981a-4cf94e415794'
+            single_workbook.name = 'renamedWorkbook'
             single_workbook = self.server.workbooks.update(single_workbook)
 
         self.assertEqual('1f951daf-4061-451a-9df1-69a8062664f2', single_workbook.id)
         self.assertEqual(True, single_workbook.show_tabs)
         self.assertEqual('1d0304cd-3796-429f-b815-7258370b9b74', single_workbook.project_id)
         self.assertEqual('dd2239f6-ddf1-4107-981a-4cf94e415794', single_workbook.owner_id)
+        self.assertEqual('renamedWorkbook', single_workbook.name)
 
     def test_update_missing_id(self):
         single_workbook = TSC.WorkbookItem('test')


### PR DESCRIPTION
Server side improvement was made recently to allow the existing 'update workbook' endpoint to rename workbooks.