### PR TITLE
Permissions Support 2.0

### DIFF
--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -3,7 +3,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem,\
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError,\
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem,\
-    SubscriptionItem, Target, ExplicitPermissions, PermissionsRule, Permission
+    SubscriptionItem, Target, PermissionsRule, Permission
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -3,7 +3,7 @@ from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem, \
     SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
-    SubscriptionItem, Target
+    SubscriptionItem, Target, PermissionsItem, Permission, CapabilityItem
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -1,9 +1,9 @@
 from .namespace import NEW_NAMESPACE as DEFAULT_NAMESPACE
 from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
-    GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem, \
-    SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
-    HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
-    SubscriptionItem, Target, PermissionsItem, Permission, CapabilityItem
+    GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem,\
+    SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError,\
+    HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem,\
+    SubscriptionItem, Target, ExplicitPermissions, PermissionsRule, Permission
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \
     Server, ServerResponseError, MissingRequiredFieldError, NotSignedInError, Pager
 from ._version import get_versions

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -17,3 +17,4 @@ from .user_item import UserItem
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 from .subscription_item import SubscriptionItem
+from .permissions_item import Permission, PermissionsItem, CapabilityItem

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -2,7 +2,7 @@ from .connection_credentials import ConnectionCredentials
 from .connection_item import ConnectionItem
 from .datasource_item import DatasourceItem
 from .exceptions import UnpopulatedPropertyError
-from .group_item import GroupItem, GranteeGroup
+from .group_item import GroupItem
 from .interval_item import IntervalItem, DailyInterval, WeeklyInterval, MonthlyInterval, HourlyInterval
 from .job_item import JobItem, BackgroundJobItem
 from .pagination_item import PaginationItem
@@ -13,7 +13,7 @@ from .site_item import SiteItem
 from .tableau_auth import TableauAuth
 from .target import Target
 from .task_item import TaskItem
-from .user_item import UserItem, GranteeUser
+from .user_item import UserItem
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 from .subscription_item import SubscriptionItem

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -2,7 +2,7 @@ from .connection_credentials import ConnectionCredentials
 from .connection_item import ConnectionItem
 from .datasource_item import DatasourceItem
 from .exceptions import UnpopulatedPropertyError
-from .group_item import GroupItem
+from .group_item import GroupItem, GranteeGroup
 from .interval_item import IntervalItem, DailyInterval, WeeklyInterval, MonthlyInterval, HourlyInterval
 from .job_item import JobItem, BackgroundJobItem
 from .pagination_item import PaginationItem
@@ -13,8 +13,8 @@ from .site_item import SiteItem
 from .tableau_auth import TableauAuth
 from .target import Target
 from .task_item import TaskItem
-from .user_item import UserItem
+from .user_item import UserItem, GranteeUser
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 from .subscription_item import SubscriptionItem
-from .permissions_item import Permission, PermissionsItem, CapabilityItem
+from .permissions_item import ExplicitPermissions, PermissionsRule, Permission

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -17,4 +17,4 @@ from .user_item import UserItem
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 from .subscription_item import SubscriptionItem
-from .permissions_item import ExplicitPermissions, PermissionsRule, Permission
+from .permissions_item import PermissionsRule, Permission

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -23,12 +23,21 @@ class DatasourceItem(object):
         self.project_id = project_id
         self.tags = set()
 
+        self._permissions = None
+
     @property
     def connections(self):
         if self._connections is None:
             error = 'Datasource item must be populated with connections first.'
             raise UnpopulatedPropertyError(error)
         return self._connections()
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @property
     def content_url(self):
@@ -83,6 +92,9 @@ class DatasourceItem(object):
 
     def _set_connections(self, connections):
         self._connections = connections
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     def _parse_common_elements(self, datasource_xml, ns):
         if not isinstance(datasource_xml, ET.Element):

--- a/tableauserverclient/models/exceptions.py
+++ b/tableauserverclient/models/exceptions.py
@@ -1,2 +1,6 @@
 class UnpopulatedPropertyError(Exception):
     pass
+
+
+class UnknownGranteeTypeError(Exception):
+    pass

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -61,8 +61,16 @@ class GroupItem(object):
             all_group_items.append(group_item)
         return all_group_items
 
+    @staticmethod
+    def for_permissions(id_):
+        return GranteeGroup(id_)
+
 
 class GranteeGroup(GroupItem):
+    """Reduced version of the GroupItem class that lets you
+    build Group objects with only an ID. Necessary for Groups returned
+    from Permissions requests, and a shortcut for creating permissions.
+    """
 
     def __init__(self, id_):
         self.id = id_

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -67,18 +67,10 @@ class GranteeGroup(GroupItem):
     def __init__(self, id_):
         self.id = id_
 
-    @property
-    def id(self):
-        return self._id
-
-    @id.setter
+    @GroupItem.id.setter
     def id(self, value):
         self._id = value
 
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
+    @GroupItem.name.setter
     def name(self, value):
         self._name = value

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -3,8 +3,6 @@ from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_empty
 
 
-    
-
 class GroupItem(object):
 
     permissions_grantee_type = 'group'
@@ -62,6 +60,7 @@ class GroupItem(object):
                 group_item._domain_name = domain_elem.get('name', None)
             all_group_items.append(group_item)
         return all_group_items
+
 
 class GranteeGroup(GroupItem):
 

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -1,11 +1,12 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_empty
+from .reference_item import ResourceReference
 
 
 class GroupItem(object):
 
-    permissions_grantee_type = 'group'
+    tag_name = 'group'
 
     def __init__(self, name=None):
         self._domain_name = None
@@ -38,6 +39,9 @@ class GroupItem(object):
         #  Each call to `.users` should create a new pager, this just runs the callable
         return self._users()
 
+    def to_reference(self):
+        return ResourceReference(id_=self.id, tag_name=self.tag_name)
+
     def _set_users(self, users):
         self._users = users
 
@@ -58,23 +62,5 @@ class GroupItem(object):
         return all_group_items
 
     @staticmethod
-    def for_permissions(id_):
-        return GranteeGroup(id_)
-
-
-class GranteeGroup(GroupItem):
-    """Reduced version of the GroupItem class that lets you
-    build Group objects with only an ID. Necessary for Groups returned
-    from Permissions requests, and a shortcut for creating permissions.
-    """
-
-    def __init__(self, id_):
-        self.id = id_
-
-    @GroupItem.id.setter
-    def id(self, value):
-        self._id = value
-
-    @GroupItem.name.setter
-    def name(self, value):
-        self._name = value
+    def as_reference(id_):
+        return ResourceReference(id_, GroupItem.tag_name)

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -21,10 +21,6 @@ class GroupItem(object):
     def id(self):
         return self._id
 
-    # @id.setter
-    # def id(self, value):
-    #     self._id = value
-
     @property
     def name(self):
         return self._name

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -3,8 +3,13 @@ from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_empty
 
 
+    
+
 class GroupItem(object):
-    def __init__(self, name):
+
+    permissions_grantee_type = 'group'
+
+    def __init__(self, name=None):
         self._domain_name = None
         self._id = None
         self._users = None
@@ -17,6 +22,10 @@ class GroupItem(object):
     @property
     def id(self):
         return self._id
+
+    # @id.setter
+    # def id(self, value):
+    #     self._id = value
 
     @property
     def name(self):
@@ -53,3 +62,24 @@ class GroupItem(object):
                 group_item._domain_name = domain_elem.get('name', None)
             all_group_items.append(group_item)
         return all_group_items
+
+class GranteeGroup(GroupItem):
+
+    def __init__(self, id_):
+        self.id = id_
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._id = value
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -61,20 +61,20 @@ class CapabilityItem(object):
         return self._object_id
 
 
-class PermissionsItem(object):
+class PermissionsRuleItem(object):
     def __init__(self):
-        self._capabilities = None
+        self._rules = None
 
-    def _set_values(self, capabilities):
-        self._capabilities = capabilities
+    def _set_values(self, rules):
+        self._rules = rules
 
     @property
-    def capabilities(self):
-        return self._capabilities
+    def rules(self):
+        return self._rules
 
     @classmethod
     def from_response(cls, resp, ns=None):
-        permissions = PermissionsItem()
+        permissions = PermissionsRuleItem()
         parsed_response = ET.fromstring(resp)
 
         capabilities = {}
@@ -118,3 +118,8 @@ class PermissionsItem(object):
 
         permissions._set_values(capabilities)
         return permissions
+
+
+## Compat Tests
+
+PermissionsItem = PermissionsRuleItem

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -33,9 +33,9 @@ class Permission:
         Write = 'Write'
 
     class Resource:
-        Workbooks = 'workbooks'
-        Datasources = 'datasources'
-        Flows = 'flows'
+        Workbook = 'workbook'
+        Datasource = 'datasource'
+        Flow = 'flow'
 
 
 class PermissionsRule(object):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree as ET
 import logging
 
 from .exceptions import UnknownGranteeTypeError
-from . import UserItem, GroupItem, GranteeGroup, GranteeUser
+from . import UserItem, GroupItem
 
 logger = logging.getLogger('tableau.models.permissions_item')
 
@@ -71,9 +71,9 @@ class ExplicitPermissions(object):
                 raise UnknownGranteeTypeError()
 
             if grantee_type == 'user':
-                grantee = GranteeUser(grantee_id)
+                grantee = UserItem.for_permissions(grantee_id)
             else:
-                grantee = GranteeGroup(grantee_id)
+                grantee = GroupItem.for_permissions(grantee_id)
 
             for capability_xml in grantee_capability_xml.findall(
                     './/t:capabilities/t:capability', namespaces=ns):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree as ET
 import logging
 
 from .exceptions import UnknownGranteeTypeError
-
+from . import UserItem, GroupItem, GranteeGroup, GranteeUser
 
 logger = logging.getLogger('tableau.models.permissions_item')
 
@@ -32,17 +32,15 @@ class Permission:
         Write = 'Write'
 
 
-from . import UserItem, GroupItem, GranteeGroup, GranteeUser
-
-
 class PermissionsRule(object):
 
     def __init__(self, grantee, capabilities):
         self.grantee = grantee
         self.capabilities = capabilities
 
+
 class ExplicitPermissions(object):
-    def __init__(self, rules = None):
+    def __init__(self, rules=None):
         self._rules = rules
 
     def _set_values(self, rules):
