### PR TITLE
Update in Write your first program.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -66,7 +66,7 @@ Run the following code to get a list of all the data sources on your installatio
 ```py
 import tableauserverclient as TSC
 
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
 server = TSC.Server('http://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):


### PR DESCRIPTION
TableauAuth Class requires site_id as the third parameter for successfully logging in. But the example on the Getting started page doesn't follow this.