### PR TITLE
Updated REST API versions for Tableau Server 18.2 and 18.3

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -62,4 +62,5 @@ The current version of TSC only supports the following REST API and Tableau Serv
 |2.7|10.4|
 |2.8|10.5|
 |3.0|2018.1|
-
+|3.1|2018.2|
+|3.2|2018.3|


### PR DESCRIPTION
The API versions from 2018.2 and 2018.3 are taken from the [REST API XML Schema doc](https://onlinehelp.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_schema.htm):
- Version 3.2 (Tableau Server 2018.3): ts-api_3_2.xsd
- Version 3.1 (Tableau Server 2018.2): ts-api_3_1.xsd