### PR TITLE
Adding support for Personal Access Token login

### DIFF
--- a/samples/login.py
+++ b/samples/login.py
@@ -9,6 +9,7 @@ import tableauserverclient as TSC
 
 import setup_helper as Helper
 
+
 def main():
 
     setup_helper = Helper.SetupHelper('Create a user group.')

--- a/samples/login.py
+++ b/samples/login.py
@@ -1,0 +1,22 @@
+####
+# This script demonstrates how to log in to Tableau Server Client.
+#
+# To run the script, you must have installed Python 2.7.9 or later.
+####
+
+
+import tableauserverclient as TSC
+
+import setup_helper as Helper
+
+def main():
+
+    setup_helper = Helper.SetupHelper('Create a user group.')
+    setup_helper.createServer()
+
+    with setup_helper.login():
+        print('Logged in successfully')
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/setup_helper.py
+++ b/samples/setup_helper.py
@@ -1,0 +1,62 @@
+####
+# This script provides the shared login logic and server creation for all other samples.
+#
+# To run the script, you must have installed Python 2.7.9 or later.
+####
+
+import argparse
+import getpass
+import logging
+
+from datetime import time
+
+import tableauserverclient as TSC
+
+class SetupHelper(object):
+    def __init__(self, description):
+        self._parser = argparse.ArgumentParser(description=description)
+        self._addServerArgs()
+        self._addLoginArgs()
+        self._addLoggerArgs()
+
+    def _addLoginArgs(self):
+        group = self._parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--username', '-u', help='username to sign into the server')
+        group.add_argument('--token-name', '-n', help='name of the personal access token used to sign into the server')
+
+    def _addServerArgs(self):
+        self._parser.add_argument('--server', '-s', required=True, help='server address')
+
+    def _addLoggerArgs(self):
+        self._parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                    help='desired logging level (set to error by default)')
+
+    def getParser(self):
+        return self._parser
+
+    def createServer(self):
+        args = self._parser.parse_args()
+
+        # Set logging level based on user input, or error by default
+        logging_level = getattr(logging, args.logging_level.upper())
+        logging.basicConfig(level=logging_level)
+
+        self._server = TSC.Server(args.server)
+        return self._server
+
+    def login(self):
+        if not self._server:
+            raise RuntimeError('Please call createServer first')
+
+        args = self._parser.parse_args()
+
+        if args.username:
+            # Trying to authenticate using username and password.
+            password = getpass.getpass("Password: ")
+            tableau_auth = TSC.TableauAuth(args.username, password)
+        else:
+            # Trying to authenticate using personal access tokens.
+            personal_access_token = getpass.getpass("Personal Access Token: ")
+            tableau_auth = TSC.TableauAuth(token_name=args.token_name, personal_access_token=personal_access_token)
+
+        return self._server.auth.sign_in(tableau_auth)

--- a/samples/setup_helper.py
+++ b/samples/setup_helper.py
@@ -12,6 +12,7 @@ from datetime import time
 
 import tableauserverclient as TSC
 
+
 class SetupHelper(object):
     def __init__(self, description):
         self._parser = argparse.ArgumentParser(description=description)
@@ -29,7 +30,7 @@ class SetupHelper(object):
 
     def _addLoggerArgs(self):
         self._parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                    help='desired logging level (set to error by default)')
+                                    help='desired logging level (set to error by default)')
 
     def getParser(self):
         return self._parser

--- a/samples/setup_helper.py
+++ b/samples/setup_helper.py
@@ -30,7 +30,7 @@ class SetupHelper(object):
 
     def _addLoggerArgs(self):
         self._parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                                    help='desired logging level (set to error by default)')
