### PR TITLE
Change server_info endpoint error message to be verbose

### DIFF
--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -22,6 +22,5 @@ class ServerInfo(Endpoint):
             if e.code == "404001":
                 raise EndpointUnavailableError
 
-
         server_info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
         return server_info

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -19,6 +19,8 @@ class ServerInfo(Endpoint):
         except ServerResponseError as e:
             if e.code == "404003":
                 raise ServerInfoEndpointNotFoundError
+            if e.code == "404001":
+                raise EndpointUnavailableError
 
         server_info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
         return server_info

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -22,5 +22,6 @@ class ServerInfo(Endpoint):
             if e.code == "404001":
                 raise EndpointUnavailableError
 
+
         server_info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
         return server_info

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -1,5 +1,5 @@
 from .endpoint import Endpoint, api
-from .exceptions import ServerResponseError, ServerInfoEndpointNotFoundError
+from .exceptions import ServerResponseError, ServerInfoEndpointNotFoundError, EndpointUnavailableError
 from ...models import ServerInfoItem
 import logging
 

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -58,7 +58,7 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags:in:[stocks,market]')
+            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags:in:%5bstocks,market%5d')
 
     def test_sort_asc(self):
         with requests_mock.mock() as m:


### PR DESCRIPTION
Add handling for case in which API version is not supported by the Tableau server. While trying to explore this library, I ran into an error when trying to call `server.server_info_get()`
```
>>> server.version = "2.5"
>>> server.server_info.get()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jojacob/development/dasre-tableau-insights_trunk/build/dasre-tableau-insights/venv/lib/python3.7/site-packages/tableauserverclient/server/endpoint/endpoint.py", line 108, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/jojacob/development/dasre-tableau-insights_trunk/build/dasre-tableau-insights/venv/lib/python3.7/site-packages/tableauserverclient/server/endpoint/server_info_endpoint.py", line 25, in get
    server_info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
UnboundLocalError: local variable 'server_response' referenced before assignment
```

This stems from the code here:

https://github.com/jacobj10/server-client-python/blob/e4ec849b19f02f016f90e641756d9bd81d23d026/tableauserverclient/server/endpoint/server_info_endpoint.py#L17-L21

which can catch an error without setting the variable, leading to a confusing and non descriptive UnboundLocalError. Right now I just added an extra check for my specific error (version unsupported), but it my be worth just raising whatever error comes from the response.

This is my first time contributing so please let me know if you have any questions, comments, or concerns.