### PR TITLE
Permissions support for Workbooks, Datasources, Projects

### DIFF
--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -3,7 +3,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, JobItem, PaginationItem, ProjectItem, ScheduleItem, \
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
-    SubscriptionItem
+    SubscriptionItem, PermissionsItem, Permission, CapabilityItem
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -16,3 +16,4 @@ from .user_item import UserItem
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 from .subscription_item import SubscriptionItem
+from .permissions_item import Permission, PermissionsItem, CapabilityItem

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -23,12 +23,21 @@ class DatasourceItem(object):
         self.project_id = project_id
         self.tags = set()
 
+        self._permissions = None
+
     @property
     def connections(self):
         if self._connections is None:
             error = 'Datasource item must be populated with connections first.'
             raise UnpopulatedPropertyError(error)
         return self._connections()
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @property
     def content_url(self):
@@ -83,6 +92,9 @@ class DatasourceItem(object):
 
     def _set_connections(self, connections):
         self._connections = connections
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     def _parse_common_elements(self, datasource_xml, ns):
         if not isinstance(datasource_xml, ET.Element):

--- a/tableauserverclient/models/exceptions.py
+++ b/tableauserverclient/models/exceptions.py
@@ -1,2 +1,6 @@
 class UnpopulatedPropertyError(Exception):
     pass
+
+
+class UnknownGranteeTypeError(Exception):
+    pass

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,0 +1,120 @@
+import xml.etree.ElementTree as ET
+import logging
+
+from .exceptions import UnknownGranteeTypeError
+
+
+logger = logging.getLogger('tableau.models.permissions_item')
+
+
+class Permission:
+    class GranteeType:
+        User = 'user'
+        Group = 'group'
+
+    class CapabilityMode:
+        Allow = 'Allow'
+        Deny = 'Deny'
+
+    class DatasourceCapabilityType:
+        ChangePermissions = 'ChangePermissions'
+        Connect = 'Connect'
+        Delete = 'Delete'
+        ExportXml = 'ExportXml'
+        Read = 'Read'
+        Write = 'Write'
+
+    class WorkbookCapabilityType:
+        AddComment = 'AddComment'
+        ChangeHierarchy = 'ChangeHierarchy'
+        ChangePermissions = 'ChangePermissions'
+        Delete = 'Delete'
+        ExportData = 'ExportData'
+        ExportImage = 'ExportImage'
+        ExportXml = 'ExportXml'
+        Filter = 'Filter'
+        Read = 'Read'
+        ShareView = 'ShareView'
+        ViewComments = 'ViewComments'
+        ViewUnderlyingData = 'ViewUnderlyingData'
+        WebAuthoring = 'WebAuthoring'
+        Write = 'Write'
+
+    class ProjectCapabilityType:
+        ProjectLeader = 'ProjectLeader'
+        Read = 'Read'
+        Write = 'Write'
+
+
+class CapabilityItem(object):
+    def __init__(self, type=None, object_id=None, map={}):
+        self._type = type
+        self._object_id = object_id
+        self.map = map
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def object_id(self):
+        return self._object_id
+
+
+class PermissionsItem(object):
+    def __init__(self):
+        self._capabilities = None
+
+    def _set_values(self, capabilities):
+        self._capabilities = capabilities
+
+    @property
+    def capabilities(self):
+        return self._capabilities
+
+    @classmethod
+    def from_response(cls, resp, ns=None):
+        permissions = PermissionsItem()
+        parsed_response = ET.fromstring(resp)
+
+        capabilities = {}
+        all_xml = parsed_response.findall('.//t:granteeCapabilities',
+                                          namespaces=ns)
+
+        for grantee_capability_xml in all_xml:
+            grantee_id = None
+            grantee_type = None
+            capability_map = {}
+
+            try:
+                grantee_id = grantee_capability_xml.find('.//t:group',
+                                                         namespaces=ns)\
+                                                    .get('id')
+                grantee_type = Permission.GranteeType.Group
+            except AttributeError:
+                pass
+            try:
+                grantee_id = grantee_capability_xml.find('.//t:user',
+                                                         namespaces=ns)\
+                                                    .get('id')
+                grantee_type = Permission.GranteeType.User
+            except AttributeError:
+                pass
+
+            if grantee_id is None:
+                logger.error('Cannot find grantee type in response')
+                raise UnknownGranteeTypeError()
+
+            for capability_xml in grantee_capability_xml.findall(
+                    './/t:capabilities/t:capability', namespaces=ns):
+                name = capability_xml.get('name')
+                mode = capability_xml.get('mode')
+
+                capability_map[name] = mode
+
+            capability_item = CapabilityItem(grantee_type, grantee_id,
+                                             capability_map)
+            capabilities[(grantee_type, grantee_id)] = capability_item
+
+        permissions._set_values(capabilities)
+        return permissions

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,5 +1,6 @@
 import xml.etree.ElementTree as ET
 from .property_decorators import property_is_enum, property_not_empty