@@ -59,7 +57,7 @@ class ExplicitPermissions(object):
 
         rules = []
         permissions_rules_list_xml = parsed_response.findall('.//t:granteeCapabilities',
-                                          namespaces=ns)
+                                                             namespaces=ns)
 
         for grantee_capability_xml in permissions_rules_list_xml:
             capability_dict = {}

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,0 +1,120 @@
+import xml.etree.ElementTree as ET
+import logging
+
+from .exceptions import UnknownGranteeTypeError
+
+
+logger = logging.getLogger('tableau.models.permissions_item')
+
+
+class Permission:
+    class GranteeType:
+        User = 'user'
+        Group = 'group'
+
+    class CapabilityMode:
+        Allow = 'Allow'
+        Deny = 'Deny'
+
+    class DatasourceCapabilityType:
+        ChangePermissions = 'ChangePermissions'
+        Connect = 'Connect'
+        Delete = 'Delete'
+        ExportXml = 'ExportXml'
+        Read = 'Read'
+        Write = 'Write'
+
+    class WorkbookCapabilityType:
+        AddComment = 'AddComment'
+        ChangeHierarchy = 'ChangeHierarchy'
+        ChangePermissions = 'ChangePermissions'
+        Delete = 'Delete'
+        ExportData = 'ExportData'
+        ExportImage = 'ExportImage'
+        ExportXml = 'ExportXml'
+        Filter = 'Filter'
+        Read = 'Read'
+        ShareView = 'ShareView'
+        ViewComments = 'ViewComments'
+        ViewUnderlyingData = 'ViewUnderlyingData'
+        WebAuthoring = 'WebAuthoring'
+        Write = 'Write'
+
+    class ProjectCapabilityType:
+        ProjectLeader = 'ProjectLeader'
+        Read = 'Read'
+        Write = 'Write'
+
+
+class CapabilityItem(object):
+    def __init__(self, type=None, object_id=None, map={}):
+        self._type = type
+        self._object_id = object_id
+        self.map = map
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def object_id(self):
+        return self._object_id
+
+
+class PermissionsItem(object):
+    def __init__(self):
+        self._capabilities = None
+
+    def _set_values(self, capabilities):
+        self._capabilities = capabilities
+
+    @property
+    def capabilities(self):
+        return self._capabilities
+
+    @classmethod
+    def from_response(cls, resp, ns=None):
+        permissions = PermissionsItem()
+        parsed_response = ET.fromstring(resp)
+
+        capabilities = {}
+        all_xml = parsed_response.findall('.//t:granteeCapabilities',
+                                          namespaces=ns)
+
+        for grantee_capability_xml in all_xml:
+            grantee_id = None
+            grantee_type = None
+            capability_map = {}
+
+            try:
+                grantee_id = grantee_capability_xml.find('.//t:group',
+                                                         namespaces=ns)\
+                                                    .get('id')
+                grantee_type = Permission.GranteeType.Group
+            except AttributeError:
+                pass
+            try:
+                grantee_id = grantee_capability_xml.find('.//t:user',
+                                                         namespaces=ns)\
+                                                    .get('id')
+                grantee_type = Permission.GranteeType.User
+            except AttributeError:
+                pass
+
+            if grantee_id is None:
+                logger.error('Cannot find grantee type in response')
+                raise UnknownGranteeTypeError()
+
+            for capability_xml in grantee_capability_xml.findall(
+                    './/t:capabilities/t:capability', namespaces=ns):
+                name = capability_xml.get('name')
+                mode = capability_xml.get('mode')
+
+                capability_map[name] = mode
+
+            capability_item = CapabilityItem(grantee_type, grantee_id,
+                                             capability_map)
+            capabilities[(grantee_type, grantee_id)] = capability_item
+
+        permissions._set_values(capabilities)
+        return permissions

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -49,7 +49,7 @@ class PermissionsRule(object):
         for grantee_capability_xml in permissions_rules_list_xml:
             capability_dict = {}
 
-            grantee = PermissionsRule._make_grantee_element(grantee_capability_xml, ns)
+            grantee = PermissionsRule._parse_grantee_element(grantee_capability_xml, ns)
 
             for capability_xml in grantee_capability_xml.findall(
                     './/t:capabilities/t:capability', namespaces=ns):
@@ -65,7 +65,7 @@ class PermissionsRule(object):
         return rules
 
     @staticmethod
-    def _make_grantee_element(grantee_capability_xml, ns):
+    def _parse_grantee_element(grantee_capability_xml, ns):
         """Use Xpath magic and some string splitting to get the right object type from the xml"""
 
         # Get the first element in the tree with an 'id' attribute

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -32,29 +32,18 @@ class Permission:
         Write = 'Write'
 
 
-from typing import Union, List, Dict
 from . import UserItem, GroupItem, GranteeGroup, GranteeUser
 
 
 class PermissionsRule(object):
 
-    def __init__(self,
-                 grantee: Union[GroupItem, UserItem], 
-                 capabilities: Dict[Permission.Capability, Permission.Mode], 
-                 *, 
-                 grantee_id: str = None,
-                 grantee_type: str = None
-        ):
-        
-        if grantee_id is not None and grantee_type is not None:
-            raise Exception("Come back to me later")
-
+    def __init__(self, grantee, capabilities):
         self.grantee = grantee
         self.capabilities = capabilities
 
 class ExplicitPermissions(object):
-    def __init__(self):
-        self._rules: List[PermissionsRule] = None
+    def __init__(self, rules = None):
+        self._rules = rules
 
     def _set_values(self, rules):
         self._rules = rules

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -38,21 +38,8 @@ class PermissionsRule(object):
         self.grantee = grantee
         self.capabilities = capabilities
 
-
-class ExplicitPermissions(object):
-    def __init__(self, rules=None):
-        self._rules = rules
-
-    def _set_values(self, rules):
-        self._rules = rules
-
-    @property
-    def rules(self):
-        return self._rules
-
     @classmethod
     def from_response(cls, resp, ns=None):
-        permissions = ExplicitPermissions()
         parsed_response = ET.fromstring(resp)
 
         rules = []
@@ -62,7 +49,7 @@ class ExplicitPermissions(object):
         for grantee_capability_xml in permissions_rules_list_xml:
             capability_dict = {}
 
-            grantee = ExplicitPermissions._make_grantee_element(grantee_capability_xml, ns)
+            grantee = PermissionsRule._make_grantee_element(grantee_capability_xml, ns)
 
             for capability_xml in grantee_capability_xml.findall(
                     './/t:capabilities/t:capability', namespaces=ns):
@@ -75,8 +62,7 @@ class ExplicitPermissions(object):
                                    capability_dict)
             rules.append(rule)
 
-        permissions._set_values(rules)
-        return permissions
+        return rules
 
     @staticmethod
     def _make_grantee_element(grantee_capability_xml, ns):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -2,7 +2,8 @@ import xml.etree.ElementTree as ET
 import logging
 
 from .exceptions import UnknownGranteeTypeError
-from . import UserItem, GroupItem
+from .user_item import UserItem
+from .group_item import GroupItem
 
 logger = logging.getLogger('tableau.models.permissions_item')
 
@@ -30,6 +31,11 @@ class Permission:
         ViewUnderlyingData = 'ViewUnderlyingData'
         WebAuthoring = 'WebAuthoring'
         Write = 'Write'
+
+    class Resource:
+        Workbooks = 'workbooks'
+        Datasources = 'datasources'
+        Flows = 'flows'
 
 
 class PermissionsRule(object):
@@ -78,9 +84,9 @@ class PermissionsRule(object):
             raise UnknownGranteeTypeError()
 
         if grantee_type == 'user':
-            grantee = UserItem.for_permissions(grantee_id)
+            grantee = UserItem.as_reference(grantee_id)
         elif grantee_type == 'group':
-            grantee = GroupItem.for_permissions(grantee_id)
+            grantee = GroupItem.as_reference(grantee_id)
         else:
             raise UnknownGranteeTypeError("No support for grantee type of {}".format(grantee_type))
 

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -17,6 +17,9 @@ class ProjectItem(object):
         self.parent_id = parent_id
 
         self._permissions = None
+        self._default_permissions_workbooks = None
+        self._default_permissions_datasources = None
+        self._default_permissions_flows = None
 
     @property
     def content_permissions(self):
@@ -73,6 +76,14 @@ class ProjectItem(object):
 
     def _set_permissions(self, permissions):
         self._permissions = permissions
+
+    def _set_default_permissions(self, permissions, content_type):
+        if content_type == "workbooks" or "workbook":
+            self._default_permissions_workbooks = permissions
+        if content_type == "datasources" or "datasource":
+            self._default_permissions_datasources = permissions
+        if content_type == "flows" or "flow":
+            self._default_permissions_flows = permissions
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -99,11 +99,11 @@ class ProjectItem(object):
         self._permissions = permissions
 
     def _set_default_permissions(self, permissions, content_type):
-        if content_type == "workbooks" or "workbook":
+        if content_type in ("workbooks", "workbook"):
             self._default_workbook_permissions = permissions
-        if content_type == "datasources" or "datasource":
+        if content_type in ("datasources", "datasource"):
             self._default_datasource_permissions = permissions
-        if content_type == "flows" or "flow":
+        if content_type in ("flows", "flow"):
             self._default_flow_permissions = permissions
 
     @classmethod

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -17,9 +17,9 @@ class ProjectItem(object):
         self.parent_id = parent_id
 
         self._permissions = None
-        self._default_permissions_workbooks = None
-        self._default_permissions_datasources = None
-        self._default_permissions_flows = None
+        self._default_workbook_permissions = None
+        self._default_datasource_permissions = None
+        self._default_flow_permissions = None
 
     @property
     def content_permissions(self):
@@ -31,6 +31,27 @@ class ProjectItem(object):
             error = "Project item must be populated with permissions first."
             raise UnpopulatedPropertyError(error)
         return self._permissions()
+
+    @property
+    def default_datasource_permissions(self):
+        if self._default_datasource_permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._default_datasource_permissions()
+
+    @property
+    def default_workbook_permissions(self):
+        if self._default_workbook_permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._default_workbook_permissions()
+
+    @property
+    def default_flow_permissions(self):
+        if self._default_flow_permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._default_flow_permissions()
 
     @content_permissions.setter
     @property_is_enum(ContentPermissions)
@@ -79,11 +100,11 @@ class ProjectItem(object):
 
     def _set_default_permissions(self, permissions, content_type):
         if content_type == "workbooks" or "workbook":
-            self._default_permissions_workbooks = permissions
+            self._default_workbook_permissions = permissions
         if content_type == "datasources" or "datasource":
-            self._default_permissions_datasources = permissions
+            self._default_datasource_permissions = permissions
         if content_type == "flows" or "flow":
-            self._default_permissions_flows = permissions
+            self._default_flow_permissions = permissions
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,4 +1,7 @@
 import xml.etree.ElementTree as ET
+
+from .permissions_item import Permission
+
 from .property_decorators import property_is_enum, property_not_empty
 from .exceptions import UnpopulatedPropertyError
 
@@ -99,6 +102,7 @@ class ProjectItem(object):
         self._permissions = permissions
 
     def _set_default_permissions(self, permissions, content_type):
