### PR TITLE
Initial support for Tableau Metadata API

### DIFF
--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -4,6 +4,7 @@ from .endpoint import Endpoint
 from .exceptions import ServerResponseError, MissingRequiredFieldError, ServerInfoEndpointNotFoundError
 from .groups_endpoint import Groups
 from .jobs_endpoint import Jobs
+from .metadata_endpoint import Metadata
 from .projects_endpoint import Projects
 from .schedules_endpoint import Schedules
 from .server_info_endpoint import ServerInfo

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -44,3 +44,12 @@ class EndpointUnavailableError(Exception):
 
 class ItemTypeNotAllowed(Exception):
     pass
+
+
+class GraphQLError(Exception):
+    def __init__(self, error_payload):
+        self.error = error_payload
+
+    def __str__(self):
+        from pprint import pformat
+        return pformat(self.error)

--- a/tableauserverclient/server/endpoint/metadata_endpoint.py
+++ b/tableauserverclient/server/endpoint/metadata_endpoint.py
@@ -24,7 +24,8 @@ class Metadata(Endpoint):
 
         # Setting content type because post_reuqest defaults to text/xml
         server_response = self.post_request(url, graphql_query, content_type='text/json')
-        results = json.loads(server_response.content)
+        breakpoint()
+        results = server_response.json()
 
         if abort_on_error and results.get('errors', None):
             raise GraphQLError(results['errors'])

--- a/tableauserverclient/server/endpoint/metadata_endpoint.py
+++ b/tableauserverclient/server/endpoint/metadata_endpoint.py
@@ -24,7 +24,6 @@ class Metadata(Endpoint):
 
         # Setting content type because post_reuqest defaults to text/xml
         server_response = self.post_request(url, graphql_query, content_type='text/json')
-        breakpoint()
         results = server_response.json()
 
         if abort_on_error and results.get('errors', None):

--- a/tableauserverclient/server/endpoint/metadata_endpoint.py
+++ b/tableauserverclient/server/endpoint/metadata_endpoint.py
@@ -1,0 +1,32 @@
+from .endpoint import Endpoint, api
+from .exceptions import GraphQLError
+import logging
+import json
+
+logger = logging.getLogger('tableau.endpoint.metadata')
+
+
+class Metadata(Endpoint):
+    @property
+    def baseurl(self):
+        return "{0}/api/exp/metadata/graphql".format(self.parent_srv._server_address)
+
+    @api("3.2")
+    def query(self, query, abort_on_error=False):
+        logger.info('Querying Metadata API')
+        url = self.baseurl
+
+        try:
+            graphql_query = json.dumps({'query': query})
+        except Exception:
+            # Place holder for now
+            raise Exception('Must provide a string')
+
+        # Setting content type because post_reuqest defaults to text/xml
+        server_response = self.post_request(url, graphql_query, content_type='text/json')
+        results = json.loads(server_response.content)
+
+        if abort_on_error and results.get('errors', None):
+            raise GraphQLError(results['errors'])
+
+        return results

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -3,8 +3,8 @@ import xml.etree.ElementTree as ET
 from .exceptions import NotSignedInError
 from ..namespace import Namespace
 from .endpoint import Sites, Views, Users, Groups, Workbooks, Datasources, Projects, Auth, \
-    Schedules, ServerInfo, Tasks, ServerInfoEndpointNotFoundError, Subscriptions, Jobs
-from .endpoint.exceptions import EndpointUnavailableError
+    Schedules, ServerInfo, Tasks, ServerInfoEndpointNotFoundError, Subscriptions, Jobs, Metadata
+from .endpoint.exceptions import EndpointUnavailableError, ServerInfoEndpointNotFoundError
 
 import requests
 
@@ -50,6 +50,7 @@ class Server(object):
         self.server_info = ServerInfo(self)
         self.tasks = Tasks(self)
         self.subscriptions = Subscriptions(self)
+        self.metadata = Metadata(self)
         self._namespace = Namespace()
 
         if use_server_version:

--- a/test/assets/metadata_query_error.json
+++ b/test/assets/metadata_query_error.json
@@ -1,0 +1,29 @@
+{
+    "data": {
+        "publishedDatasources": [
+          {
+            "id": "01cf92b2-2d17-b656-fc48-5c25ef6d5352",
+            "name": "Batters (TestV1)"
+          },
+          {
+            "id": "020ae1cd-c356-f1ad-a846-b0094850d22a",
+            "name": "SharePoint_List_sharepoint2010.test.tsi.lan"
+          },
+          {
+            "id": "061493a0-c3b2-6f39-d08c-bc3f842b44af",
+            "name": "Batters_mongodb"
+          },
+          {
+            "id": "089fe515-ad2f-89bc-94bd-69f55f69a9c2",
+            "name": "Sample - Superstore"
+          }
+        ]
+      },
+  "errors": [
+    {
+      "message": "Reached time limit of PT5S for query execution.",
+      "path": null,
+      "extensions": null
+    }
+  ]
+}

