### PR TITLE
Add parsing for embed_password field and allow updating value to false

### DIFF
--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -44,6 +44,7 @@ class ConnectionItem(object):
             connection_item = cls()
             connection_item._id = connection_xml.get('id', None)
             connection_item._connection_type = connection_xml.get('type', None)
+            connection_item.embed_password = string_to_bool(connection_xml.get('embedPassword', ''))
             connection_item.server_address = connection_xml.get('serverAddress', None)
             connection_item.server_port = connection_xml.get('serverPort', None)
             connection_item.username = connection_xml.get('userName', None)
@@ -82,3 +83,8 @@ class ConnectionItem(object):
                 connection_item.connection_credentials = ConnectionCredentials.from_xml_element(connection_credentials)
 
         return all_connection_items
+
+
+# Used to convert string represented boolean to a boolean type
+def string_to_bool(s):
+    return s.lower() == 'true'

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -422,8 +422,8 @@ class Connection(object):
             connection_element.attrib['userName'] = connection_item.username
         if connection_item.password:
             connection_element.attrib['password'] = connection_item.password
-        if connection_item.embed_password:
-            connection_element.attrib['embedPassword'] = str(connection_item.embed_password)
+        if connection_item.embed_password is not None:
+            connection_element.attrib['embedPassword'] = str(connection_item.embed_password).lower()
 
 
 class TaskRequest(object):

--- a/test/assets/datasource_populate_connections.xml
+++ b/test/assets/datasource_populate_connections.xml
@@ -1,8 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.8.xsd">
     <connections>
-        <connection id="be786ae0-d2bf-4a4b-9b34-e2de8d2d4488" type="textscan" serverAddress="" userName="" />
-        <connection id="970e24bc-e200-4841-a3e9-66e7d122d77e" type="sqlserver" serverAddress="database.com" userName="heero" />
-        <connection id="7d85b889-283b-42df-b23e-3c811e402f1f" type="textscan" serverAddress="forty-two.net" userName="duo" />
+        <connection id="be786ae0-d2bf-4a4b-9b34-e2de8d2d4488" type="textscan" serverAddress="forty-two.net" userName="duo" embedPassword="true"/>
+        <connection id="970e24bc-e200-4841-a3e9-66e7d122d77e" type="sqlserver" serverAddress="database.com" userName="heero" embedPassword="false" />
     </connections>
 </tsResponse>

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -140,15 +140,21 @@ class DatasourceTests(unittest.TestCase):
             single_datasource.owner_id = 'dd2239f6-ddf1-4107-981a-4cf94e415794'
             single_datasource._id = '9dbd2263-16b5-46e1-9c43-a76bb8ab65fb'
             self.server.datasources.populate_connections(single_datasource)
-
             self.assertEqual('9dbd2263-16b5-46e1-9c43-a76bb8ab65fb', single_datasource.id)
-
             connections = single_datasource.connections
-            self.assertTrue(connections)
-            ds1, ds2, ds3 = connections
-            self.assertEqual(ds1.id, 'be786ae0-d2bf-4a4b-9b34-e2de8d2d4488')
-            self.assertEqual(ds2.id, '970e24bc-e200-4841-a3e9-66e7d122d77e')
-            self.assertEqual(ds3.id, '7d85b889-283b-42df-b23e-3c811e402f1f')
+
+        self.assertTrue(connections)
+        ds1, ds2 = connections
+        self.assertEqual('be786ae0-d2bf-4a4b-9b34-e2de8d2d4488', ds1.id)
+        self.assertEqual('textscan', ds1.connection_type)
+        self.assertEqual('forty-two.net', ds1.server_address)
+        self.assertEqual('duo', ds1.username)
+        self.assertEqual(True, ds1.embed_password)
+        self.assertEqual('970e24bc-e200-4841-a3e9-66e7d122d77e', ds2.id)
+        self.assertEqual('sqlserver', ds2.connection_type)
+        self.assertEqual('database.com', ds2.server_address)
+        self.assertEqual('heero', ds2.username)
+        self.assertEqual(False, ds2.embed_password)
 
     def test_update_connection(self):
         populate_xml, response_xml = read_xml_assets(POPULATE_CONNECTIONS_XML, UPDATE_CONNECTION_XML)


### PR DESCRIPTION
Added proper parsing of the 'embed_password' field of ConnectionItem.
Also added a fix to allow 'embed_password' field to be updated correctly with the update datasource connection endpoint.