### PR TITLE
Personal Access Token Authentication

### DIFF
--- a/samples/login.py
+++ b/samples/login.py
@@ -1,0 +1,48 @@
+####
+# This script demonstrates how to log in to Tableau Server Client.
+#
+# To run the script, you must have installed Python 2.7.9 or later.
+####
+
+import argparse
+import getpass
+import logging
+
+import tableauserverclient as TSC
+
+
+def main():
+        parser = argparse.ArgumentParser(description='Logs in to the server.')
+
+        parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                                  help='desired logging level (set to error by default)')
+
+        parser.add_argument('--server', '-s', required=True, help='server address')
+
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--username', '-u', help='username to sign into the server')
+        group.add_argument('--token-name', '-n', help='name of the personal access token used to sign into the server')
+
+        args = parser.parse_args()
+
+        # Set logging level based on user input, or error by default
+        logging_level = getattr(logging, args.logging_level.upper())
+        logging.basicConfig(level=logging_level)
+
+        server = TSC.Server(args.server)
+
+        if args.username:
+            # Trying to authenticate using username and password.
+            password = getpass.getpass("Password: ")
+            tableau_auth = TSC.TableauAuth(args.username, password)
+        else:
+            # Trying to authenticate using personal access tokens.
+            personal_access_token = getpass.getpass("Personal Access Token: ")
+            tableau_auth = TSC.PersonalAccessTokenAuth(token_name=args.token_name, personal_access_token=personal_access_token)
+
+        with server.auth.sign_in(tableau_auth):
+            print('Logged in successfully')
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/login.py
+++ b/samples/login.py
@@ -12,36 +12,37 @@ import tableauserverclient as TSC
 
 
 def main():
-        parser = argparse.ArgumentParser(description='Logs in to the server.')
+    parser = argparse.ArgumentParser(description='Logs in to the server.')
 
-        parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                                  help='desired logging level (set to error by default)')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
 
-        parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--server', '-s', required=True, help='server address')
 
-        group = parser.add_mutually_exclusive_group(required=True)
-        group.add_argument('--username', '-u', help='username to sign into the server')
-        group.add_argument('--token-name', '-n', help='name of the personal access token used to sign into the server')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--username', '-u', help='username to sign into the server')
+    group.add_argument('--token-name', '-n', help='name of the personal access token used to sign into the server')
 
-        args = parser.parse_args()
+    args = parser.parse_args()
 
-        # Set logging level based on user input, or error by default
-        logging_level = getattr(logging, args.logging_level.upper())
-        logging.basicConfig(level=logging_level)
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
 
-        server = TSC.Server(args.server)
+    server = TSC.Server(args.server)
 
-        if args.username:
-            # Trying to authenticate using username and password.
-            password = getpass.getpass("Password: ")
-            tableau_auth = TSC.TableauAuth(args.username, password)
-        else:
-            # Trying to authenticate using personal access tokens.
-            personal_access_token = getpass.getpass("Personal Access Token: ")
-            tableau_auth = TSC.PersonalAccessTokenAuth(token_name=args.token_name, personal_access_token=personal_access_token)
+    if args.username:
+        # Trying to authenticate using username and password.
+        password = getpass.getpass("Password: ")
+        tableau_auth = TSC.TableauAuth(args.username, password)
+    else:
+        # Trying to authenticate using personal access tokens.
+        personal_access_token = getpass.getpass("Personal Access Token: ")
+        tableau_auth = TSC.PersonalAccessTokenAuth(token_name=args.token_name,
+                                                   personal_access_token=personal_access_token)
 
-        with server.auth.sign_in(tableau_auth):
-            print('Logged in successfully')
+    with server.auth.sign_in(tableau_auth):
+        print('Logged in successfully')
 
 
 if __name__ == '__main__':

--- a/samples/login.py
+++ b/samples/login.py
@@ -25,24 +25,27 @@ def main():
 
     args = parser.parse_args()
 