--- a/test/assets/metadata_query_success.json
+++ b/test/assets/metadata_query_success.json
@@ -1,0 +1,22 @@
+{
+    "data": {
+      "publishedDatasources": [
+        {
+          "id": "01cf92b2-2d17-b656-fc48-5c25ef6d5352",
+          "name": "Batters (TestV1)"
+        },
+        {
+          "id": "020ae1cd-c356-f1ad-a846-b0094850d22a",
+          "name": "SharePoint_List_sharepoint2010.test.tsi.lan"
+        },
+        {
+          "id": "061493a0-c3b2-6f39-d08c-bc3f842b44af",
+          "name": "Batters_mongodb"
+        },
+        {
+          "id": "089fe515-ad2f-89bc-94bd-69f55f69a9c2",
+          "name": "Sample - Superstore"
+        }
+      ]
+    }
+  }

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -37,9 +37,9 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query(self):
         with open(METADATA_QUERY_SUCCESS, 'rb') as f:
-            response_json = f.read()
+            response_json = json.load(f)
         with requests_mock.mock() as m:
-            m.post(self.baseurl, content=response_json)
+            m.post(self.baseurl, json=response_json)
             actual = self.server.metadata.query('fake query')
 
             datasources = actual['data']
@@ -48,9 +48,9 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query_ignore_error(self):
         with open(METADATA_QUERY_ERROR, 'rb') as f:
-            response_json = f.read()
+            response_json = json.load(f)
         with requests_mock.mock() as m:
-            m.post(self.baseurl, content=response_json)
+            m.post(self.baseurl, json=response_json)
             actual = self.server.metadata.query('fake query')
             datasources = actual['data']
 
@@ -60,9 +60,9 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query_abort_on_error(self):
         with open(METADATA_QUERY_ERROR, 'rb') as f:
-            response_json = f.read()
+            response_json = json.load(f)
         with requests_mock.mock() as m:
-            m.post(self.baseurl, content=response_json)
+            m.post(self.baseurl, json=response_json)
 
             with self.assertRaises(GraphQLError) as e:
                 self.server.metadata.query('fake query', abort_on_error=True)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,0 +1,69 @@
+import unittest
+import os.path
+import json
+import requests_mock
+import tableauserverclient as TSC
+
+from tableauserverclient.server.endpoint.exceptions import GraphQLError
+
+TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
+
+METADATA_QUERY_SUCCESS = os.path.join(TEST_ASSET_DIR, 'metadata_query_success.json')
+METADATA_QUERY_ERROR = os.path.join(TEST_ASSET_DIR, 'metadata_query_error.json')
+
+EXPECTED_DICT = {'publishedDatasources':
+                 [{'id': '01cf92b2-2d17-b656-fc48-5c25ef6d5352', 'name': 'Batters (TestV1)'},
+                  {'id': '020ae1cd-c356-f1ad-a846-b0094850d22a', 'name': 'SharePoint_List_sharepoint2010.test.tsi.lan'},
+                  {'id': '061493a0-c3b2-6f39-d08c-bc3f842b44af', 'name': 'Batters_mongodb'},
+                  {'id': '089fe515-ad2f-89bc-94bd-69f55f69a9c2', 'name': 'Sample - Superstore'}]}
+
+EXPECTED_DICT_ERROR = [
+    {
+        "message": "Reached time limit of PT5S for query execution.",
+        "path": None,
+        "extensions": None
+    }
+]
+
+
+class MetadataTests(unittest.TestCase):
+    def setUp(self):
+        self.server = TSC.Server('http://test')
+        self.baseurl = self.server.metadata.baseurl
+        self.server.version = "3.2"
+
+        self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
+        self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
+
+    def test_metadata_query(self):
+        with open(METADATA_QUERY_SUCCESS, 'rb') as f:
+            response_json = json.load(f)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl, json=response_json)
+            actual = self.server.metadata.query('fake query')
+
+            datasources = actual['data']
+
+        self.assertDictEqual(EXPECTED_DICT, datasources)
+
+    def test_metadata_query_ignore_error(self):
+        with open(METADATA_QUERY_ERROR, 'rb') as f:
+            response_json = json.load(f)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl, json=response_json)
+            actual = self.server.metadata.query('fake query')
+            datasources = actual['data']
+
+        self.assertNotEqual(actual.get('errors', None), None)
+        self.assertListEqual(EXPECTED_DICT_ERROR, actual['errors'])
+        self.assertDictEqual(EXPECTED_DICT, datasources)
+
+    def test_metadata_query_abort_on_error(self):
+        with open(METADATA_QUERY_ERROR, 'rb') as f:
+            response_json = json.load(f)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl, json=response_json)
+
+            with self.assertRaises(GraphQLError) as e:
+                self.server.metadata.query('fake query', abort_on_error=True)
+                self.assertListEqual(e.error, EXPECTED_DICT_ERROR)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -37,7 +37,7 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query(self):
         with open(METADATA_QUERY_SUCCESS, 'rb') as f:
