### PR TITLE
 Adding reference to new REST API version 3.0 

### DIFF
--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -31,7 +31,7 @@ class Server(object):
         self._session = requests.Session()
         self._http_options = dict()
 
-        self.version = "3.0"
+        self.version = "2.3"
         self.auth = Auth(self)
         self.views = Views(self)
         self.users = Users(self)
@@ -77,7 +77,7 @@ class Server(object):
     def _determine_highest_version(self):
         try:
             old_version = self.version
-            self.version = "3.0"
+            self.version = "2.4"
             version = self.server_info.get().rest_api_version
         except ServerInfoEndpointNotFoundError:
             version = self._get_legacy_version()


### PR DESCRIPTION
On server.py

Adding to "_PRODUCT_TO_REST_VERSION" the new REST API version.
Changing in "def __init__(self, server_address, use_server_version=False):" 
Changing in "def _determine_highest_version(self):"