-    # Set logging level based on user input, or error by default
+    # Set logging level based on user input, or error by default.
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    server = TSC.Server(args.server)
+    # Make sure we use an updated version of the rest apis.
+    server = TSC.Server(args.server, use_server_version=True)
 
     if args.username:
         # Trying to authenticate using username and password.
         password = getpass.getpass("Password: ")
         tableau_auth = TSC.TableauAuth(args.username, password)
+        with server.auth.sign_in(tableau_auth):
+            print('Logged in successfully')
+
     else:
         # Trying to authenticate using personal access tokens.
         personal_access_token = getpass.getpass("Personal Access Token: ")
         tableau_auth = TSC.PersonalAccessTokenAuth(token_name=args.token_name,
                                                    personal_access_token=personal_access_token)
-
-    with server.auth.sign_in(tableau_auth):
-        print('Logged in successfully')
+        with server.auth.sign_in_with_personal_access_token(tableau_auth):
+            print('Logged in successfully')
 
 
 if __name__ == '__main__':

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -1,7 +1,7 @@
 from .namespace import NEW_NAMESPACE as DEFAULT_NAMESPACE
 from .models import ConnectionCredentials, ConnectionItem, DatasourceItem,\
     GroupItem, JobItem, BackgroundJobItem, PaginationItem, ProjectItem, ScheduleItem, \
-    SiteItem, TableauAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
+    SiteItem, TableauAuth, PersonalAccessTokenAuth, UserItem, ViewItem, WorkbookItem, UnpopulatedPropertyError, \
     HourlyInterval, DailyInterval, WeeklyInterval, MonthlyInterval, IntervalItem, TaskItem, \
     SubscriptionItem, Target
 from .server import RequestOptions, CSVRequestOptions, ImageRequestOptions, PDFRequestOptions, Filter, Sort, \

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -11,6 +11,7 @@ from .schedule_item import ScheduleItem
 from .server_info_item import ServerInfoItem
 from .site_item import SiteItem
 from .tableau_auth import TableauAuth
+from .personal_access_token_auth import PersonalAccessTokenAuth
 from .target import Target
 from .task_item import TaskItem
 from .user_item import UserItem

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -6,5 +6,6 @@ class PersonalAccessTokenAuth(object):
         # Personal Access Tokens doesn't support impersonation.
         self.user_id_to_impersonate = None
 
+    @property
     def credentials(self):
         return {'clientId': self.token_name, 'personalAccessToken': self.personal_access_token}

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -7,4 +7,4 @@ class PersonalAccessTokenAuth(object):
         self.user_id_to_impersonate = None
 
     def credentials(self):
-        return { 'clientId': self.token_name, 'personalAccessToken': self.personal_access_token }
+        return {'clientId': self.token_name, 'personalAccessToken': self.personal_access_token}

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -1,0 +1,10 @@
+class PersonalAccessTokenAuth(object):
+    def __init__(self, token_name, personal_access_token, site_id=''):
+        self.token_name = token_name
+        self.personal_access_token = personal_access_token
+        self.site_id = site_id
+        # Personal Access Tokens doesn't support impersonation.
+        self.user_id_to_impersonate = None
+
+    def credentials(self):
+        return { 'clientId': self.token_name, 'personalAccessToken': self.personal_access_token }

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -26,5 +26,6 @@ class TableauAuth(object):
                       DeprecationWarning)
         self.site_id = value
 
+    @property
     def credentials(self):
         return {'name': self.username, 'password': self.password}

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -27,4 +27,4 @@ class TableauAuth(object):
         self.site_id = value
 
     def credentials(self):
-        return { 'name': self.username, 'password': self.password }
+        return {'name': self.username, 'password': self.password}

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -25,3 +25,6 @@ class TableauAuth(object):
         warnings.warn('TableauAuth.site is deprecated, use TableauAuth.site_id instead.',
                       DeprecationWarning)
         self.site_id = value