-            response_json = json.load(f)
+            response_json = json.loads(f.read().decode())
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)
             actual = self.server.metadata.query('fake query')
@@ -48,7 +48,7 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query_ignore_error(self):
         with open(METADATA_QUERY_ERROR, 'rb') as f:
-            response_json = json.load(f)
+            response_json = json.loads(f.read().decode())
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)
             actual = self.server.metadata.query('fake query')
@@ -60,7 +60,7 @@ class MetadataTests(unittest.TestCase):
 
     def test_metadata_query_abort_on_error(self):
         with open(METADATA_QUERY_ERROR, 'rb') as f:
-            response_json = json.load(f)
+            response_json = json.loads(f.read().decode())
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -36,7 +36,7 @@ class MetadataTests(unittest.TestCase):
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
     def test_metadata_query(self):
-        with open(METADATA_QUERY_SUCCESS, 'rb') as f:
+        with open(METADATA_QUERY_SUCCESS, 'r') as f:
             response_json = json.load(f)
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)
@@ -47,7 +47,7 @@ class MetadataTests(unittest.TestCase):
         self.assertDictEqual(EXPECTED_DICT, datasources)
 
     def test_metadata_query_ignore_error(self):
-        with open(METADATA_QUERY_ERROR, 'rb') as f:
+        with open(METADATA_QUERY_ERROR, 'r') as f:
             response_json = json.load(f)
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)
@@ -59,7 +59,7 @@ class MetadataTests(unittest.TestCase):
         self.assertDictEqual(EXPECTED_DICT, datasources)
 
     def test_metadata_query_abort_on_error(self):
-        with open(METADATA_QUERY_ERROR, 'rb') as f:
+        with open(METADATA_QUERY_ERROR, 'r') as f:
             response_json = json.load(f)
         with requests_mock.mock() as m:
             m.post(self.baseurl, json=response_json)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -36,10 +36,10 @@ class MetadataTests(unittest.TestCase):
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
 
     def test_metadata_query(self):
-        with open(METADATA_QUERY_SUCCESS, 'r') as f:
-            response_json = json.load(f)
+        with open(METADATA_QUERY_SUCCESS, 'rb') as f:
+            response_json = f.read()
         with requests_mock.mock() as m:
-            m.post(self.baseurl, json=response_json)
+            m.post(self.baseurl, content=response_json)
             actual = self.server.metadata.query('fake query')
 
             datasources = actual['data']
@@ -47,10 +47,10 @@ class MetadataTests(unittest.TestCase):
         self.assertDictEqual(EXPECTED_DICT, datasources)
 
     def test_metadata_query_ignore_error(self):
-        with open(METADATA_QUERY_ERROR, 'r') as f:
-            response_json = json.load(f)
+        with open(METADATA_QUERY_ERROR, 'rb') as f:
+            response_json = f.read()
         with requests_mock.mock() as m:
-            m.post(self.baseurl, json=response_json)
+            m.post(self.baseurl, content=response_json)
             actual = self.server.metadata.query('fake query')
             datasources = actual['data']
 
@@ -59,10 +59,10 @@ class MetadataTests(unittest.TestCase):
         self.assertDictEqual(EXPECTED_DICT, datasources)
 
     def test_metadata_query_abort_on_error(self):
-        with open(METADATA_QUERY_ERROR, 'r') as f:
-            response_json = json.load(f)
+        with open(METADATA_QUERY_ERROR, 'rb') as f:
+            response_json = f.read()
         with requests_mock.mock() as m:
-            m.post(self.baseurl, json=response_json)
+            m.post(self.baseurl, content=response_json)
 
             with self.assertRaises(GraphQLError) as e:
                 self.server.metadata.query('fake query', abort_on_error=True)


### PR DESCRIPTION
In preparation for the Metadata API (soon to be in wide beta) I wanted to add support to TSC.

It's very basic right now, it just takes a GraphQL query (a string) and returns a dict from the json response.

We could build in some helpers over time for pagination (It's more complicated in GraphQL) and methods to convert from metadata node objects to REST API objects... but for now this should let people get going.