### PR TITLE
Fix update_workbook endpoint to address #454

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -382,7 +382,7 @@ class WorkbookRequest(object):
         workbook_element = ET.SubElement(xml_request, 'workbook')
         if workbook_item.name:
             workbook_element.attrib['name'] = workbook_item.name
-        if workbook_item.show_tabs:
+        if workbook_item.show_tabs is not None:
             workbook_element.attrib['showTabs'] = str(workbook_item.show_tabs).lower()
         if workbook_item.project_id:
             project_element = ET.SubElement(workbook_element, 'project')
@@ -390,7 +390,8 @@ class WorkbookRequest(object):
         if workbook_item.owner_id:
             owner_element = ET.SubElement(workbook_element, 'owner')
             owner_element.attrib['id'] = workbook_item.owner_id
-        if workbook_item.materialized_views_config is not None:
+        if workbook_item.materialized_views_config['materialized_views_enabled']\
+                and workbook_item.materialized_views_config['run_materialization_now']:
             materialized_views_config = workbook_item.materialized_views_config
             materialized_views_element = ET.SubElement(workbook_element, 'materializedViewsEnablementConfig')
             materialized_views_element.attrib['materializedViewsEnabled'] = str(materialized_views_config


### PR DESCRIPTION
Fixing error in update workbook that was caused by materialized view config being included in the request, even for old server versions.
Also fixed a bug where showTabs property would not get updated properly if changing it to 'false'. 