### PR TITLE
Adding SupportUser role to the list of possible site roles

### DIFF
--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -22,7 +22,9 @@ class UserItem(object):
         ReadOnly = 'ReadOnly'
         SiteAdministratorCreator = 'SiteAdministratorCreator'
         SiteAdministratorExplorer = 'SiteAdministratorExplorer'
-        UnlicensedWithPublish = 'UnlicensedWithPublish'
+
+        # Online only
+        SupportUser = 'SupportUser'
 
     class Auth:
         SAML = 'SAML'


### PR DESCRIPTION
Online sites have a "SupportUser" role that was not getting parsed properly by TSC. 