### PR TITLE
Improve handling of 500 errors

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,4 +1,4 @@
-from .exceptions import ServerResponseError, EndpointUnavailableError, ItemTypeNotAllowed
+from .exceptions import ServerResponseError, InternalServerError
 from functools import wraps
 
 import logging
@@ -62,7 +62,9 @@ class Endpoint(object):
 
     def _check_status(self, server_response):
         logger.debug(self._safe_to_log(server_response))
-        if server_response.status_code not in Success_codes:
+        if server_response.status_code >= 500:
+            raise InternalServerError(server_response)
+        elif server_response.status_code not in Success_codes:
             raise ServerResponseError.from_response(server_response.content, self.parent_srv.namespace)
 
     def get_unauthenticated_request(self, url, request_object=None):

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -21,6 +21,15 @@ class ServerResponseError(Exception):
         return error_response
 
 
+class InternalServerError(Exception):
+    def __init__(self, server_response):
+        self.code = server_response.status_code
+        self.content = server_response.content
+
+    def __str__(self):
+        return "\n\nError status code: {0}\n{1}".format(self.code, self.content)
+
+
 class MissingRequiredFieldError(Exception):
     pass
 

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,5 +1,5 @@
 from .endpoint import Endpoint, api, parameter_added_in
-from .exceptions import MissingRequiredFieldError
+from .exceptions import InternalServerError, MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
 from .. import RequestFactory, WorkbookItem, ConnectionItem, ViewItem, PaginationItem
@@ -256,7 +256,15 @@ class Workbooks(Endpoint):
                                                                             connection_credentials=conn_creds,
                                                                             connections=connections)
         logger.debug('Request xml: {0} '.format(xml_request[:1000]))
-        server_response = self.post_request(url, xml_request, content_type)
+
+        # Send the publishing request to server
+        try:
+            server_response = self.post_request(url, xml_request, content_type)
+        except InternalServerError as err:
+            if err.code == 504 and not as_job:
+                err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+            raise err
+
         if as_job:
             new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
             logger.info('Published {0} (JOB_ID: {1}'.format(filename, new_job.id))


### PR DESCRIPTION
Addressing #358 to improve how we output 500 errors. Also added error handling for the 2 publishing methods (workbook and datasource) to notify client to use async publishing if synchronous publish call timed out.