+        {}
         if content_type in ("workbooks", "workbook"):
             self._default_workbook_permissions = permissions
         if content_type in ("datasources", "datasource"):

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,5 +1,6 @@
 import xml.etree.ElementTree as ET
 from .property_decorators import property_is_enum, property_not_empty
+from .exceptions import UnpopulatedPropertyError
 
 
 class ProjectItem(object):
@@ -15,9 +16,18 @@ class ProjectItem(object):
         self.content_permissions = content_permissions
         self.parent_id = parent_id
 
+        self._permissions = None
+
     @property
     def content_permissions(self):
         return self._content_permissions
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @content_permissions.setter
     @property_is_enum(ContentPermissions)
@@ -60,6 +70,9 @@ class ProjectItem(object):
             self._content_permissions = content_permissions
         if parent_id:
             self.parent_id = parent_id
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -102,13 +102,7 @@ class ProjectItem(object):
         self._permissions = permissions
 
     def _set_default_permissions(self, permissions, content_type):
-        {}
-        if content_type in ("workbooks", "workbook"):
-            self._default_workbook_permissions = permissions
-        if content_type in ("datasources", "datasource"):
-            self._default_datasource_permissions = permissions
-        if content_type in ("flows", "flow"):
-            self._default_flow_permissions = permissions
+        setattr(self, "_default_{content}_permissions".format(content=content_type), permissions)
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/reference_item.py
+++ b/tableauserverclient/models/reference_item.py
@@ -1,0 +1,21 @@
+class ResourceReference(object):
+
+    def __init__(self, id_, tag_name):
+        self.id = id_
+        self.tag_name = tag_name
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._id = value
+
+    @property
+    def tag_name(self):
+        return self._tag_name
+
+    @tag_name.setter
+    def tag_name(self, value):
+        self._tag_name = value

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -5,6 +5,9 @@ from ..datetime_helpers import parse_datetime
 
 
 class UserItem(object):
+
+    permissions_grantee_type = 'user'
+
     class Roles:
         Interactor = 'Interactor'
         Publisher = 'Publisher'
@@ -30,7 +33,7 @@ class UserItem(object):
         SAML = 'SAML'
         ServerDefault = 'ServerDefault'
 
-    def __init__(self, name, site_role, auth_setting=None):
+    def __init__(self, name=None, site_role=None, auth_setting=None):
         self._auth_setting = None
         self._domain_name = None
         self._external_auth_user_id = None
@@ -160,3 +163,32 @@ class UserItem(object):
 
     def __repr__(self):
         return "<User {} name={} role={}>".format(self.id, self.name, self.site_role)
+
+class GranteeUser(UserItem):
+
+    def __init__(self, id_):
+        self.id = id_
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._id = value
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def site_role(self):
+        return self._site_role
+
+    @site_role.setter
+    def site_role(self, value):
+        self._site_role = value

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -164,6 +164,7 @@ class UserItem(object):
     def __repr__(self):
         return "<User {} name={} role={}>".format(self.id, self.name, self.site_role)
 
+
 class GranteeUser(UserItem):
 
     def __init__(self, id_):

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -144,6 +144,10 @@ class UserItem(object):
         return all_user_items
 
     @staticmethod
+    def for_permissions(id_):
+        return GranteeUser(id_)
+
+    @staticmethod
     def _parse_element(user_xml, ns):
         id = user_xml.get('id', None)
         name = user_xml.get('name', None)
@@ -166,6 +170,10 @@ class UserItem(object):
 
 
 class GranteeUser(UserItem):
+    """Reduced version of the UserItem class that lets you
+    build User objects with only an ID. Necessary for Users returned
+    from Permissions requests, and a shortcut for creating permissions.
+    """
 
     def __init__(self, id_):
         self.id = id_

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -2,11 +2,12 @@ import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_is_enum, property_not_empty, property_not_nullable
 from ..datetime_helpers import parse_datetime
+from .reference_item import ResourceReference
 
 
 class UserItem(object):
 
-    permissions_grantee_type = 'user'
+    tag_name = 'user'
 
     class Roles:
         Interactor = 'Interactor'
@@ -97,6 +98,9 @@ class UserItem(object):
             raise UnpopulatedPropertyError(error)
         return self._workbooks()
 
+    def to_reference(self):
+        return ResourceReference(id_=self.id, tag_name=self.tag_name)
+
     def _set_workbooks(self, workbooks):
         self._workbooks = workbooks
 
@@ -144,8 +148,8 @@ class UserItem(object):
         return all_user_items
 
     @staticmethod
-    def for_permissions(id_):
-        return GranteeUser(id_)
+    def as_reference(id_):
+        return ResourceReference(id_, UserItem.tag_name)
 
     @staticmethod
     def _parse_element(user_xml, ns):
@@ -167,25 +171,3 @@ class UserItem(object):
 
     def __repr__(self):
         return "<User {} name={} role={}>".format(self.id, self.name, self.site_role)
-
-
-class GranteeUser(UserItem):
-    """Reduced version of the UserItem class that lets you
-    build User objects with only an ID. Necessary for Users returned
-    from Permissions requests, and a shortcut for creating permissions.
-    """
-
-    def __init__(self, id_):
-        self.id = id_
-
-    @UserItem.id.setter
-    def id(self, value):
-        self._id = value
-
-    @UserItem.name.setter
-    def name(self, value):
-        self._name = value
-
-    @UserItem.site_role.setter
-    def site_role(self, value):
-        self._site_role = value

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -170,26 +170,14 @@ class GranteeUser(UserItem):
     def __init__(self, id_):
         self.id = id_
 
-    @property
-    def id(self):
-        return self._id
-
-    @id.setter
+    @UserItem.id.setter
     def id(self, value):
         self._id = value
 
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
+    @UserItem.name.setter
     def name(self, value):
         self._name = value
 
-    @property
-    def site_role(self):
-        return self._site_role
-
-    @site_role.setter
+    @UserItem.site_role.setter
     def site_role(self, value):
         self._site_role = value

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -3,7 +3,7 @@ from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_nullable, property_is_boolean, property_is_materialized_views_config
 from .tag_item import TagItem
 from .view_item import ViewItem
-from .permissions_item import PermissionsItem
+from .permissions_item import PermissionsRule
 from ..datetime_helpers import parse_datetime
 import copy
 

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -3,6 +3,7 @@ from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_nullable, property_is_boolean, property_is_materialized_views_config
 from .tag_item import TagItem
 from .view_item import ViewItem
+from .permissions_item import PermissionsItem
 from ..datetime_helpers import parse_datetime
 import copy
 
@@ -27,6 +28,7 @@ class WorkbookItem(object):
         self.tags = set()
         self.materialized_views_config = {'materialized_views_enabled': None,
                                           'run_materialization_now': None}
+        self._permissions = None
 
     @property
     def connections(self):
@@ -34,6 +36,13 @@ class WorkbookItem(object):
             error = "Workbook item must be populated with connections first."
             raise UnpopulatedPropertyError(error)
         return self._connections()
+
+    @property
+    def permissions(self):
+        if self._permissions is None:
+            error = "Workbook item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._permissions()
 
     @property
     def content_url(self):
@@ -119,6 +128,9 @@ class WorkbookItem(object):
 
     def _set_connections(self, connections):
         self._connections = connections
+
+    def _set_permissions(self, permissions):
+        self._permissions = permissions
 
     def _set_views(self, views):
         self._views = views

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -4,7 +4,7 @@ from .filter import Filter
 from .sort import Sort
 from .. import ConnectionItem, DatasourceItem, JobItem, BackgroundJobItem, \
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, SiteItem, TableauAuth,\
-    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem
+    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsItem
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, Subscriptions, ServerResponseError, \
     MissingRequiredFieldError

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -4,7 +4,7 @@ from .filter import Filter
 from .sort import Sort
 from .. import ConnectionItem, DatasourceItem, JobItem, BackgroundJobItem, \
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, SiteItem, TableauAuth,\
-    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsRule
+    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsRule, Permission
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, Subscriptions, ServerResponseError, \
     MissingRequiredFieldError

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -4,7 +4,7 @@ from .filter import Filter
 from .sort import Sort
 from .. import ConnectionItem, DatasourceItem, JobItem, BackgroundJobItem, \
     GroupItem, PaginationItem, ProjectItem, ScheduleItem, SiteItem, TableauAuth,\
-    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsItem
+    UserItem, ViewItem, WorkbookItem, TaskItem, SubscriptionItem, PermissionsRule
 from .endpoint import Auth, Datasources, Endpoint, Groups, Projects, Schedules, \
     Sites, Users, Views, Workbooks, Subscriptions, ServerResponseError, \
     MissingRequiredFieldError

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -1,5 +1,8 @@
 from .endpoint import Endpoint, api, parameter_added_in
 from .exceptions import InternalServerError, MissingRequiredFieldError
+from .endpoint import api, parameter_added_in, Endpoint
+from .permissions_endpoint import _PermissionsEndpoint
+from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
 from .. import RequestFactory, DatasourceItem, PaginationItem, ConnectionItem
@@ -24,6 +27,7 @@ class Datasources(Endpoint):
     def __init__(self, parent_srv):
         super(Datasources, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
 
     @property
     def baseurl(self):
@@ -196,6 +200,7 @@ class Datasources(Endpoint):
                                                                               file_contents,
                                                                               connection_credentials,
                                                                               connections)
+<<<<<<< HEAD
 
         # Send the publishing request to server
         try:
@@ -213,3 +218,21 @@ class Datasources(Endpoint):
             new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]
             logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
             return new_datasource
+=======
+        server_response = self.post_request(url, xml_request, content_type)
+        new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]
+        logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
+        return new_datasource
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)
+>>>>>>> adding permissions support for workbook, datasource, project

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -200,7 +200,6 @@ class Datasources(Endpoint):
                                                                               file_contents,
                                                                               connection_credentials,
                                                                               connections)
-<<<<<<< HEAD
 
         # Send the publishing request to server
         try:
@@ -218,7 +217,6 @@ class Datasources(Endpoint):
             new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]
             logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
             return new_datasource
-=======
         server_response = self.post_request(url, xml_request, content_type)
         new_datasource = DatasourceItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Published {0} (ID: {1})'.format(filename, new_datasource.id))
@@ -235,4 +233,3 @@ class Datasources(Endpoint):
     @api(version='2.0')
     def delete_permission(self, item, capability_item):
         self._permissions.delete(item, capability_item)
->>>>>>> adding permissions support for workbook, datasource, project

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -38,7 +38,9 @@ class _DefaultPermissionsEndpoint(Endpoint):
 
     def delete_default_permission(self, resource, rule, content_type):
         for capability, mode in rule.capabilities.items():
