### PR TITLE
Documentation: Update in Write your first program

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -66,7 +66,7 @@ Run the following code to get a list of all the data sources on your installatio
 ```py
 import tableauserverclient as TSC
 
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
 server = TSC.Server('http://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):


### PR DESCRIPTION
**TableauAuth** Class requires a third parameter **site_id** as specified in the _API reference_. But the Getting started sample code passes only **username** and **password**. This leads to an authentication  error.