### PR TITLE
Adding created_at, updated_at and sheet_type properties to view items

### DIFF
--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -2405,11 +2405,15 @@ Source file: models/view_item.py
 
 Name | Description
 :--- | :---  
+`created_at` |  The date and time when the view was created.  
+`favorites_total` |  The number of times the view was marked down as favorite.  
 `id` | The identifier of the view item.  
 `name`  | The name of the view. 
 `owner_id` |  The id for the owner of the view. 
 `preview_image` | The thumbnail image for the view. 
+`sheet_type`  |  The type of the view which is either a worksheet, a dashboard or a story. 
 `total_views`  |  The usage statistics for the view. Indicates the total number of times the view has been looked at. 
+`updated_at` |  The date and time when the view was last updated.  
 `workbook_id`  |  The id of the workbook associated with the view. 
 
 

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -2406,7 +2406,6 @@ Source file: models/view_item.py
 Name | Description
 :--- | :---  
 `created_at` |  The date and time when the view was created.  
-`favorites_total` |  The number of times the view was marked down as favorite.  
 `id` | The identifier of the view item.  
 `name`  | The name of the view. 
 `owner_id` |  The id for the owner of the view. 

--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -7,7 +7,6 @@ class ViewItem(object):
     def __init__(self):
         self._content_url = None
         self._created_at = None
-        self._favorites_total = None
         self._id = None
         self._image = None
         self._initial_tags = set()
@@ -42,10 +41,6 @@ class ViewItem(object):
     @property
     def created_at(self):
         return self._created_at
-
-    @property
-    def favorites_total(self):
-        return self._favorites_total
 
     @property
     def id(self):
@@ -124,16 +119,12 @@ class ViewItem(object):
             workbook_elem = view_xml.find('.//t:workbook', namespaces=ns)
             owner_elem = view_xml.find('.//t:owner', namespaces=ns)
             project_elem = view_xml.find('.//t:project', namespaces=ns)
-            favoritesTotal = view_xml.get('favoritesTotal', None)
             view_item._created_at = parse_datetime(view_xml.get('createdAt', None))
             view_item._updated_at = parse_datetime(view_xml.get('updatedAt', None))
             view_item._id = view_xml.get('id', None)
             view_item._name = view_xml.get('name', None)
             view_item._content_url = view_xml.get('contentUrl', None)
             view_item._sheet_type = view_xml.get('sheetType', None)
-
-            if favoritesTotal:
-                view_item._favorites_total = int(favoritesTotal)
 
             if usage_elem is not None:
                 total_view = usage_elem.get('totalViewCount', None)

--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -1,10 +1,13 @@
 import xml.etree.ElementTree as ET
+from ..datetime_helpers import parse_datetime
 from .exceptions import UnpopulatedPropertyError
 
 
 class ViewItem(object):
     def __init__(self):
         self._content_url = None
+        self._created_at = None
+        self._favorites_total = None
         self._id = None
         self._image = None
         self._initial_tags = set()
@@ -15,6 +18,8 @@ class ViewItem(object):
         self._pdf = None
         self._csv = None
         self._total_views = None
+        self._sheet_type = None
+        self._updated_at = None
         self._workbook_id = None
         self.tags = set()
 
@@ -33,6 +38,14 @@ class ViewItem(object):
     @property
     def content_url(self):
         return self._content_url
+
+    @property
+    def created_at(self):
+        return self._created_at
+
+    @property
+    def favorites_total(self):
+        return self._favorites_total
 
     @property
     def id(self):
@@ -79,11 +92,19 @@ class ViewItem(object):
         return self._csv()
 
     @property
+    def sheet_type(self):
+        return self._sheet_type
+
+    @property
     def total_views(self):
         if self._total_views is None:
             error = "Usage statistics must be requested when querying for view."
             raise UnpopulatedPropertyError(error)
         return self._total_views
+
+    @property
+    def updated_at(self):
+        return self._updated_at
 
     @property
     def workbook_id(self):