+
+    def credentials(self):
+        return { 'name': self.username, 'password': self.password }

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -35,7 +35,7 @@ class Auth(Endpoint):
         user_id = parsed_response.find('.//t:user', namespaces=self.parent_srv.namespace).get('id', None)
         auth_token = parsed_response.find('t:credentials', namespaces=self.parent_srv.namespace).get('token', None)
         self.parent_srv._set_auth(site_id, user_id, auth_token)
-        logger.info('Signed into {0} as {1}'.format(self.parent_srv.server_address, auth_req.username))
+        logger.info('Signed into {0} as user with id {1}'.format(self.parent_srv.server_address, user_id))
         return Auth.contextmgr(self.sign_out)
 
     @api(version="2.0")

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -38,6 +38,11 @@ class Auth(Endpoint):
         logger.info('Signed into {0} as user with id {1}'.format(self.parent_srv.server_address, user_id))
         return Auth.contextmgr(self.sign_out)
 
+    @api(version="3.6")
+    def sign_in_with_personal_access_token(self, auth_req):
+        # We use the same request that username/password login uses.
+        return self.sign_in(auth_req)
+
     @api(version="2.0")
     def sign_out(self):
         url = "{0}/{1}".format(self.baseurl, 'signout')

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -47,16 +47,18 @@ def _add_credentials_element(parent_element, connection_credentials):
 class AuthRequest(object):
     def signin_req(self, auth_item):
         xml_request = ET.Element('tsRequest')
+
         credentials_element = ET.SubElement(xml_request, 'credentials')
-        credentials_element.attrib['name'] = auth_item.username
-        credentials_element.attrib['password'] = auth_item.password
+        for attribute_name, attribute_value in auth_item.credentials().items():
+            credentials_element.attrib[attribute_name] = attribute_value
+
         site_element = ET.SubElement(credentials_element, 'site')
         site_element.attrib['contentUrl'] = auth_item.site_id
+
         if auth_item.user_id_to_impersonate:
             user_element = ET.SubElement(credentials_element, 'user')
             user_element.attrib['id'] = auth_item.user_id_to_impersonate
         return ET.tostring(xml_request)
-
 
 class DatasourceRequest(object):
     def _generate_xml(self, datasource_item, connection_credentials=None, connections=None):

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -60,6 +60,7 @@ class AuthRequest(object):
             user_element.attrib['id'] = auth_item.user_id_to_impersonate
         return ET.tostring(xml_request)
 
+
 class DatasourceRequest(object):
     def _generate_xml(self, datasource_item, connection_credentials=None, connections=None):
         xml_request = ET.Element('tsRequest')

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -49,7 +49,7 @@ class AuthRequest(object):
         xml_request = ET.Element('tsRequest')
 
         credentials_element = ET.SubElement(xml_request, 'credentials')
-        for attribute_name, attribute_value in auth_item.credentials().items():
+        for attribute_name, attribute_value in auth_item.credentials.items():
             credentials_element.attrib[attribute_name] = attribute_value
 
         site_element = ET.SubElement(credentials_element, 'site')

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -39,7 +39,7 @@ class AuthTests(unittest.TestCase):
         self.assertEqual('eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l', self.server.auth_token)
         self.assertEqual('6b7179ba-b82b-4f0f-91ed-812074ac5da6', self.server.site_id)
         self.assertEqual('1a96d216-e9b8-497b-a82a-0b899a965e01', self.server.user_id)
-        
+
     def test_sign_in_impersonate(self):
         with open(SIGN_IN_IMPERSONATE_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
@@ -68,7 +68,7 @@ class AuthTests(unittest.TestCase):
             m.post(self.baseurl + '/signin', text=response_xml, status_code=401)
             tableau_auth = TSC.PersonalAccessTokenAuth(token_name='mytoken', personal_access_token='invalid')
             self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
-            
+
     def test_sign_in_without_auth(self):
         with open(SIGN_IN_ERROR_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')


### PR DESCRIPTION
The rest api sign in request will support providing a personal access token, along with its name, as a valid credential instead of username and password.

Created a new credential type aside of TableauAuth. They both have the same request/response format, the only difference is the credentials section of the request, where they provide different arguments.

Adding tests and a sample that shows how to use the new capabilities