+                                  help='desired logging level (set to error by default)')
 
     def getParser(self):
         return self._parser

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -1,6 +1,6 @@
 class TableauAuth(object):
     def __init__(self, username='', password='', site=None, site_id='', user_id_to_impersonate=None, token_name='',
-                    personal_access_token=''):
+                 personal_access_token=''):
         if site is not None:
             import warnings
             warnings.warn('TableauAuth(...site=""...) is deprecated, '

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -1,5 +1,6 @@
 class TableauAuth(object):
-    def __init__(self, username='', password='', site=None, site_id='', user_id_to_impersonate=None, token_name='', personal_access_token=''):
+    def __init__(self, username='', password='', site=None, site_id='', user_id_to_impersonate=None, token_name='',
+                    personal_access_token=''):
         if site is not None:
             import warnings
             warnings.warn('TableauAuth(...site=""...) is deprecated, '

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -1,5 +1,5 @@
 class TableauAuth(object):
-    def __init__(self, username, password, site=None, site_id='', user_id_to_impersonate=None):
+    def __init__(self, username='', password='', site=None, site_id='', user_id_to_impersonate=None, token_name='', personal_access_token=''):
         if site is not None:
             import warnings
             warnings.warn('TableauAuth(...site=""...) is deprecated, '
@@ -11,6 +11,8 @@ class TableauAuth(object):
         self.password = password
         self.site_id = site_id
         self.username = username
+        self.token_name = token_name
+        self.personal_access_token = personal_access_token
 
     @property
     def site(self):

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -35,7 +35,7 @@ class Auth(Endpoint):
         user_id = parsed_response.find('.//t:user', namespaces=self.parent_srv.namespace).get('id', None)
         auth_token = parsed_response.find('t:credentials', namespaces=self.parent_srv.namespace).get('token', None)
         self.parent_srv._set_auth(site_id, user_id, auth_token)
-        logger.info('Signed into {0} as {1}'.format(self.parent_srv.server_address, auth_req.username))
+        logger.info('Signed into {0} as user with id {1}'.format(self.parent_srv.server_address, user_id))
         return Auth.contextmgr(self.sign_out)
 
     @api(version="2.0")

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -50,6 +50,8 @@ class AuthRequest(object):
         credentials_element = ET.SubElement(xml_request, 'credentials')
         credentials_element.attrib['name'] = auth_item.username
         credentials_element.attrib['password'] = auth_item.password
+        credentials_element.attrib['clientId'] = auth_item.token_name
+        credentials_element.attrib['personalAccessToken'] = auth_item.personal_access_token
         site_element = ET.SubElement(credentials_element, 'site')
         site_element.attrib['contentUrl'] = auth_item.site_id
         if auth_item.user_id_to_impersonate:

--- a/test/assets/auth_sign_in_impersonate_error.xml
+++ b/test/assets/auth_sign_in_impersonate_error.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <error code="401001">
+        <summary>Signin Error</summary>
+        <detail>Impersonation is not supported when using Personal Access Tokens.</detail>
+    </error>
+</tsResponse>

--- a/test/assets/auth_sign_in_multiple_credentials_error.xml
+++ b/test/assets/auth_sign_in_multiple_credentials_error.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <error code="400000">
+        <summary>Bad Request</summary>
+        <detail>Please provide either name and password or clientId and personalAccessToken.</detail>
+    </error>
+</tsResponse>

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -60,7 +60,7 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
             tableau_auth = TSC.TableauAuth(token_name='mytoken', personal_access_token='mvFsqyansa4',
-                                            user_id_to_impersonate='dd2239f6-ddf1-4107-981a-4cf94e415794')
+                                           user_id_to_impersonate='dd2239f6-ddf1-4107-981a-4cf94e415794')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_in_error(self):
@@ -85,7 +85,7 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
             tableau_auth = TSC.TableauAuth('testuser', 'somepassword', token_name='mytoken',
-                                            personal_access_token='sometokenstring')
+                                           personal_access_token='sometokenstring')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_out(self):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -7,7 +7,9 @@ TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
 SIGN_IN_XML = os.path.join(TEST_ASSET_DIR, 'auth_sign_in.xml')
 SIGN_IN_IMPERSONATE_XML = os.path.join(TEST_ASSET_DIR, 'auth_sign_in_impersonate.xml')
+SIGN_IN_IMPERSONATE_ERROR_XML = os.path.join(TEST_ASSET_DIR, 'auth_sign_in_impersonate_error.xml')
 SIGN_IN_ERROR_XML = os.path.join(TEST_ASSET_DIR, 'auth_sign_in_error.xml')
+SIGN_IN_MULTIPLE_CREDEINTIALS_ERROR_XML = os.path.join(TEST_ASSET_DIR, 'auth_sign_in_multiple_credentials_error.xml')
 
 
 class AuthTests(unittest.TestCase):
@@ -27,6 +29,18 @@ class AuthTests(unittest.TestCase):
         self.assertEqual('6b7179ba-b82b-4f0f-91ed-812074ac5da6', self.server.site_id)
         self.assertEqual('1a96d216-e9b8-497b-a82a-0b899a965e01', self.server.user_id)
 
+    def test_sign_in_with_personal_access_tokens(self):
+        with open(SIGN_IN_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/signin', text=response_xml)
+            tableau_auth = TSC.TableauAuth(token_name='mytoken', personal_access_token='mvFsqyansa4', site_id='Samples')
+            self.server.auth.sign_in(tableau_auth)
+
+        self.assertEqual('eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l', self.server.auth_token)
+        self.assertEqual('6b7179ba-b82b-4f0f-91ed-812074ac5da6', self.server.site_id)
+        self.assertEqual('1a96d216-e9b8-497b-a82a-0b899a965e01', self.server.user_id)
+
     def test_sign_in_impersonate(self):
         with open(SIGN_IN_IMPERSONATE_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
@@ -39,6 +53,14 @@ class AuthTests(unittest.TestCase):
         self.assertEqual('MJonFA6HDyy2C3oqR13fRGqE6cmgzwq3', self.server.auth_token)
         self.assertEqual('dad65087-b08b-4603-af4e-2887b8aafc67', self.server.site_id)
         self.assertEqual('dd2239f6-ddf1-4107-981a-4cf94e415794', self.server.user_id)
+
+    def test_sign_in_impersonate_with_personal_access_tokens(self):
+        with open(SIGN_IN_IMPERSONATE_ERROR_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
+            tableau_auth = TSC.TableauAuth(token_name='mytoken', personal_access_token='mvFsqyansa4', user_id_to_impersonate='dd2239f6-ddf1-4107-981a-4cf94e415794')
+            self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_in_error(self):
         with open(SIGN_IN_ERROR_XML, 'rb') as f:
@@ -54,6 +76,14 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
             tableau_auth = TSC.TableauAuth('', '')
+            self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
+
+    def test_sign_in_multiple_credentials(self):
+        with open(SIGN_IN_MULTIPLE_CREDEINTIALS_ERROR_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
+            tableau_auth = TSC.TableauAuth('testuser', 'somepassword', token_name='mytoken', personal_access_token='sometokenstring')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_out(self):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -59,7 +59,8 @@ class AuthTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
-            tableau_auth = TSC.TableauAuth(token_name='mytoken', personal_access_token='mvFsqyansa4', user_id_to_impersonate='dd2239f6-ddf1-4107-981a-4cf94e415794')
+            tableau_auth = TSC.TableauAuth(token_name='mytoken', personal_access_token='mvFsqyansa4',
+                                            user_id_to_impersonate='dd2239f6-ddf1-4107-981a-4cf94e415794')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_in_error(self):
@@ -83,7 +84,8 @@ class AuthTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
-            tableau_auth = TSC.TableauAuth('testuser', 'somepassword', token_name='mytoken', personal_access_token='sometokenstring')
+            tableau_auth = TSC.TableauAuth('testuser', 'somepassword', token_name='mytoken',
+                                            personal_access_token='sometokenstring')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_out(self):

--- a/test/test_tableauauth_model.py
+++ b/test/test_tableauauth_model.py
@@ -10,10 +10,6 @@ class TableauAuthModelTests(unittest.TestCase):
                                     site_id='site1',
                                     user_id_to_impersonate='admin')
 
-    def test_username_password_required(self):
-        with self.assertRaises(TypeError):
-            TSC.TableauAuth()
-
     def test_site_arg_raises_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")


### PR DESCRIPTION
The rest api sign in request will support providing a personal access token, along with its name, as a valid credential instead of username and password.

Setting up shared code to be able to migrate all samples to use the same helper and give support to standard arguments, like serverURL, logLevel and sign in credentials