-            url = '{baseurl}/{content_id}/default-permissions/{content_type}/{grantee_type}/{grantee_id}/{cap}/{mode}'.format(
+            # Made readibility better but line is too long, will make this look better
+            url = '{baseurl}/{content_id}/default-permissions/\
+                {content_type}/{grantee_type}/{grantee_id}/{cap}/{mode}'.format(
                 baseurl=self.owner_baseurl(),
                 content_id=resource.id,
                 content_type=content_type,
@@ -61,6 +63,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
         if not item.id:
             error = "Server item is missing ID. Item must be retrieved from server first."
             raise MissingRequiredFieldError(error)
+
         def permission_fetcher():
             return self._get_default_permissions(item, content_type)
 
@@ -71,6 +74,6 @@ class _DefaultPermissionsEndpoint(Endpoint):
         url = "{0}/{1}/default-permissions/{2}".format(self.owner_baseurl(), item.id, content_type)
         server_response = self.get_request(url, req_options)
         permissions = PermissionsRule.from_response(server_response.content,
-                                                        self.parent_srv.namespace)
+                                                    self.parent_srv.namespace)
 
         return permissions

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -30,22 +30,22 @@ class _DefaultPermissionsEndpoint(Endpoint):
         url = '{0}/{1}/default-permissions/{2}'.format(self.owner_baseurl(), resource.id, content_type)
         update_req = RequestFactory.Permission.add_req(permissions)
         response = self.put_request(url, update_req)
-        permissions = ExplicitPermissions.from_response(response.content,
-                                                        self.parent_srv.namespace)
+        permissions = PermissionsRule.from_response(response.content,
+                                                    self.parent_srv.namespace)
         logger.info('Updated permissions for resource {0}'.format(resource.id))
 
         return permissions
 
     def delete_default_permission(self, resource, rule, content_type):
         for capability, mode in rule.capabilities.items():
-            url = '{0}/{1}/default-permissions/{2}/{3}/{4}/{5}/{6}'.format(
-                self.owner_baseurl(),
-                resource.id,
-                content_type,
-                rule.grantee.permissions_grantee_type + 's',
-                rule.grantee.id,
-                capability,
-                mode)
+            url = '{baseurl}/{content_id}/default-permissions/{content_type}/{grantee_type}/{grantee_id}/{cap}/{mode}'.format(
+                baseurl=self.owner_baseurl(),
+                content_id=resource.id,
+                content_type=content_type,
+                grantee_type=rule.grantee.permissions_grantee_type + 's',
+                grantee_id=rule.grantee.id,
+                cap=capability,
+                mode=mode)
 
             logger.debug('Removing {0} permission for capabilty {1}'.format(
                 mode, capability))
@@ -61,7 +61,6 @@ class _DefaultPermissionsEndpoint(Endpoint):
         if not item.id:
             error = "Server item is missing ID. Item must be retrieved from server first."
             raise MissingRequiredFieldError(error)
-
         def permission_fetcher():
             return self._get_default_permissions(item, content_type)
 
@@ -71,7 +70,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
     def _get_default_permissions(self, item, content_type, req_options=None):
         url = "{0}/{1}/default-permissions/{2}".format(self.owner_baseurl(), item.id, content_type)
         server_response = self.get_request(url, req_options)
-        permissions = ExplicitPermissions.from_response(server_response.content,
+        permissions = PermissionsRule.from_response(server_response.content,
                                                         self.parent_srv.namespace)
 
         return permissions

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -1,7 +1,7 @@
 import logging
 
 from .. import RequestFactory
-from ...models import ExplicitPermissions, PermissionsRule
+from ...models import PermissionsRule
 
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -44,7 +44,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
                 baseurl=self.owner_baseurl(),
                 content_id=resource.id,
                 content_type=content_type,
-                grantee_type=rule.grantee.permissions_grantee_type + 's',
+                grantee_type=rule.grantee.tag_name + 's',
                 grantee_id=rule.grantee.id,
                 cap=capability,
                 mode=mode)
@@ -55,7 +55,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
             self.delete_request(url)
 
         logger.info('Deleted permission for {0} {1} item {2}'.format(
-            rule.grantee.permissions_grantee_type,
+            rule.grantee.tag_name,
             rule.grantee.id,
             resource.id))
 
@@ -71,7 +71,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
         logger.info('Populated {0} permissions for item (ID: {1})'.format(item.id, content_type))
 
     def _get_default_permissions(self, item, content_type, req_options=None):
-        url = "{0}/{1}/default-permissions/{2}".format(self.owner_baseurl(), item.id, content_type)
+        url = "{0}/{1}/default-permissions/{2}".format(self.owner_baseurl(), item.id, content_type + "s")
         server_response = self.get_request(url, req_options)
         permissions = PermissionsRule.from_response(server_response.content,
                                                     self.parent_srv.namespace)

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -1,0 +1,77 @@
+import logging
+
+from .. import RequestFactory
+from ...models import ExplicitPermissions, PermissionsRule
+
+from .endpoint import Endpoint, api
+from .exceptions import MissingRequiredFieldError
+
+
+logger = logging.getLogger(__name__)
+
+
+class _DefaultPermissionsEndpoint(Endpoint):
+    ''' Adds default-permission model to another endpoint
+
+    Tableau default-permissions model applies only to databases and projects
+    and then takes an object type in the uri to set the defaults.
+    This class is meant to be instantated inside a parent endpoint which
+    has these supported endpoints
+    '''
+    def __init__(self, parent_srv, owner_baseurl):
+        super(_DefaultPermissionsEndpoint, self).__init__(parent_srv)
+
+        # owner_baseurl is the baseurl of the parent.  The MUST be a lambda
+        # since we don't know the full site URL until we sign in.  If
+        # populated without, we will get a sign-in error
+        self.owner_baseurl = owner_baseurl
+
+    def update_default_permissions(self, resource, template_type, permissions):
+        url = '{0}/{1}/default-permissions/{2}'.format(self.owner_baseurl(), resource.id, template_type)
+        update_req = RequestFactory.Permission.add_req(permissions)
+        response = self.put_request(url, update_req)
+        permissions = ExplicitPermissions.from_response(response.content,
+                                                        self.parent_srv.namespace)
+        logger.info('Updated permissions for resource {0}'.format(resource.id))
+
+        return permissions
+
+    def delete_default_permission(self, resource, template_type, rule):
+        for capability, mode in rule.capabilities.items():
+            url = '{0}/{1}/default-permissions/{2}/{3}/{4}/{5}/{6}'.format(
+                self.owner_baseurl(),
+                resource.id,
+                template_type,
+                rule.grantee.permissions_grantee_type + 's',
+                rule.grantee.id,
+                capability,
+                mode)
+
+            logger.debug('Removing {0} permission for capabilty {1}'.format(
+                mode, capability))
+
+            self.delete_request(url)
+
+        logger.info('Deleted permission for {0} {1} item {2}'.format(
+            rule.grantee.permissions_grantee_type,
+            rule.grantee.id,
+            resource.id))
+
+    def populate(self, item):
+        if not item.id:
+            error = "Server item is missing ID. Item must be retrieved from server first."
+            raise MissingRequiredFieldError(error)
+
+        def permission_fetcher():
+            return self._get_default_permissions(item)
+
+        item._set_permissions(permission_fetcher)
+        logger.info('Populated permissions for item (ID: {0})'.format(item.id))
+
+    def _get_default_permissions(self, item, template_type, req_options=None):
+        url = "{0}/{1}/default-permissions/{2}".format(self.owner_baseurl(), item.id, template_type)
+        server_response = self.get_request(url, req_options)
+        permissions = ExplicitPermissions.from_response(server_response.content,
+                                                        self.parent_srv.namespace)
+
+        return permissions

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -44,3 +44,16 @@ class EndpointUnavailableError(Exception):
 
 class ItemTypeNotAllowed(Exception):
     pass
+
+
+class NonXMLResponseError(Exception):
+    pass
+
+
+class GraphQLError(Exception):
+    def __init__(self, error_payload):
+        self.error = error_payload
+
+    def __str__(self):
+        from pprint import pformat
+        return pformat(self.error)

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -31,7 +31,7 @@ class _PermissionsEndpoint(Endpoint):
         response = self.put_request(url, update_req)
         permissions = PermissionsItem.from_response(response.content,
                                                     self.parent_srv.namespace)
-
+        breakpoint()
         logger.info('Updated permissions for item {0}'.format(item.id))
 
         return permissions

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -40,10 +40,10 @@ class _PermissionsEndpoint(Endpoint):
         for capability, mode in rule.capabilities.items():
             "              /permissions/groups/group-id/capability-name/capability-mode"
             url = '{0}/{1}/permissions/{2}/{3}/{4}/{5}'.format(
-                self.owner_baseurl(), 
+                self.owner_baseurl(),
                 resource.id,
                 rule.grantee.permissions_grantee_type + 's',
-                rule.grantee.id, 
+                rule.grantee.id,
                 capability,
                 mode)
 
@@ -73,5 +73,5 @@ class _PermissionsEndpoint(Endpoint):
         server_response = self.get_request(url, req_options)
         permissions = ExplicitPermissions.from_response(server_response.content,
                                                         self.parent_srv.namespace)
-    
+
         return permissions

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -1,7 +1,7 @@
 import logging
 
 from .. import RequestFactory
-from ...models import ExplicitPermissions, PermissionsRule
+from ...models import PermissionsRule
 
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
@@ -30,8 +30,8 @@ class _PermissionsEndpoint(Endpoint):
         url = '{0}/{1}/permissions'.format(self.owner_baseurl(), resource.id)
         update_req = RequestFactory.Permission.add_req(permissions)
         response = self.put_request(url, update_req)
-        permissions = ExplicitPermissions.from_response(response.content,
-                                                        self.parent_srv.namespace)
+        permissions = PermissionsRule.from_response(response.content,
+                                                    self.parent_srv.namespace)
         logger.info('Updated permissions for resource {0}'.format(resource.id))
 
         return permissions
@@ -71,7 +71,7 @@ class _PermissionsEndpoint(Endpoint):
     def _get_permissions(self, item, req_options=None):
         url = "{0}/{1}/permissions".format(self.owner_baseurl(), item.id)
         server_response = self.get_request(url, req_options)
-        permissions = ExplicitPermissions.from_response(server_response.content,
-                                                        self.parent_srv.namespace)
+        permissions = PermissionsRule.from_response(server_response.content,
+                                                    self.parent_srv.namespace)
 
         return permissions

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -1,6 +1,7 @@
 import logging
 
-from .. import RequestFactory, PermissionsItem
+from .. import RequestFactory
+from ...models import ExplicitPermissions
 
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
@@ -29,7 +30,7 @@ class _PermissionsEndpoint(Endpoint):
         url = '{0}/{1}/permissions'.format(self.owner_baseurl(), item.id)
         update_req = RequestFactory.Permission.add_req(item, permission_item)
         response = self.put_request(url, update_req)
-        permissions = PermissionsItem.from_response(response.content,
+        permissions = ExplicitPremissions.from_response(response.content,
                                                     self.parent_srv.namespace)
         breakpoint()
         logger.info('Updated permissions for item {0}'.format(item.id))
@@ -68,6 +69,6 @@ class _PermissionsEndpoint(Endpoint):
     def _get_permissions(self, item, req_options=None):
         url = "{0}/{1}/permissions".format(self.owner_baseurl(), item.id)
         server_response = self.get_request(url, req_options)
-        permissions = PermissionsItem.from_response(server_response.content,
+        permissions = ExplicitPermissions.from_response(server_response.content,
                                                     self.parent_srv.namespace)
         return permissions

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -1,0 +1,73 @@
+import logging
+
+from .. import RequestFactory, PermissionsItem
+
+from .endpoint import Endpoint, api
+from .exceptions import MissingRequiredFieldError
+
+
+logger = logging.getLogger(__name__)
+
+
+class _PermissionsEndpoint(Endpoint):
+    ''' Adds permission model to another endpoint
+
+    Tableau permissions model is identical between objects but they are nested under
+    the parent object endpoint (i.e. permissions for workbooks are under
+    /workbooks/:id/permission).  This class is meant to be instantated inside a
+    parent endpoint which has these supported endpoints
+    '''
+    def __init__(self, parent_srv, owner_baseurl):
+        super(_PermissionsEndpoint, self).__init__(parent_srv)
+
+        # owner_baseurl is the baseurl of the parent.  The MUST be a lambda
+        # since we don't know the full site URL until we sign in.  If
+        # populated without, we will get a sign-in error
+        self.owner_baseurl = owner_baseurl
+
+    def update(self, item, permission_item):
+        url = '{0}/{1}/permissions'.format(self.owner_baseurl(), item.id)
+        update_req = RequestFactory.Permission.add_req(item, permission_item)
+        response = self.put_request(url, update_req)
+        permissions = PermissionsItem.from_response(response.content,
+                                                    self.parent_srv.namespace)
+
+        logger.info('Updated permissions for item {0}'.format(item.id))
+
+        return permissions
+
+    def delete(self, item, capability_item):
+        for capability_type, capability_mode in capability_item.map.items():
+            url = '{0}/{1}/permissions/{2}/{3}/{4}/{5}'.format(
+                self.owner_baseurl(), item.id,
+                capability_item.type + 's',
+                capability_item.object_id, capability_type,
+                capability_mode)
+
+            logger.debug('Removing {0} permission for capabilty {1}'.format(
+                capability_mode, capability_type))
+
+            self.delete_request(url)
+
+        logger.info('Deleted permission for {0} {1} item {2}'.format(
+            capability_item.type,
+            capability_item.object_id,
+            item.id))
+
+    def populate(self, item):
+        if not item.id:
+            error = "Server item is missing ID. Item must be retrieved from server first."
+            raise MissingRequiredFieldError(error)
+
+        def permission_fetcher():
+            return self._get_permissions(item)
+
+        item._set_permissions(permission_fetcher)
+        logger.info('Populated permissions for item (ID: {0})'.format(item.id))
+
+    def _get_permissions(self, item, req_options=None):
+        url = "{0}/{1}/permissions".format(self.owner_baseurl(), item.id)
+        server_response = self.get_request(url, req_options)
+        permissions = PermissionsItem.from_response(server_response.content,
+                                                    self.parent_srv.namespace)
+        return permissions

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -2,7 +2,9 @@ from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
 from .default_permissions_endpoint import _DefaultPermissionsEndpoint
-from .. import RequestFactory, ProjectItem, PaginationItem
+
+from .. import RequestFactory, ProjectItem, PaginationItem, PermissionsRule, Permission
+
 import logging
 
 logger = logging.getLogger('tableau.endpoint.projects')
@@ -68,25 +70,41 @@ class Projects(Endpoint):
         return self._permissions.update(item, rules)
 
     @api(version='2.0')
-    def delete_permission(self, item, rule):
-        return self._permissions.delete(item, rule)
+    def delete_permission(self, item, rules):
+        return self._permissions.delete(item, rules)
 
     @api(version='2.1')
     def populate_workbook_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, 'workbooks')
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Workbooks)
 
     @api(version='2.1')
     def populate_datasource_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, 'datasources')
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Datasources)
 
     @api(version='3.4')
     def populate_flow_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, 'flows')
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Flows)
 
     @api(version='2.1')