@@ -103,9 +124,17 @@ class ViewItem(object):
             workbook_elem = view_xml.find('.//t:workbook', namespaces=ns)
             owner_elem = view_xml.find('.//t:owner', namespaces=ns)
             project_elem = view_xml.find('.//t:project', namespaces=ns)
+            favoritesTotal = view_xml.get('favoritesTotal', None)
+            view_item._created_at = parse_datetime(view_xml.get('createdAt', None))
+            view_item._updated_at = parse_datetime(view_xml.get('updatedAt', None))
             view_item._id = view_xml.get('id', None)
             view_item._name = view_xml.get('name', None)
             view_item._content_url = view_xml.get('contentUrl', None)
+            view_item._sheet_type = view_xml.get('sheetType', None)
+
+            if favoritesTotal:
+                view_item._favorites_total = int(favoritesTotal)
+
             if usage_elem is not None:
                 total_view = usage_elem.get('totalViewCount', None)
                 if total_view:

--- a/test/assets/view_get.xml
+++ b/test/assets/view_get.xml
@@ -7,7 +7,7 @@
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <project id="5241e88d-d384-4fd7-9c2f-648b5247efc5" />
         </view>
-        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview">
+        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story" favoritesTotal="2">
             <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <project id="5b534f74-3226-11e8-b47a-cb2e00f738a3" />

--- a/test/assets/view_get.xml
+++ b/test/assets/view_get.xml
@@ -7,7 +7,7 @@
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <project id="5241e88d-d384-4fd7-9c2f-648b5247efc5" />
         </view>
-        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story" favoritesTotal="2">
+        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story">
             <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <project id="5b534f74-3226-11e8-b47a-cb2e00f738a3" />

--- a/test/assets/view_get_usage.xml
+++ b/test/assets/view_get_usage.xml
@@ -8,7 +8,7 @@
             <tags />
             <usage totalViewCount="7" />
         </view>
-        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story" favoritesTotal="2">
+        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story">
             <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <tags />

--- a/test/assets/view_get_usage.xml
+++ b/test/assets/view_get_usage.xml
@@ -8,7 +8,7 @@
             <tags />
             <usage totalViewCount="7" />
         </view>
-        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview">
+        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story" favoritesTotal="2">
             <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <tags />

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -3,6 +3,8 @@ import os
 import requests_mock
 import tableauserverclient as TSC
 
+from tableauserverclient.datetime_helpers import format_datetime
+
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
 ADD_TAGS_XML = os.path.join(TEST_ASSET_DIR, 'view_add_tags.xml')
@@ -40,6 +42,10 @@ class ViewTests(unittest.TestCase):
         self.assertEqual('3cc6cd06-89ce-4fdc-b935-5294135d6d42', all_views[0].workbook_id)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_views[0].owner_id)
         self.assertEqual('5241e88d-d384-4fd7-9c2f-648b5247efc5', all_views[0].project_id)
+        self.assertIsNone(all_views[0].created_at)
+        self.assertIsNone(all_views[0].updated_at)
+        self.assertIsNone(all_views[0].favorites_total)
+        self.assertIsNone(all_views[0].sheet_type)
 
         self.assertEqual('fd252f73-593c-4c4e-8584-c032b8022adc', all_views[1].id)
         self.assertEqual('Overview', all_views[1].name)
@@ -47,6 +53,10 @@ class ViewTests(unittest.TestCase):
         self.assertEqual('6d13b0ca-043d-4d42-8c9d-3f3313ea3a00', all_views[1].workbook_id)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_views[1].owner_id)
         self.assertEqual('5b534f74-3226-11e8-b47a-cb2e00f738a3', all_views[1].project_id)
+        self.assertEqual('2002-05-30T09:00:00Z', format_datetime(all_views[1].created_at))
+        self.assertEqual('2002-06-05T08:00:59Z', format_datetime(all_views[1].updated_at))
+        self.assertEqual(2, all_views[1].favorites_total)
+        self.assertEqual('story', all_views[1].sheet_type)
 
     def test_get_with_usage(self):
         with open(GET_XML_USAGE, 'rb') as f:
