### PR TITLE
adding basestring conversion to str for python3

### DIFF
--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -3,6 +3,12 @@ from .. import JobItem, BackgroundJobItem, PaginationItem
 from ..request_options import RequestOptionsBase
 import logging
 
+try:
+    basestring
+except NameError:
+    # In case we are in python 3 the string check is different
+    basestring = str
+
 logger = logging.getLogger('tableau.endpoint.jobs')
 
 


### PR DESCRIPTION
Addressing #351 where the usage of `basestring` would cause errors in python 3