### PR TITLE
Change default server API version to 2.4

### DIFF
--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -36,7 +36,7 @@ class Server(object):
         self._session = requests.Session()
         self._http_options = dict()
 
-        self.version = "2.3"
+        self.version = "2.4"
         self.auth = Auth(self)
         self.views = Views(self)
         self.users = Users(self)


### PR DESCRIPTION
On our Tableau server (version 2018.2.1 / API version 3.1) the original code thinks the server version is 2.3 because it can't run line 86. Setting the default version to 2.4 fixes the issue and the code can now correctly identify the server version.

This is an extremely minor change that should not negatively affect anyone but helps situations like ours.