### PR TITLE
View docs

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -3169,7 +3169,7 @@ This endpoint is available with REST API version 2.5 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution. See [ImageRequestOptions class](#imagerequestoptions-class)
+`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution. See [ImageRequestOptions class](#imagerequestoptions-class) for more details.
 
 **Exceptions**
 
@@ -3242,7 +3242,7 @@ This endpoint is available with REST API version 2.7 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation. See [PDFRequestOptions class](#pdfrequestoptions-class)
+`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation. See [PDFRequestOptions class](#pdfrequestoptions-class) for more details.
 
 **Exceptions**
 

--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -1540,23 +1540,48 @@ Name  |  Description
 `Asc` | Sets the sort direction to ascending (`TSC.RequestOptions.Direction.Asc`)
 `Desc`  |  Sets the sort direction to descending (`TSC.RequestOptions.Direction.Desc`). 
 
+<br>
+<br>
 
+### CSVRequestOptions class
+
+```py
+CSVRequestOptions()
+```
+Use this class to specify view filters to be applied when the CSV data is generated. See `views.populate_csv`.
+
+**Example**
+
+```py
+# import tableauserverclient as TSC
+# server = TSC.Server('http://MY-SERVER')
+# sign in, get a specific view, etc.
+
+# set view filters
+csv_req_option = TSC.CSVRequestOptions()
+csv_req_option.vf('Region', 'South')
+csv_req_option.vf('Category', 'Furniture')
+
+# retrieve the csv data for the view
+server.views.populate_csv(view_item, csv_req_option)
+```
 
 ### ImageRequestOptions class
 
 ```py  
 ImageRequestOptions(imageresolution=None)
-
 ```
-Use this class to specify the resolution of the view returned as an image. See `views.populate_view`. 
+Use this class to specify the resolution of the view returned as an image. You can also use this class to specify view filters to be applied when the image is generated. See `views.populate_image`. 
 
 **Attributes**
 
 Name  |  Description  
 :--- | :---  
-`imageresolution` | The resolution of the view returned as an image. You set this option with the `Resolution` class. If unspecified, the `views.populate_view` method returns an image with standard resolution (the width of the returned image is 784 pixels). If you set this parameter value to high (`Resolution.High`), the width of the returned image is 1568 pixels. For both resolutions, the height varies to preserve the aspect ratio of the view.
+`imageresolution` | The resolution of the view returned as an image. You set this option with the `Resolution` class. If unspecified, the `views.populate_image` method returns an image with standard resolution (the width of the returned image is 784 pixels). If you set this parameter value to high (`Resolution.High`), the width of the returned image is 1568 pixels. For both resolutions, the height varies to preserve the aspect ratio of the view.
 
+**View Filters**
 
+You can use the `vf('filter_name', 'filter_value')` method to add view filters. When the image is generated, the specified filters will be applied to the view.
 
 **Example**
 
@@ -1568,6 +1593,9 @@ Name  |  Description
 # set the image request option 
 image_req_option = TSC.ImageRequestOptions(imageresolution=TSC.ImageRequestOptions.Resolution.High)
 
+# (optional) set a view filter
+image_req_option.vf('Category', 'Furniture')
+
 # retrieve the image for the view
 server.views.populate_image(view_item, image_req_option)
 
@@ -1577,7 +1605,6 @@ server.views.populate_image(view_item, image_req_option)
 
 ```py  
 PDFRequestOptions(page_type=None, orientation=None)
-
 ```
 Use this class to specify the format of the PDF that is returned for the view. See `views.populate_pdf`. 
 
@@ -1588,6 +1615,8 @@ Name  |  Description
 `page_type` | The type of page returned in PDF format for the view. The page_type is set using the `PageType` class: <br> `PageType.A3`<br> `PageType.A4`<br> `PageType.A5`<br> `PageType.B5`<br> `PageType.Executive`<br> `PageType.Folio`<br>  `PageType.Ledger`<br> `PageType.Legal`<br> `PageType.Letter`<br> `PageType.Note`<br> `PageType.Quarto`<br> `PageType.Tabloid`
 `orientation` | The orientation of the page. The options are portrait and landscape. The options are set using the `Orientation` class: <br>`Orientation.Portrait`<br> `Orientation.Landscape`
 
+**View Filters**
+You can use the `vf('filter_name', 'filter_value')` method to add view filters. When the PDF is generated, the specified filters will be applied to the view.
 
 **Example**
 
@@ -1598,6 +1627,9 @@ Name  |  Description
 
 # set the PDF request options
 pdf_req_option = TSC.PDFRequestOptions(page_type=TSC.PDFRequestOptions.PageType.A4, orientation=TSC.PDFRequestOptions.Orientation.Landscape)
+
+# (optional) set a view filter
+pdf_req_option.vf('Region', 'West')
 
 # retrieve the PDF for a view
 server.views.populate_pdf(view_item, pdf_req_option)
@@ -3138,10 +3170,19 @@ Error | Description
 `View item missing ID or workbook ID` |  Raises an error if the ID of the view or workbook is missing.
 
 
-
 **Returns**
 
 None. The preview image is added to `view_item` and can be accessed by its `preview_image` field.
+
+**Example**
+```py
+# Sign in, get view, etc.
+
+# Populate and save the preview image as 'view_preview_image.png'
+server.views.populate_preview_image(view_item)
+with open('./view_preview_image.png', 'wb') as f:
+	f.write(view_item.preview_image)
+```
 
 See [ViewItem class](#viewitem-class)
 
@@ -3169,7 +3210,7 @@ This endpoint is available with REST API version 2.5 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution. See [ImageRequestOptions class](#imagerequestoptions-class) for more details.
+`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution. You can also specify view filters to be applied when the image is generated. See [ImageRequestOptions class](#imagerequestoptions-class) for more details.
 
 **Exceptions**
 
@@ -3180,6 +3221,16 @@ Error | Description
 **Returns**
 
 None. The image is added to the `view_item` and can be accessed by its `image` field.
+
+**Example**
+```py
+# Sign in, get view, etc.
+
+# Populate and save the view image as 'view_image.png'
+server.views.populate_image(view_item)
+with open('./view_image.png', 'wb') as f:
+	f.write(view_item.image)
+```
 
 See [ViewItem class](#viewitem-class)
 
@@ -3206,6 +3257,7 @@ This endpoint is available with REST API version 2.7 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
+`req_options` | (Optional) You can pass in a request object to specify view filters to be applied when the CSV data is generated. See [CSVRequestOptions class](#csvrequestoptions-class) for more details.
 
 **Exceptions**
 
@@ -3216,6 +3268,17 @@ Error | Description
 **Returns**
 
 None. The CSV data is added to the `view_item` and can be accessed by its `csv` field.
+
+**Example**
+```py
+# Sign in, get view, etc.
+
+# Populate and save the CSV data as 'view_csv.csv'
+server.views.populate_csv(view_item)
+with open('./view_csv.csv', 'wb') as f:
+	# Perform byte join on the CSV data
+	f.write(b''.join(view_item.csv))
+```
 
 See [ViewItem class](#viewitem-class)
 
@@ -3242,7 +3305,7 @@ This endpoint is available with REST API version 2.7 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation. See [PDFRequestOptions class](#pdfrequestoptions-class) for more details.
+`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation. You can also specify view filters to be applied when the PDF is generated. See [PDFRequestOptions class](#pdfrequestoptions-class) for more details.
 
 **Exceptions**
 
@@ -3253,6 +3316,16 @@ Error | Description
 **Returns**
 
 None. The PDF content is added to the `view_item` and can be accessed by its `pdf` field.
+
+**Example**
+```py
+# Sign in, get view, etc.
+
+# Populate and save the view pdf as 'view_pdf.pdf'
+server.views.populate_pdf(view_item)
+with open('./view_pdf.pdf', 'wb') as f:
+	f.write(view_item.pdf)
+```
 
 See [ViewItem class](#viewitem-class)
 

--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -3030,13 +3030,13 @@ Source file: models/view_item.py
 Name | Description
 :--- | :---  
 `content_url` | The name of the view as it would appear in a URL.
-`csv` | The CSV data of the view. You must first call the [views.populate_csv](#views.populate_csv) method to access the CSV data.
+`csv` | The CSV data of the view. You must first call the `views.populate_csv` method to access the CSV data.
 `id` | The identifier of the view item.  
-`image` | The image of the view. You must first call the [views.populate_image](#views.populate_image) method to access the image.
+`image` | The image of the view. You must first call the `views.populate_image`method to access the image.
 `name`  | The name of the view.
 `owner_id` |  The ID for the owner of the view.
-`pdf` | The PDF of the view. You must first call the [views.populate_pdf](#views.populate_pdf) method to access the PDF content.
-`preview_image` | The thumbnail image for the view. You must first call the [views.populate_preview_image](#views.populate_preview_image) method to access the preview image.
+`pdf` | The PDF of the view. You must first call the `views.populate_pdf` method to access the PDF content.
+`preview_image` | The thumbnail image for the view. You must first call the `views.populate_preview_image` method to access the preview image.
 `project_id` | The ID of the project that contains the view.
 `total_views`  |  The usage statistics for the view. Indicates the total number of times the view has been looked at.
 `workbook_id`  |  The ID of the workbook associated with the view.
@@ -3128,7 +3128,7 @@ This endpoint is available with REST API version 2.0 and up.
 
 Name | Description  
 :--- | :---  
-`view_item`  |  Specified the view to populate.
+`view_item`  |  Specifies the view to populate.
 
 
 **Exceptions**
@@ -3169,7 +3169,7 @@ This endpoint is available with REST API version 2.5 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution.
+`req_options` | (Optional) You can pass in a request object to specify a high resolution image. By default, the image will be in low resolution. See [ImageRequestOptions class](#imagerequestoptions-class)
 
 **Exceptions**
 
@@ -3180,14 +3180,6 @@ Error | Description
 **Returns**
 
 None. The image is added to the `view_item` and can be accessed by its `image` field.
-
-**Example**
-
-Creating a request option for high resolution image:
-```py
-req_options = TSC.ImageRequestOptions(imageresolution=TSC.ImageRequestOptions.Resolution.High)
-server.views.populate_image(view_item, req_options=req_options)
-```
 
 See [ViewItem class](#viewitem-class)
 
@@ -3250,7 +3242,7 @@ This endpoint is available with REST API version 2.7 and up.
 Name | description
 :--- | :---
 `view_item` | Specifies the view to populate.
-`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation.
+`req_options` | (Optional) You can pass in a request object to specify the page type and orientation of the PDF content. If not specified, PDF content will have default page type and orientation. See [PDFRequestOptions class](#pdfrequestoptions-class)
 
 **Exceptions**
 
@@ -3261,15 +3253,6 @@ Error | Description
 **Returns**
 
 None. The PDF content is added to the `view_item` and can be accessed by its `pdf` field.
-
-**Example**
-
-Creating a request option for page type and orientation:
-```py
-req_options = TSC.PDFRequestOptions(page_type=TSC.PDFRequestOptions.PageType.A5,
-                                    orientation=TSC.PDFRequestOptions.Orientation.Landscape)
-server.views.populate_pdf(view_item, req_options=req_options)                          
-```
 
 See [ViewItem class](#viewitem-class)
 


### PR DESCRIPTION
Docs on views were a bit outdated. Updated fields and added more methods. Also added information about view filters for CSVRequestOptions, ImageRequestOptions, and PDFRequestOptions.

Found some issues with the code itself while updating docs:
- No support for 'get_view_by_id', added version 3.1 (#388)
- The 'update' endpoint (add/delete tags) does not delete properly (#389)

Once the above issues are resolved, I will update the docs for them.