+from .exceptions import UnpopulatedPropertyError
 
 
 class ProjectItem(object):
@@ -15,9 +16,18 @@ class ProjectItem(object):
         self.content_permissions = content_permissions
         self.parent_id = parent_id
 
+        self._permissions = None
+
     @property
     def content_permissions(self):
         return self._content_permissions
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @content_permissions.setter
     @property_is_enum(ContentPermissions)
@@ -60,6 +70,9 @@ class ProjectItem(object):
             self._content_permissions = content_permissions
         if parent_id:
             self.parent_id = parent_id
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -3,6 +3,7 @@ from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_nullable, property_is_boolean
 from .tag_item import TagItem
 from .view_item import ViewItem
+from .permissions_item import PermissionsItem
 from ..datetime_helpers import parse_datetime
 import copy
 
@@ -24,6 +25,7 @@ class WorkbookItem(object):
         self.project_id = project_id
         self.show_tabs = show_tabs
         self.tags = set()
+        self._permissions = None
 
     @property
     def connections(self):
@@ -31,6 +33,13 @@ class WorkbookItem(object):
             error = "Workbook item must be populated with connections first."
             raise UnpopulatedPropertyError(error)
         return self._connections()
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Workbook item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @property
     def content_url(self):
@@ -100,6 +109,9 @@ class WorkbookItem(object):
 
     def _set_connections(self, connections):
         self._connections = connections
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     def _set_views(self, views):
         self._views = views

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -4,7 +4,7 @@ from .filter import Filter
 from .sort import Sort
 from .. import ConnectionItem, DatasourceItem, JobItem, \
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, SiteItem, TableauAuth,\
-    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem
+    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsItem
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, Subscriptions, ServerResponseError, \
     MissingRequiredFieldError

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -1,4 +1,5 @@
-from .endpoint import Endpoint, api, parameter_added_in
+from .endpoint import api, parameter_added_in, Endpoint
+from .permissions_endpoint import _PermissionsEndpoint
 from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
