### PR TITLE
Quick Fix for NonXMLErrorException

### DIFF
--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -5,7 +5,7 @@ import requests_mock
 
 import tableauserverclient as TSC
 
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
+from tableauserverclient.server.endpoint.exceptions import InternalServerError, NonXMLResponseError
 
 
 class RequestTests(unittest.TestCase):
@@ -55,3 +55,11 @@ class RequestTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.register_uri('GET', self.server.server_info.baseurl, status_code=500, text=server_response)
             self.assertRaisesRegexp(InternalServerError, server_response, self.server.server_info.get)
+
+    # Test that 500 server errors are handled properly
+    def test_non_xml_error(self):
+        self.server.version = "3.2"
+        server_response = "this is not xml"
+        with requests_mock.mock() as m:
+            m.register_uri('GET', self.server.server_info.baseurl, status_code=499, text=server_response)
+            self.assertRaisesRegexp(NonXMLResponseError, server_response, self.server.server_info.get)

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -56,7 +56,7 @@ class RequestTests(unittest.TestCase):
             m.register_uri('GET', self.server.server_info.baseurl, status_code=500, text=server_response)
             self.assertRaisesRegexp(InternalServerError, server_response, self.server.server_info.get)
 
-    # Test that 500 server errors are handled properly
+    # Test that non-xml server errors are handled properly
     def test_non_xml_error(self):
         self.server.version = "3.2"
         server_response = "this is not xml"


### PR DESCRIPTION
This is a quick fix in response to #514. 

This should pass through any response body, regardless of whether or not it has one of our well-formed error XML objects in it.

However, it doesn't address all of the reporting user's issues -- for that I think we would need to re-evaluate how we catch exceptions and bubble them up.

The user requested we go back to v0.8.1 functionality, but I believe that would just throw ParseError because of the check in https://github.com/tableau/server-client-python/blob/master/tableauserverclient/server/endpoint/exceptions.py#L17

So let's take this fix now, and we can take some more time to better handle the report from #514 