### PR TITLE
Documentation: Update Write your first program

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ with server.auth.sign_in(tableau_auth):
     print("\nThere are {} datasources on site: ".format(pagination_item.total_available))
     print([datasource.name for datasource in all_datasources])
 ```
-For Tableau online TSC.TableauAuth should be used with site_id
+To authenticate to Tableau Online, or a site other than the default site within a local Tableau Server installation, the site_id(SITE_NAME) parameter must be used to specify the site.
 ```py
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITENAME')
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ Run the following code to get a list of all the data sources on your installatio
 ```py
 import tableauserverclient as TSC
 
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
 server = TSC.Server('http://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ with server.auth.sign_in(tableau_auth):
     print("\nThere are {} datasources on site: ".format(pagination_item.total_available))
     print([datasource.name for datasource in all_datasources])
 ```
-For Tableau online TSC.TableauAuth is used with site_id
+For Tableau online TSC.TableauAuth should be used with site_id
 ```py
 tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,11 +66,15 @@ Run the following code to get a list of all the data sources on your installatio
 ```py
 import tableauserverclient as TSC
 
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
 server = TSC.Server('http://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):
     all_datasources, pagination_item = server.datasources.get()
     print("\nThere are {} datasources on site: ".format(pagination_item.total_available))
     print([datasource.name for datasource in all_datasources])
+```
+For Tableau online TSC.TableauAuth is used with site_id
+```py
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD','SITEID')
 ```


### PR DESCRIPTION
TableauAuth Class requires a third parameter site_id as given in the API reference. If only username and password is given it would lead to a Authentication Error.