### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
 # command to install dependencies
 install:
   - "pip install -e ."
@@ -14,5 +12,4 @@ install:
 script:
   # Tests
   - python setup.py test
-  # pep8 - disabled for now until we can scrub the files to make sure we pass before turning it on
   - pycodestyle tableauserverclient test samples


### PR DESCRIPTION
3.3 and 3.4 are EOL, as well as not significantly different than the other 3's.

Dropping them, and pypy (which is also not significantly different at this point, and is slow to run the pipeline), and adding 3.7