-    def update_default_permission(self, item, permissions, content_type):
-        self._default_permissions.update_default_permissions(item, permissions, content_type)
+    def update_workbook_default_permissions(self, item):
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Workbooks)
 
     @api(version='2.1')
-    def delete_default_permission(self, item, rule, content_type):
-        self._default_permissions.delete_default_permission(item, rule, content_type)
+    def update_datasource_default_permissions(self, item):
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Datasources)
+
+    @api(version='3.4')
+    def update_flow_default_permissions(self, item):
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Flows)
+
+    @api(version='2.1')
+    def delete_workbook_default_permissions(self, item):
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Workbooks)
+
+    @api(version='2.1')
+    def delete_datasource_default_permissions(self, item):
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Datasources)
+
+    @api(version='3.4')
+    def delete_flow_default_permissions(self, item):
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Flows)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -64,29 +64,29 @@ class Projects(Endpoint):
         self._permissions.populate(item)
 
     @api(version='2.0')
-    def update_permission(self, item, permission_item):
-        return self._permissions.update(item, permission_item)
+    def update_permission(self, item, rules):
+        return self._permissions.update(item, rules)
 
     @api(version='2.0')
-    def delete_permission(self, item, capability_item):
-        return self._permissions.delete(item, capability_item)
+    def delete_permission(self, item, rule):
+        return self._permissions.delete(item, rule)
 
-    @api(version='2.0')
-    def populate_workbook_defaults(self, item):
-        self._default_permissions.populate_workbook_defaults(item)
+    @api(version='2.1')
+    def populate_workbook_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, 'workbooks')
 
-    @api(version='2.0')
-    def populate_datasource_defaults(self, item):
-        self._default_permissions.populate_datasource_defaults(item)
+    @api(version='2.1')
+    def populate_datasource_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, 'datasources')
 
-    @api(version='2.0')
-    def populate_flow_defaults(self, item):
-        self._default_permissions.populate_flow_defaults(item)
+    @api(version='3.4')
+    def populate_flow_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, 'flows')
 
-    @api(version='2.0')
+    @api(version='2.1')
     def update_default_permissions(self, item, permissions, content_type):
         self._default_permissions.update_default_permissions(item, permissions, content_type)
 
-    @api(version='2.0')
-    def delete_permission(self, item, capability_item):
-        self._permissions.delete(item, capability_item)
+    @api(version='2.1')
+    def delete_default_permission(self, item, rule, content_type):
+        self._default_permissions.delete_default_permission(item, rule, content_type)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -1,5 +1,6 @@
-from .endpoint import Endpoint, api
+from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
+from .permissions_endpoint import _PermissionsEndpoint
 from .. import RequestFactory, ProjectItem, PaginationItem
 import logging
 
@@ -7,6 +8,11 @@ logger = logging.getLogger('tableau.endpoint.projects')
 
 
 class Projects(Endpoint):
+    def __init__(self, parent_srv):
+        super(Projects, self).__init__(parent_srv)
+
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
+
     @property
     def baseurl(self):
         return "{0}/sites/{1}/projects".format(self.parent_srv.baseurl, self.parent_srv.site_id)
@@ -50,3 +56,15 @@ class Projects(Endpoint):
         new_project = ProjectItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Created new project (ID: {0})'.format(new_project.id))
         return new_project
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -75,36 +75,36 @@ class Projects(Endpoint):
 
     @api(version='2.1')
     def populate_workbook_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, Permission.Resource.Workbooks)
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Workbook)
 
     @api(version='2.1')
     def populate_datasource_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, Permission.Resource.Datasources)
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Datasource)
 
     @api(version='3.4')
     def populate_flow_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, Permission.Resource.Flows)
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Flow)
 
     @api(version='2.1')
     def update_workbook_default_permissions(self, item):
-        self._default_permissions.update_default_permissions(item, Permission.Resource.Workbooks)
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Workbook)
 
     @api(version='2.1')
     def update_datasource_default_permissions(self, item):
-        self._default_permissions.update_default_permissions(item, Permission.Resource.Datasources)
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Datasource)
 
     @api(version='3.4')
     def update_flow_default_permissions(self, item):
-        self._default_permissions.update_default_permissions(item, Permission.Resource.Flows)
+        self._default_permissions.update_default_permissions(item, Permission.Resource.Flow)
 
     @api(version='2.1')
     def delete_workbook_default_permissions(self, item):
-        self._default_permissions.delete_default_permissions(item, Permission.Resource.Workbooks)
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Workbook)
 
     @api(version='2.1')
     def delete_datasource_default_permissions(self, item):
-        self._default_permissions.delete_default_permissions(item, Permission.Resource.Datasources)
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Datasource)
 
     @api(version='3.4')
     def delete_flow_default_permissions(self, item):
-        self._default_permissions.delete_default_permissions(item, Permission.Resource.Flows)
+        self._default_permissions.delete_default_permissions(item, Permission.Resource.Flow)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -84,7 +84,7 @@ class Projects(Endpoint):
         self._default_permissions.populate_default_permissions(item, 'flows')
 
     @api(version='2.1')
-    def update_default_permissions(self, item, permissions, content_type):
+    def update_default_permission(self, item, permissions, content_type):
         self._default_permissions.update_default_permissions(item, permissions, content_type)
 
     @api(version='2.1')

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -1,6 +1,7 @@
 from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
+from .default_permissions_endpoint import _DefaultPermissionsEndpoint
 from .. import RequestFactory, ProjectItem, PaginationItem
 import logging
 
@@ -12,6 +13,7 @@ class Projects(Endpoint):
         super(Projects, self).__init__(parent_srv)
 
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
+        self._default_permissions = _DefaultPermissionsEndpoint(parent_srv, lambda: self.baseurl)
 
     @property
     def baseurl(self):
