### PR TITLE
Fixing import of TSC.Target to client access

### DIFF
--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -3,7 +3,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem, \
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
-    SubscriptionItem
+    SubscriptionItem, Target
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -11,6 +11,7 @@ from .schedule_item import ScheduleItem
 from .server_info_item import ServerInfoItem
 from .site_item import SiteItem
 from .tableau_auth import TableauAuth
+from .target import Target
 from .task_item import TaskItem
 from .user_item import UserItem
 from .view_item import ViewItem

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -10,6 +10,7 @@ class ScheduleItem(object):
     class Type:
         Extract = "Extract"
         Subscription = "Subscription"
+        Flow = "Flow"
 
     class ExecutionOrder:
         Parallel = "Parallel"

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -10,7 +10,6 @@ class ScheduleItem(object):
     class Type:
         Extract = "Extract"
         Subscription = "Subscription"
-        Flow = "Flow"
 
     class ExecutionOrder:
         Parallel = "Parallel"

--- a/test/assets/subscription_create.xml
+++ b/test/assets/subscription_create.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.3.xsd">
+    <subscription id="78e9318d-2d29-4d67-b60f-3f2f5fd89ecc" subject="sub_name">
+        <content id="960e61f2-1838-40b2-bba2-340c9492f943" type="Workbook"/>
+        <schedule id="4906c453-d5ec-4972-9ff4-789b629bdfa2" name="Monday morning"/>
+        <user id="8d30c8de-0a5f-4bee-b266-c621b4f3eed0" name="user1"/>
+    </subscription>
+</tsResponse>

--- a/test/test_subscription.py
+++ b/test/test_subscription.py
@@ -5,6 +5,7 @@ import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 
+CREATE_XML = os.path.join(TEST_ASSET_DIR, "subscription_create.xml")
 GET_XML = os.path.join(TEST_ASSET_DIR, "subscription_get.xml")
 GET_XML_BY_ID = os.path.join(TEST_ASSET_DIR, "subscription_get_by_id.xml")
 
@@ -48,3 +49,26 @@ class SubscriptionTests(unittest.TestCase):
         self.assertEqual('c0d5fc44-ad8c-4957-bec0-b70ed0f8df1e', subscription.user_id)
         self.assertEqual('Not Found Alert', subscription.subject)
         self.assertEqual('7617c389-cdca-4940-a66e-69956fcebf3e', subscription.schedule_id)
+
+    def test_create_subscription(self):
+        with open(CREATE_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl, text=response_xml)
+
+            target_item = TSC.Target("960e61f2-1838-40b2-bba2-340c9492f943", "workbook")
+            new_subscription = TSC.SubscriptionItem("subject", "4906c453-d5ec-4972-9ff4-789b629bdfa2",
+                                                    "8d30c8de-0a5f-4bee-b266-c621b4f3eed0", target_item)
+            new_subscription = self.server.subscriptions.create(new_subscription)
+
+        self.assertEqual("78e9318d-2d29-4d67-b60f-3f2f5fd89ecc", new_subscription.id)
+        self.assertEqual("sub_name", new_subscription.subject)
+        self.assertEqual("960e61f2-1838-40b2-bba2-340c9492f943", new_subscription.target.id)
+        self.assertEqual("Workbook", new_subscription.target.type)
+        self.assertEqual("4906c453-d5ec-4972-9ff4-789b629bdfa2", new_subscription.schedule_id)
+        self.assertEqual("8d30c8de-0a5f-4bee-b266-c621b4f3eed0", new_subscription.user_id)
+
+    def test_delete_subscription(self):
+        with requests_mock.mock() as m:
+            m.delete(self.baseurl + '/78e9318d-2d29-4d67-b60f-3f2f5fd89ecc', status_code=204)
+            self.server.subscriptions.delete('78e9318d-2d29-4d67-b60f-3f2f5fd89ecc')


### PR DESCRIPTION
Target object has been created to represent either a "View" or a "Workbook" when creating a subscription. But the object was not accessible by clients because of missing import statements.