### PR TITLE
Add topLevelProject filter to projects (#491)

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -34,6 +34,7 @@ class RequestOptions(RequestOptionsBase):
         Subtitle = 'subtitle'
         Tags = 'tags'
         Title = 'title'
+        TopLevelProject = 'topLevelProject'
         Type = 'type'
         UpdatedAt = 'updatedAt'
         UserCount = 'userCount'


### PR DESCRIPTION
Addressing issue #491:
With this change, you will be able to filter projects based on its 'topLevelProject' field value.