@@ -63,7 +65,27 @@ class Projects(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, permission_item):
-        self._permissions.update(item, permission_item)
+        return self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        return self._permissions.delete(item, capability_item)
+
+    @api(version='2.0')
+    def populate_workbook_defaults(self, item):
+        self._default_permissions.populate_workbook_defaults(item)
+
+    @api(version='2.0')
+    def populate_datasource_defaults(self, item):
+        self._default_permissions.populate_datasource_defaults(item)
+
+    @api(version='2.0')
+    def populate_flow_defaults(self, item):
+        self._default_permissions.populate_flow_defaults(item)
+
+    @api(version='2.0')
+    def update_default_permissions(self, item, permissions, content_type):
+        self._default_permissions.update_default_permissions(item, permissions, content_type)
 
     @api(version='2.0')
     def delete_permission(self, item, capability_item):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -225,12 +225,12 @@ class Workbooks(Endpoint):
         self._permissions.populate(item)
 
     @api(version='2.0')
-    def update_permission(self, item, permission_item):
-        self._permissions.update(item, permission_item)
+    def update_permissions(self, resource, rules):
+        return self._permissions.update(resource, rules)
 
     @api(version='2.0')
     def delete_permission(self, item, capability_item):
-        self._permissions.delete(item, capability_item)
+        return self._permissions.delete(item, capability_item)
 
     # Publishes workbook. Chunking method if file over 64MB
     @api(version="2.0")

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,5 +1,8 @@
 from .endpoint import Endpoint, api, parameter_added_in
 from .exceptions import InternalServerError, MissingRequiredFieldError
+from .endpoint import api, parameter_added_in, Endpoint
+from .permissions_endpoint import _PermissionsEndpoint
+from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
 from .. import RequestFactory, WorkbookItem, ConnectionItem, ViewItem, PaginationItem
@@ -25,6 +28,7 @@ class Workbooks(Endpoint):
     def __init__(self, parent_srv):
         super(Workbooks, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)
+        self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
 
     @property
     def baseurl(self):
@@ -215,6 +219,18 @@ class Workbooks(Endpoint):
         server_response = self.get_request(url)
         preview_image = server_response.content
         return preview_image
+
+    @api(version='2.0')
+    def populate_permissions(self, item):
+        self._permissions.populate(item)
+
+    @api(version='2.0')
+    def update_permission(self, item, permission_item):
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def delete_permission(self, item, capability_item):
+        self._permissions.delete(item, capability_item)
 
     # Publishes workbook. Chunking method if file over 64MB
     @api(version="2.0")

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -149,6 +149,7 @@ class PermissionRequest(object):
         item_element.attrib['id'] = item.id
 
         self._add_all_capabilities(permissions_element, permission_item.capabilities)
+        print(ET.tostring(xml_request))
         return ET.tostring(xml_request)
 
     def _add_all_capabilities(self, permissions_element, capabilities_map):

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -140,9 +140,11 @@ class GroupRequest(object):
             project_element.attrib['siteRole'] = default_site_role
         return ET.tostring(xml_request)
 
+from typing import Union
+from ..models import UserItem, GroupItem
 
 class PermissionRequest(object):
-    def add_req(self, item, permission_item):
+    def add_req(self, item: Union[UserItem, GroupItem], permission_item):
         xml_request = ET.Element('tsRequest')
         permissions_element = ET.SubElement(xml_request, 'permissions')
         item_element = ET.SubElement(permissions_element, type(item).__name__.split('Item')[0].lower())

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -5,6 +5,8 @@ from functools import wraps
 from requests.packages.urllib3.fields import RequestField
 from requests.packages.urllib3.filepost import encode_multipart_formdata
 
+from ..models import UserItem, GroupItem, PermissionsRule
+
 
 def _add_multipart(parts):
     mime_multipart_parts = list()
@@ -140,7 +142,6 @@ class GroupRequest(object):
             project_element.attrib['siteRole'] = default_site_role
         return ET.tostring(xml_request)
 
-from ..models import UserItem, GroupItem, PermissionsRule
 
 class PermissionRequest(object):
     def add_req(self, rules):
@@ -151,9 +152,10 @@ class PermissionRequest(object):
             grantee_capabilities_element = ET.SubElement(permissions_element, 'granteeCapabilities')
             grantee_element = ET.SubElement(grantee_capabilities_element, rule.grantee.permissions_grantee_type)
             grantee_element.attrib['id'] = rule.grantee.id
+
             capabilities_element = ET.SubElement(grantee_capabilities_element, 'capabilities')
-            
             self._add_all_capabilities(capabilities_element, rule.capabilities)
+
         return ET.tostring(xml_request)
 
     def _add_all_capabilities(self, capabilities_element, capabilities_map):

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -150,7 +150,7 @@ class PermissionRequest(object):
 
         for rule in rules:
             grantee_capabilities_element = ET.SubElement(permissions_element, 'granteeCapabilities')
-            grantee_element = ET.SubElement(grantee_capabilities_element, rule.grantee.permissions_grantee_type)
+            grantee_element = ET.SubElement(grantee_capabilities_element, rule.grantee.tag_name)
             grantee_element.attrib['id'] = rule.grantee.id
 
             capabilities_element = ET.SubElement(grantee_capabilities_element, 'capabilities')

--- a/test/assets/datasource_populate_permissions.xml
+++ b/test/assets/datasource_populate_permissions.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+    <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <permissions>
+        <datasource id="0448d2ed-590d-4fa0-b272-a2a8a24555b5" name="Some datasource">
+            <owner id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+        </datasource>
+        <granteeCapabilities>
+            <group id="5e5e1978-71fa-11e4-87dd-7382f5c437af" />
+            <capabilities>
+                <capability name="Delete" mode="Deny" />
+                <capability name="ChangePermissions" mode="Deny" />
+                <capability name="Connect" mode="Allow" />
+                <capability name="Read" mode="Allow" />
+            </capabilities>
+        </granteeCapabilities>
+        <granteeCapabilities>
+            <user id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+            <capabilities>
+                <capability name="Write" mode="Allow" />
+            </capabilities>
+        </granteeCapabilities>
+    </permissions>
+</tsResponse>

--- a/test/assets/project_populate_permissions.xml
+++ b/test/assets/project_populate_permissions.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.5.xsd">
+    <permissions>
+        <project id="90f09c23-440a-44ee-857c-5744a51d5b08" name="Project3">
+            <owner id="26183d16-82f7-4fcf-b163-0e607bf292bc"/>
+        </project>
+        <granteeCapabilities>
+            <group id="c8f2773a-c83a-11e8-8c8f-33e6d787b506"/>
+            <capabilities>
+                <capability name="Read" mode="Allow"/>
+                <capability name="Write" mode="Allow"/>
+            </capabilities>
+        </granteeCapabilities>
+    </permissions>
+</tsResponse>

--- a/test/assets/project_populate_workbook_default_permissions.xml
+++ b/test/assets/project_populate_workbook_default_permissions.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.5.xsd">
+    <permissions>
+        <project id="90f09c23-440a-44ee-857c-5744a51d5b08" name="Project3">
+            <owner id="26183d16-82f7-4fcf-b163-0e607bf292bc"/>
+        </project>
+        <granteeCapabilities>
+            <group id="c8f2773a-c83a-11e8-8c8f-33e6d787b506"/>
+            <capabilities>
+                <capability name="Read" mode="Allow"/>
+                <capability name="Filter" mode="Allow"/>
+                <capability name="ChangePermissions" mode="Allow"/>
+                <capability name="WebAuthoring" mode="Allow"/>
+                <capability name="Write" mode="Allow"/>
+                <capability name="ExportXml" mode="Allow"/>
+                <capability name="ExportData" mode="Allow"/>
+                <capability name="AddComment" mode="Allow"/>
+                <capability name="ViewUnderlyingData" mode="Deny"/>
+                <capability name="ViewComments" mode="Allow"/>
+                <capability name="ChangeHierarchy" mode="Allow"/>
+                <capability name="Delete" mode="Deny"/>
+                <capability name="ExportImage" mode="Allow"/>
+                <capability name="ShareView" mode="Allow"/>
+            </capabilities>
+        </granteeCapabilities>
+    </permissions>
+</tsResponse>

--- a/test/assets/workbook_populate_permissions.xml
+++ b/test/assets/workbook_populate_permissions.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <permissions>
+        <workbook id="21778de4-b7b9-44bc-a599-1506a2639ace" name="ComplianceDashboard">
+            <owner id="91d5931a-2cd6-4dbc-8b7c-211e85cf5fa3" />
+        </workbook>
+    <granteeCapabilities>
+        <group id="5e5e1978-71fa-11e4-87dd-7382f5c437af" />
+        <capabilities>
+            <capability name="WebAuthoring" mode="Allow" />
+            <capability name="Read" mode="Allow" />
+            <capability name="Filter" mode="Allow" />
+            <capability name="AddComment" mode="Allow" />
+        </capabilities>
+    </granteeCapabilities>
+    <granteeCapabilities>
+        <user id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+        <capabilities>
+            <capability name="ExportImage" mode="Allow" />
+            <capability name="ShareView" mode="Allow" />
+            <capability name="ExportData" mode="Deny" />
+            <capability name="ViewComments" mode="Deny" />
+        </capabilities>
+    </granteeCapabilities>
+    </permissions>
+</tsResponse>
+

--- a/test/assets/workbook_update_permissions.xml
+++ b/test/assets/workbook_update_permissions.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <permissions>
+        <workbook id="21778de4-b7b9-44bc-a599-1506a2639ace" name="ComplianceDashboard">
+            <owner id="91d5931a-2cd6-4dbc-8b7c-211e85cf5fa3" />
+        </workbook>
+    <granteeCapabilities>
+        <group id="5e5e1978-71fa-11e4-87dd-7382f5c437af" />
+        <capabilities>
+            <capability name="Read" mode="Deny" />
+        </capabilities>
+    </granteeCapabilities>
+    <granteeCapabilities>
+        <user id="7c37ee24-c4b1-42b6-a154-eaeab7ee330a" />
+        <capabilities>
+            <capability name="Write" mode="Allow" />
+        </capabilities>
+    </granteeCapabilities>
+    </permissions>
+</tsResponse>
+

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -193,25 +193,23 @@ class DatasourceTests(unittest.TestCase):
             self.server.datasources.populate_permissions(single_datasource)
             permissions = single_datasource.permissions
             
-            grantee_type = TSC.Permission.GranteeType.Group
+            grantee_type = 'group'
             object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
