### PR TITLE
fix link pointing to old doc content on master branch

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -48,7 +48,7 @@ anyone can add to an issue:
 ## Fixes, Implementations, and Documentation
 
 For all other things, please submit a PR that includes the fix, documentation, or new code that you are trying to contribute.  More information on
-creating a PR can be found in the [Development Guide](docs/docs/dev-guide.md)
+creating a PR can be found in the [Development Guide](https://tableau.github.io/server-client-python/docs/dev-guide)
 
 If the feature is complex or has multiple solutions that could be equally appropriate approaches, it would be helpful to file an issue to discuss the
 design trade-offs of each solution before implementing, to allow us to collectively arrive at the best solution, which most likely exists in the middle


### PR DESCRIPTION
The link points to the old version of the dev-guide on the master branch. Point link to the new version on the gh-pages branch by linking to the built docs instead of repo location.