### PR TITLE
Pin to urllib3 to fix encoding issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     test_suite='test',
     setup_requires=pytest_runner,
     install_requires=[
-        'requests>=2.11,<3.0'
+        'requests>=2.11,<3.0',
+        'urllib3==1.24.3'
     ],
     tests_require=[
         'requests-mock>=1.0,<2.0',


### PR DESCRIPTION
This is a quick fix to the url encoding issue(s) we are seeing.

There was a change after urllib3 1.24.3 that starting force encoding all non safe characters (I believe it is https://github.com/urllib3/urllib3/commit/5d523706c7b03f947dc50a7e783758a2bfff0532 that caused the issue.

Testing done: clean venv, pip installed with this change and saw the pinned version installed