-            key = (grantee_type, object_id)
-            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.Group)
-            self.assertEqual(permissions.capabilities[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-            self.assertDictEqual(permissions.capabilities[key].map, {
-                TSC.Permission.DatasourceCapabilityType.Delete: TSC.Permission.CapabilityMode.Deny,
-                TSC.Permission.DatasourceCapabilityType.ChangePermissions: TSC.Permission.CapabilityMode.Deny,
-                TSC.Permission.DatasourceCapabilityType.Connect: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.DatasourceCapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
+            self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions.rules[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.rules[0].capabilities, {
+                TSC.Permission.Capability.Delete: TSC.Permission.Mode.Deny,
+                TSC.Permission.Capability.ChangePermissions: TSC.Permission.Mode.Deny,
+                TSC.Permission.Capability.Connect: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.Read: TSC.Permission.Mode.Allow,
             })
 
-            grantee_type = TSC.Permission.GranteeType.User
+            grantee_type = 'user'
             object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
-            key = (grantee_type, object_id)
-            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.User)
-            self.assertEqual(permissions.capabilities[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-            self.assertDictEqual(permissions.capabilities[key].map, {
-                TSC.Permission.DatasourceCapabilityType.Write: TSC.Permission.CapabilityMode.Allow,
+            self.assertEqual(permissions.rules[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions.rules[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.rules[1].capabilities, {
+                TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow,
             })
 
     def test_publish(self):

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -195,9 +195,9 @@ class DatasourceTests(unittest.TestCase):
 
             grantee_type = 'group'
             object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
-            self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')
-            self.assertEqual(permissions.rules[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-            self.assertDictEqual(permissions.rules[0].capabilities, {
+            self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions[0].capabilities, {
                 TSC.Permission.Capability.Delete: TSC.Permission.Mode.Deny,
                 TSC.Permission.Capability.ChangePermissions: TSC.Permission.Mode.Deny,
                 TSC.Permission.Capability.Connect: TSC.Permission.Mode.Allow,
@@ -206,9 +206,9 @@ class DatasourceTests(unittest.TestCase):
 
             grantee_type = 'user'
             object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
-            self.assertEqual(permissions.rules[1].grantee.permissions_grantee_type, 'user')
-            self.assertEqual(permissions.rules[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-            self.assertDictEqual(permissions.rules[1].capabilities, {
+            self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions[1].capabilities, {
                 TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow,
             })
 

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -13,6 +13,7 @@ GET_XML = 'datasource_get.xml'
 GET_EMPTY_XML = 'datasource_get_empty.xml'
 GET_BY_ID_XML = 'datasource_get_by_id.xml'
 POPULATE_CONNECTIONS_XML = 'datasource_populate_connections.xml'
+POPULATE_PERMISSIONS_XML = 'datasource_populate_permissions.xml'
 PUBLISH_XML = 'datasource_publish.xml'
 PUBLISH_XML_ASYNC = 'datasource_publish_async.xml'
 UPDATE_XML = 'datasource_update.xml'
@@ -180,6 +181,38 @@ class DatasourceTests(unittest.TestCase):
             self.assertEquals('bar', new_connection.server_address)
             self.assertEquals('9876', new_connection.server_port)
             self.assertEqual('foo', new_connection.username)
+
+    def test_populate_permissions(self):
+        with open(asset(POPULATE_PERMISSIONS_XML), 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/0448d2ed-590d-4fa0-b272-a2a8a24555b5/permissions', text=response_xml)
+            single_datasource = TSC.DatasourceItem('test')
+            single_datasource._id = '0448d2ed-590d-4fa0-b272-a2a8a24555b5'
+
+            self.server.datasources.populate_permissions(single_datasource)
+            permissions = single_datasource.permissions
+            
+            grantee_type = TSC.Permission.GranteeType.Group
+            object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.Group)
+            self.assertEqual(permissions.capabilities[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.DatasourceCapabilityType.Delete: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.DatasourceCapabilityType.ChangePermissions: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.DatasourceCapabilityType.Connect: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.DatasourceCapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
+            })
+
+            grantee_type = TSC.Permission.GranteeType.User
+            object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.User)
+            self.assertEqual(permissions.capabilities[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.DatasourceCapabilityType.Write: TSC.Permission.CapabilityMode.Allow,
+            })
 
     def test_publish(self):
         response_xml = read_xml_asset(PUBLISH_XML)

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -193,9 +193,7 @@ class DatasourceTests(unittest.TestCase):
             self.server.datasources.populate_permissions(single_datasource)
             permissions = single_datasource.permissions
 
-            grantee_type = 'group'
-            object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
-            self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions[0].grantee.tag_name, 'group')
             self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
             self.assertDictEqual(permissions[0].capabilities, {
                 TSC.Permission.Capability.Delete: TSC.Permission.Mode.Deny,
@@ -204,9 +202,7 @@ class DatasourceTests(unittest.TestCase):
                 TSC.Permission.Capability.Read: TSC.Permission.Mode.Allow,
             })
 
-            grantee_type = 'user'
-            object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
-            self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions[1].grantee.tag_name, 'user')
             self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
             self.assertDictEqual(permissions[1].capabilities, {
                 TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow,

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -192,7 +192,7 @@ class DatasourceTests(unittest.TestCase):
 
             self.server.datasources.populate_permissions(single_datasource)
             permissions = single_datasource.permissions
-            
+
             grantee_type = 'group'
             object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
             self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -7,9 +7,9 @@ from ._utils import read_xml_asset, read_xml_assets, asset
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
-GET_XML = os.path.join(TEST_ASSET_DIR, 'project_get.xml')
-UPDATE_XML = os.path.join(TEST_ASSET_DIR, 'project_update.xml')
-CREATE_XML = os.path.join(TEST_ASSET_DIR, 'project_create.xml')
+GET_XML = asset('project_get.xml')
+UPDATE_XML = asset('project_update.xml')
+CREATE_XML = asset('project_create.xml')
 POPULATE_PERMISSIONS_XML = 'project_populate_permissions.xml'
 POPULATE_WORKBOOK_DEFAULT_PERMISSIONS_XML = 'project_populate_workbook_default_permissions.xml'
 

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -57,8 +57,8 @@ class SortTests(unittest.TestCase):
                                                        request_object=opts,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
-
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags:in:%5bstocks,market%5d')
+            self.assertDictEqual(resp.request.qs, {'pagenumber': ['13'], 'pagesize': [
+                                 '13'], 'filter': ['tags:in:[stocks,market]']})
 
     def test_sort_asc(self):
         with requests_mock.mock() as m:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -282,28 +282,23 @@ class WorkbookTests(unittest.TestCase):
             self.server.workbooks.populate_permissions(single_workbook)
             permissions = single_workbook.permissions
 
-            grantee_type = TSC.Permission.GranteeType.Group
-            object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
-            key = (grantee_type, object_id)
-            self.assertEqual(permissions.rules[key].type, TSC.Permission.GranteeType.Group)
-            self.assertEqual(permissions.rules[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-            self.assertDictEqual(permissions.rules[key].map, {
-                TSC.Permission.CapabilityType.WebAuthoring: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.CapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.CapabilityType.Filter: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.CapabilityType.AddComment: TSC.Permission.CapabilityMode.Allow
+            breakpoint()
+            self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions.rules[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.rules[0].capabilities, {
+                TSC.Permission.Capability.WebAuthoring: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.Read: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.Filter: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.AddComment: TSC.Permission.Mode.Allow
             })
 
-            grantee_type = TSC.Permission.GranteeType.User
-            object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
-            key = (grantee_type, object_id)
-            self.assertEqual(permissions.rules[key].type, TSC.Permission.GranteeType.User)
-            self.assertEqual(permissions.rules[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-            self.assertDictEqual(permissions.rules[key].map, {
-                TSC.Permission.CapabilityType.ExportImage: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.CapabilityType.ShareView: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.CapabilityType.ExportData: TSC.Permission.CapabilityMode.Deny,
-                TSC.Permission.CapabilityType.ViewComments: TSC.Permission.CapabilityMode.Deny
+            self.assertEqual(permissions.rules[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions.rules[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.rules[1].capabilities, {
+                TSC.Permission.Capability.ExportImage: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.ShareView: TSC.Permission.Mode.Allow,
+                TSC.Permission.Capability.ExportData: TSC.Permission.Mode.Deny,
+                TSC.Permission.Capability.ViewComments: TSC.Permission.Mode.Deny
             })
 
     def test_populate_connections_missing_id(self):

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -7,7 +7,9 @@ import xml.etree.ElementTree as ET
 from tableauserverclient.datetime_helpers import format_datetime
 from tableauserverclient.server.endpoint.exceptions import InternalServerError
 from tableauserverclient.server.request_factory import RequestFactory
-from tableauserverclient.models.permissions_item import PermissionsRule, ExplicitPermissions, GranteeGroup, GranteeUser
+from tableauserverclient.models.permissions_item import PermissionsRule
+from tableauserverclient.models.user_item import UserItem
+from tableauserverclient.models.group_item import GroupItem
 
 from ._utils import asset
 
@@ -310,8 +312,8 @@ class WorkbookTests(unittest.TestCase):
         single_workbook = TSC.WorkbookItem('test')
         single_workbook._id = '21778de4-b7b9-44bc-a599-1506a2639ace'
 
-        bob = GranteeUser("7c37ee24-c4b1-42b6-a154-eaeab7ee330a")
-        group_of_people = GranteeGroup("5e5e1978-71fa-11e4-87dd-7382f5c437af")
+        bob = UserItem.for_permissions("7c37ee24-c4b1-42b6-a154-eaeab7ee330a")
+        group_of_people = GroupItem.for_permissions("5e5e1978-71fa-11e4-87dd-7382f5c437af")
 
         new_permissions = [
             PermissionsRule(bob, {'Write': 'Allow'}),

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -17,6 +17,7 @@ GET_EMPTY_XML = os.path.join(TEST_ASSET_DIR, 'workbook_get_empty.xml')
 GET_XML = os.path.join(TEST_ASSET_DIR, 'workbook_get.xml')
 POPULATE_CONNECTIONS_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_connections.xml')
 POPULATE_PDF = os.path.join(TEST_ASSET_DIR, 'populate_pdf.pdf')
+POPULATE_PERMISSIONS_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_permissions.xml')
 POPULATE_PREVIEW_IMAGE = os.path.join(TEST_ASSET_DIR, 'RESTAPISample Image.png')
 POPULATE_VIEWS_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_views.xml')
 POPULATE_VIEWS_USAGE_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_views_usage.xml')
@@ -269,6 +270,41 @@ class WorkbookTests(unittest.TestCase):
             self.assertEqual('dataengine', single_workbook.connections[0].connection_type)
             self.assertEqual('4506225a-0d32-4ab1-82d3-c24e85f7afba', single_workbook.connections[0].datasource_id)
             self.assertEqual('World Indicators', single_workbook.connections[0].datasource_name)
+
+    def test_populate_permissions(self):
+        with open(POPULATE_PERMISSIONS_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/21778de4-b7b9-44bc-a599-1506a2639ace/permissions', text=response_xml)
+            single_workbook = TSC.WorkbookItem('test')
+            single_workbook._id = '21778de4-b7b9-44bc-a599-1506a2639ace'
+
+            self.server.workbooks.populate_permissions(single_workbook)
+            permissions = single_workbook.permissions
+
+            grantee_type = TSC.Permission.GranteeType.Group
+            object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.Group)
+            self.assertEqual(permissions.capabilities[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.WorkbookCapabilityType.WebAuthoring: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.WorkbookCapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.WorkbookCapabilityType.Filter: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.WorkbookCapabilityType.AddComment: TSC.Permission.CapabilityMode.Allow
+            })
+
+            grantee_type = TSC.Permission.GranteeType.User
+            object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
+            key = (grantee_type, object_id)
+            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.User)
+            self.assertEqual(permissions.capabilities[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.capabilities[key].map, {
+                TSC.Permission.WorkbookCapabilityType.ExportImage: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.WorkbookCapabilityType.ShareView: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.WorkbookCapabilityType.ExportData: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.WorkbookCapabilityType.ViewComments: TSC.Permission.CapabilityMode.Deny
+            })
 
     def test_populate_connections_missing_id(self):
         single_workbook = TSC.WorkbookItem('test')

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -317,7 +317,7 @@ class WorkbookTests(unittest.TestCase):
             PermissionsRule(bob, {'Write': 'Allow'}),
             PermissionsRule(group_of_people, {'Read': 'Deny'})
         ]
-        
+
         with requests_mock.mock() as m:
             m.put(self.baseurl + "/21778de4-b7b9-44bc-a599-1506a2639ace/permissions", text=response_xml)
             permissions = self.server.workbooks.update_permissions(single_workbook, new_permissions)
@@ -333,7 +333,6 @@ class WorkbookTests(unittest.TestCase):
         self.assertDictEqual(permissions.rules[1].capabilities, {
             TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow
         })
-
 
     def test_populate_connections_missing_id(self):
         single_workbook = TSC.WorkbookItem('test')

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -285,25 +285,25 @@ class WorkbookTests(unittest.TestCase):
             grantee_type = TSC.Permission.GranteeType.Group
             object_id = '5e5e1978-71fa-11e4-87dd-7382f5c437af'
             key = (grantee_type, object_id)
-            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.Group)
-            self.assertEqual(permissions.capabilities[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-            self.assertDictEqual(permissions.capabilities[key].map, {
-                TSC.Permission.WorkbookCapabilityType.WebAuthoring: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.WorkbookCapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.WorkbookCapabilityType.Filter: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.WorkbookCapabilityType.AddComment: TSC.Permission.CapabilityMode.Allow
+            self.assertEqual(permissions.rules[key].type, TSC.Permission.GranteeType.Group)
+            self.assertEqual(permissions.rules[key].object_id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions.rules[key].map, {
+                TSC.Permission.CapabilityType.WebAuthoring: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.CapabilityType.Read: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.CapabilityType.Filter: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.CapabilityType.AddComment: TSC.Permission.CapabilityMode.Allow
             })
 
             grantee_type = TSC.Permission.GranteeType.User
             object_id = '7c37ee24-c4b1-42b6-a154-eaeab7ee330a'
             key = (grantee_type, object_id)
-            self.assertEqual(permissions.capabilities[key].type, TSC.Permission.GranteeType.User)
-            self.assertEqual(permissions.capabilities[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-            self.assertDictEqual(permissions.capabilities[key].map, {
-                TSC.Permission.WorkbookCapabilityType.ExportImage: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.WorkbookCapabilityType.ShareView: TSC.Permission.CapabilityMode.Allow,
-                TSC.Permission.WorkbookCapabilityType.ExportData: TSC.Permission.CapabilityMode.Deny,
-                TSC.Permission.WorkbookCapabilityType.ViewComments: TSC.Permission.CapabilityMode.Deny
+            self.assertEqual(permissions.rules[key].type, TSC.Permission.GranteeType.User)
+            self.assertEqual(permissions.rules[key].object_id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions.rules[key].map, {
+                TSC.Permission.CapabilityType.ExportImage: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.CapabilityType.ShareView: TSC.Permission.CapabilityMode.Allow,
+                TSC.Permission.CapabilityType.ExportData: TSC.Permission.CapabilityMode.Deny,
+                TSC.Permission.CapabilityType.ViewComments: TSC.Permission.CapabilityMode.Deny
             })
 
     def test_populate_connections_missing_id(self):

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -287,7 +287,7 @@ class WorkbookTests(unittest.TestCase):
             self.server.workbooks.populate_permissions(single_workbook)
             permissions = single_workbook.permissions
 
-            self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions[0].grantee.tag_name, 'group')
             self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
             self.assertDictEqual(permissions[0].capabilities, {
                 TSC.Permission.Capability.WebAuthoring: TSC.Permission.Mode.Allow,
@@ -296,7 +296,7 @@ class WorkbookTests(unittest.TestCase):
                 TSC.Permission.Capability.AddComment: TSC.Permission.Mode.Allow
             })
 
-            self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions[1].grantee.tag_name, 'user')
             self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
             self.assertDictEqual(permissions[1].capabilities, {
                 TSC.Permission.Capability.ExportImage: TSC.Permission.Mode.Allow,
@@ -312,8 +312,8 @@ class WorkbookTests(unittest.TestCase):
         single_workbook = TSC.WorkbookItem('test')
         single_workbook._id = '21778de4-b7b9-44bc-a599-1506a2639ace'
 
-        bob = UserItem.for_permissions("7c37ee24-c4b1-42b6-a154-eaeab7ee330a")
-        group_of_people = GroupItem.for_permissions("5e5e1978-71fa-11e4-87dd-7382f5c437af")
+        bob = UserItem.as_reference("7c37ee24-c4b1-42b6-a154-eaeab7ee330a")
+        group_of_people = GroupItem.as_reference("5e5e1978-71fa-11e4-87dd-7382f5c437af")
 
         new_permissions = [
             PermissionsRule(bob, {'Write': 'Allow'}),
@@ -324,13 +324,13 @@ class WorkbookTests(unittest.TestCase):
             m.put(self.baseurl + "/21778de4-b7b9-44bc-a599-1506a2639ace/permissions", text=response_xml)
             permissions = self.server.workbooks.update_permissions(single_workbook, new_permissions)
 
-        self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+        self.assertEqual(permissions[0].grantee.tag_name, 'group')
         self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
         self.assertDictEqual(permissions[0].capabilities, {
             TSC.Permission.Capability.Read: TSC.Permission.Mode.Deny
         })
 
-        self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+        self.assertEqual(permissions[1].grantee.tag_name, 'user')
         self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
         self.assertDictEqual(permissions[1].capabilities, {
             TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -287,18 +287,18 @@ class WorkbookTests(unittest.TestCase):
             self.server.workbooks.populate_permissions(single_workbook)
             permissions = single_workbook.permissions
 
-            self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')
-            self.assertEqual(permissions.rules[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-            self.assertDictEqual(permissions.rules[0].capabilities, {
+            self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+            self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+            self.assertDictEqual(permissions[0].capabilities, {
                 TSC.Permission.Capability.WebAuthoring: TSC.Permission.Mode.Allow,
                 TSC.Permission.Capability.Read: TSC.Permission.Mode.Allow,
                 TSC.Permission.Capability.Filter: TSC.Permission.Mode.Allow,
                 TSC.Permission.Capability.AddComment: TSC.Permission.Mode.Allow
             })
 
-            self.assertEqual(permissions.rules[1].grantee.permissions_grantee_type, 'user')
-            self.assertEqual(permissions.rules[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-            self.assertDictEqual(permissions.rules[1].capabilities, {
+            self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+            self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+            self.assertDictEqual(permissions[1].capabilities, {
                 TSC.Permission.Capability.ExportImage: TSC.Permission.Mode.Allow,
                 TSC.Permission.Capability.ShareView: TSC.Permission.Mode.Allow,
                 TSC.Permission.Capability.ExportData: TSC.Permission.Mode.Deny,
@@ -324,15 +324,15 @@ class WorkbookTests(unittest.TestCase):
             m.put(self.baseurl + "/21778de4-b7b9-44bc-a599-1506a2639ace/permissions", text=response_xml)
             permissions = self.server.workbooks.update_permissions(single_workbook, new_permissions)
 
-        self.assertEqual(permissions.rules[0].grantee.permissions_grantee_type, 'group')
-        self.assertEqual(permissions.rules[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
-        self.assertDictEqual(permissions.rules[0].capabilities, {
+        self.assertEqual(permissions[0].grantee.permissions_grantee_type, 'group')
+        self.assertEqual(permissions[0].grantee.id, '5e5e1978-71fa-11e4-87dd-7382f5c437af')
+        self.assertDictEqual(permissions[0].capabilities, {
             TSC.Permission.Capability.Read: TSC.Permission.Mode.Deny
         })
 
-        self.assertEqual(permissions.rules[1].grantee.permissions_grantee_type, 'user')
-        self.assertEqual(permissions.rules[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
-        self.assertDictEqual(permissions.rules[1].capabilities, {
+        self.assertEqual(permissions[1].grantee.permissions_grantee_type, 'user')
+        self.assertEqual(permissions[1].grantee.id, '7c37ee24-c4b1-42b6-a154-eaeab7ee330a')
+        self.assertDictEqual(permissions[1].capabilities, {
             TSC.Permission.Capability.Write: TSC.Permission.Mode.Allow
         })
 


### PR DESCRIPTION
This is an old massive PR that slowly works on getting permissions into tsc.

@DepthDeluxe contributed a lot (most) of the initial code, but I've forked and simplified a lot of the interfaces. I think we can still build the convenience functions they want but this is a simpler starting point.

I have two main open questions:

1. What do we do with Grantees? The GranteeUser/Group object only needs an 'id' to be passed into a PermissionsRule. However, the Group and User Item classes have a bunch of required (and non-nullable) properties. It's nice that we can just pass in a UserItem or GroupItem from a query, into PermissionsRules but I ALSO want to enable the ability to just create the users/groups you need based on ID. Currently I have this subtyped and overriding the problematic properties, but we could also just change UserItem/GroupItem to be more flexible. A middle ground is some kind of classmethod that constructs a UserItem/GroupItem out of only ID (a classmethod of some sort). What do you think?

2. How should we handle Default Permissions? [Help Link](https://onlinehelp.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#add_default_permissions)
I have a few ideas, one is to just have a default permissions endpoint that's largely copy/paste from the permissions endpoint, and then have an update method on it that takes (ResourceType, List[PermissionsRule]). Alternatively I can reuse most of the existing code if I just make a `update_datasource_default_permissions`, `update_workbook_default_permissions`, etc -- on to the permissions endpoint, and then somehow only enable that for projects (via an optional parameter in the init for the permissions endpoint? Via a classmethod? something else?) I need to prototype here more.

/cc @shinchris @RussTheAerialist @gaoang2148 

If I can get answers to those two, I can implement the remaining stuff and start on the tests.