@@ -57,8 +67,17 @@ class ViewTests(unittest.TestCase):
 
         self.assertEqual('d79634e1-6063-4ec9-95ff-50acbf609ff5', all_views[0].id)
         self.assertEqual(7, all_views[0].total_views)
+        self.assertIsNone(all_views[0].created_at)
+        self.assertIsNone(all_views[0].updated_at)
+        self.assertIsNone(all_views[0].favorites_total)
+        self.assertIsNone(all_views[0].sheet_type)
+
         self.assertEqual('fd252f73-593c-4c4e-8584-c032b8022adc', all_views[1].id)
         self.assertEqual(13, all_views[1].total_views)
+        self.assertEqual('2002-05-30T09:00:00Z', format_datetime(all_views[1].created_at))
+        self.assertEqual('2002-06-05T08:00:59Z', format_datetime(all_views[1].updated_at))
+        self.assertEqual(2, all_views[1].favorites_total)
+        self.assertEqual('story', all_views[1].sheet_type)
 
     def test_get_with_usage_and_filter(self):
         with open(GET_XML_USAGE, 'rb') as f:

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -44,7 +44,6 @@ class ViewTests(unittest.TestCase):
         self.assertEqual('5241e88d-d384-4fd7-9c2f-648b5247efc5', all_views[0].project_id)
         self.assertIsNone(all_views[0].created_at)
         self.assertIsNone(all_views[0].updated_at)
-        self.assertIsNone(all_views[0].favorites_total)
         self.assertIsNone(all_views[0].sheet_type)
 
         self.assertEqual('fd252f73-593c-4c4e-8584-c032b8022adc', all_views[1].id)
@@ -55,7 +54,6 @@ class ViewTests(unittest.TestCase):
         self.assertEqual('5b534f74-3226-11e8-b47a-cb2e00f738a3', all_views[1].project_id)
         self.assertEqual('2002-05-30T09:00:00Z', format_datetime(all_views[1].created_at))
         self.assertEqual('2002-06-05T08:00:59Z', format_datetime(all_views[1].updated_at))
-        self.assertEqual(2, all_views[1].favorites_total)
         self.assertEqual('story', all_views[1].sheet_type)
 
     def test_get_with_usage(self):
@@ -69,14 +67,12 @@ class ViewTests(unittest.TestCase):
         self.assertEqual(7, all_views[0].total_views)
         self.assertIsNone(all_views[0].created_at)
         self.assertIsNone(all_views[0].updated_at)
-        self.assertIsNone(all_views[0].favorites_total)
         self.assertIsNone(all_views[0].sheet_type)
 
         self.assertEqual('fd252f73-593c-4c4e-8584-c032b8022adc', all_views[1].id)
         self.assertEqual(13, all_views[1].total_views)
         self.assertEqual('2002-05-30T09:00:00Z', format_datetime(all_views[1].created_at))
         self.assertEqual('2002-06-05T08:00:59Z', format_datetime(all_views[1].updated_at))
-        self.assertEqual(2, all_views[1].favorites_total)
         self.assertEqual('story', all_views[1].sheet_type)
 
     def test_get_with_usage_and_filter(self):


### PR DESCRIPTION
Hello,

I noticed that some property fields which are available in the rest API for View Items where not implemented. Here is an implementation for the following fields as describe in the XML schema (https://onlinehelp.tableau.com/samples/en-us/rest_api/ts-api_3_0.xsd) : created_at, updated_at, sheet_type.

The following modification have been applied : 
- Add field property and  parsing to ViewItem class
- Add fields to test assets
- Add relevant test
- Update documentation.

I noticed that while describe in the API doc, the sheet_type does not appear in the response on API version 3.0 (tested on Tableau Online).