@@ -24,6 +25,7 @@ class Datasources(Endpoint):
     def __init__(self, parent_srv):
         super(Datasources, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
 
     @property
     def baseurl(self):
@@ -196,3 +198,15 @@ class Datasources(Endpoint):
         new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
         return new_datasource
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -1,0 +1,73 @@
+import logging
+
+from .. import RequestFactory, PermissionsItem
+
+from .endpoint import Endpoint, api
+from .exceptions import MissingRequiredFieldError
+
+
+logger = logging.getLogger(__name__)
+
+
+class _PermissionsEndpoint(Endpoint):
+    ''' Adds permission model to another endpoint
+
+    Tableau permissions model is identical between objects but they are nested under
+    the parent object endpoint (i.e. permissions for workbooks are under
+    /workbooks/:id/permission).  This class is meant to be instantated inside a
+    parent endpoint which has these supported endpoints
+    '''
+    def __init__(self, parent_srv, owner_baseurl):
+        super(_PermissionsEndpoint, self).__init__(parent_srv)
+
+        # owner_baseurl is the baseurl of the parent.  The MUST be a lambda
+        # since we don't know the full site URL until we sign in.  If
+        # populated without, we will get a sign-in error
+        self.owner_baseurl = owner_baseurl
+
+    def update(self, item, permission_item):
+        url = '{0}/{1}/permissions'.format(self.owner_baseurl(), item.id)
+        update_req = RequestFactory.Permission.add_req(item, permission_item)
+        response = self.put_request(url, update_req)
+        permissions = PermissionsItem.from_response(response.content,
+                                                    self.parent_srv.namespace)
+
+        logger.info('Updated permissions for item {0}'.format(item.id))
+
+        return permissions
+
+    def delete(self, item, capability_item):
+        for capability_type, capability_mode in capability_item.map.items():
+            url = '{0}/{1}/permissions/{2}/{3}/{4}/{5}'.format(
+                self.owner_baseurl(), item.id,
+                capability_item.type + 's',
+                capability_item.object_id, capability_type,
+                capability_mode)
+
+            logger.debug('Removing {0} permission for capabilty {1}'.format(
+                capability_mode, capability_type))
+
+            self.delete_request(url)
+
+        logger.info('Deleted permission for {0} {1} item {2}'.format(
+            capability_item.type,
+            capability_item.object_id,
+            item.id))
+
+    def populate(self, item):
+        if not item.id:
+            error = "Server item is missing ID. Item must be retrieved from server first."
+            raise MissingRequiredFieldError(error)
+
+        def permission_fetcher():
+            return self._get_permissions(item)
+
+        item._set_permissions(permission_fetcher)
+        logger.info('Populated permissions for item (ID: {0})'.format(item.id))
+
+    def _get_permissions(self, item, req_options=None):
+        url = "{0}/{1}/permissions".format(self.owner_baseurl(), item.id)
+        server_response = self.get_request(url, req_options)
+        permissions = PermissionsItem.from_response(server_response.content,
+                                                    self.parent_srv.namespace)
+        return permissions

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -1,5 +1,6 @@
-from .endpoint import Endpoint, api
+from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
+from .permissions_endpoint import _PermissionsEndpoint
 from .. import RequestFactory, ProjectItem, PaginationItem
 import logging
 
@@ -7,6 +8,11 @@ logger = logging.getLogger('tableau.endpoint.projects')
 
 
 class Projects(Endpoint):
+    def __init__(self, parent_srv):
+        super(Projects, self).__init__(parent_srv)
+
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
+
     @property
     def baseurl(self):
         return "{0}/sites/{1}/projects".format(self.parent_srv.baseurl, self.parent_srv.site_id)
@@ -50,3 +56,15 @@ class Projects(Endpoint):
         new_project = ProjectItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Created new project (ID: {0})'.format(new_project.id))
         return new_project
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,4 +1,5 @@
-from .endpoint import Endpoint, api, parameter_added_in
+from .endpoint import api, parameter_added_in, Endpoint
+from .permissions_endpoint import _PermissionsEndpoint
 from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
@@ -25,6 +26,7 @@ class Workbooks(Endpoint):
     def __init__(self, parent_srv):
         super(Workbooks, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
 
     @property
     def baseurl(self):
@@ -196,6 +198,18 @@ class Workbooks(Endpoint):
         server_response = self.get_request(url)
         preview_image = server_response.content
         return preview_image
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)
 
     # Publishes workbook. Chunking method if file over 64MB
     @api(version="2.0")

--- a/test/assets/datasource_populate_permissions.xml
+++ b/test/assets/datasource_populate_permissions.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+    <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <permissions>
+        <datasource id="0448d2ed-590d-4fa0-b272-a2a8a24555b5" name="Some datasource">
+            <owner id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+        </datasource>
+        <granteeCapabilities>
+            <group id="5e5e1978-71fa-11e4-87dd-7382f5c437af" />
+            <capabilities>
+                <capability name="Delete" mode="Deny" />
+                <capability name="ChangePermissions" mode="Deny" />
+                <capability name="Connect" mode="Allow" />
+                <capability name="Read" mode="Allow" />
+            </capabilities>
+        </granteeCapabilities>
+        <granteeCapabilities>
+            <user id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+            <capabilities>
+                <capability name="Write" mode="Allow" />
+            </capabilities>
+        </granteeCapabilities>
+    </permissions>
+</tsResponse>

--- a/test/assets/workbook_populate_permissions.xml
+++ b/test/assets/workbook_populate_permissions.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <permissions>
+        <workbook id="21778de4-b7b9-44bc-a599-1506a2639ace" name="ComplianceDashboard">
+            <owner id="91d5931a-2cd6-4dbc-8b7c-211e85cf5fa3" />
+        </workbook>
+    <granteeCapabilities>
+        <group id="5e5e1978-71fa-11e4-87dd-7382f5c437af" />
+        <capabilities>
+            <capability name="WebAuthoring" mode="Allow" />
+            <capability name="Read" mode="Allow" />
+            <capability name="Filter" mode="Allow" />
+            <capability name="AddComment" mode="Allow" />
+        </capabilities>
+    </granteeCapabilities>
+    <granteeCapabilities>
+        <user id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+        <capabilities>
+            <capability name="ExportImage" mode="Allow" />
+            <capability name="ShareView" mode="Allow" />
+            <capability name="ExportData" mode="Deny" />
+            <capability name="ViewComments" mode="Deny" />
+        </capabilities>
+    </granteeCapabilities>
+    </permissions>
+</tsResponse>
+

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -12,6 +12,7 @@ GET_XML = 'datasource_get.xml'
 GET_EMPTY_XML = 'datasource_get_empty.xml'
 GET_BY_ID_XML = 'datasource_get_by_id.xml'
 POPULATE_CONNECTIONS_XML = 'datasource_populate_connections.xml'
+POPULATE_PERMISSIONS_XML = 'datasource_populate_permissions.xml'
 PUBLISH_XML = 'datasource_publish.xml'
 UPDATE_XML = 'datasource_update.xml'
 UPDATE_CONNECTION_XML = 'datasource_connection_update.xml'
@@ -172,6 +173,38 @@ class DatasourceTests(unittest.TestCase):
             self.assertEquals('bar', new_connection.server_address)
             self.assertEquals('9876', new_connection.server_port)
             self.assertEqual('foo', new_connection.username)
+
+    def test_populate_permissions(self):
+        with open(asset(POPULATE_PERMISSIONS_XML), 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/0448d2ed-590d-4fa0-b272-a2a8a24555b5/permissions', text=response_xml)
+            single_datasource = TSC.DatasourceItem('test')
+            single_datasource._id = '0448d2ed-590d-4fa0-b272-a2a8a24555b5'
+
+            self.server.datasources.populate_permissions(single_datasource)
+            permissions = single_datasource.permissions
+            
+            grantee_type = TSC.Permission.GranteeType.Group
+            object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.Group)
+            self.assertEqual(permissions.capabilities[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.DatasourceCapabilityType.Delete: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.DatasourceCapabilityType.ChangePermissions: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.DatasourceCapabilityType.Connect: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.DatasourceCapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
+            })
+
+            grantee_type = TSC.Permission.GranteeType.User
+            object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.User)
+            self.assertEqual(permissions.capabilities[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.DatasourceCapabilityType.Write: TSC.Permission.CapabilityMode.Allow,
+            })
 
     def test_publish(self):
         response_xml = read_xml_asset(PUBLISH_XML)


### PR DESCRIPTION
Addresses #41 
@t8y8 previously commented in the conversation.

My approach here was to minimize the duplication of code as Projects, Datasources, and Workbooks all have the same remote access model.  The two bigger classes, `PermissionsItem` and `EndpointWithPermissions` are more like mixins which add the functionality.

Other classes added are `GranteeCapabilityItem` which stores the actual permissions for a single group and `Permission` which stores all the constants.

I tried to closely follow the way the data and naming conventions are represented in the API.  One thing to note: group permissions and user permissions are stored in the same list.  The previous partial implementation suggested that we keep user and group permissions separate.  I wanted to keep them together to match the API.  In addition, the permissions collection is a list so there is a chance for users of this client library might have two separate `GranteeCapabilityItem`s for the same entity.

I also added a couple of test cases to validate reading.  I tested reading permissions and updating permissions for both users and groups on a Tableau Server 10.1 deployment.