### PR TITLE
Fix filename behavior and refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     ],
     tests_require=[
         'requests-mock>=1.0,<2.0',
-        'pytest'
+        'pytest',
+        'mock'
     ]
 )

--- a/tableauserverclient/filesys_helpers.py
+++ b/tableauserverclient/filesys_helpers.py
@@ -1,6 +1,22 @@
+import os
 ALLOWED_SPECIAL = (' ', '.', '_', '-')
 
 
 def to_filename(string_to_sanitize):
     sanitized = (c for c in string_to_sanitize if c.isalnum() or c in ALLOWED_SPECIAL)
     return "".join(sanitized)
+
+
+def make_download_path(filepath, filename):
+    download_path = None
+
+    if filepath is None:
+        download_path = filename
+
+    elif os.path.isdir(filepath):
+        download_path = os.path.join(filepath, filename)
+
+    else:
+        download_path = filepath + os.path.splitext(filename)[1]
+
+    return download_path

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -6,7 +6,7 @@ from .exceptions import MissingRequiredFieldError
 from .fileuploads_endpoint import Fileuploads
 from .resource_tagger import _ResourceTagger
 from .. import RequestFactory, DatasourceItem, PaginationItem, ConnectionItem
-from ...filesys_helpers import to_filename
+from ...filesys_helpers import to_filename, make_download_path
 from ...models.tag_item import TagItem
 from ...models.job_item import JobItem
 import os
@@ -104,17 +104,15 @@ class Datasources(Endpoint):
         with closing(self.get_request(url, parameters={'stream': True})) as server_response:
             _, params = cgi.parse_header(server_response.headers['Content-Disposition'])
             filename = to_filename(os.path.basename(params['filename']))
-            if filepath is None:
-                filepath = filename
-            elif os.path.isdir(filepath):
-                filepath = os.path.join(filepath, filename)
 
-            with open(filepath, 'wb') as f:
+            download_path = make_download_path(filepath, filename)
+
+            with open(download_path, 'wb') as f:
                 for chunk in server_response.iter_content(1024):  # 1KB
                     f.write(chunk)
 
-        logger.info('Downloaded datasource to {0} (ID: {1})'.format(filepath, datasource_id))
-        return os.path.abspath(filepath)
+        logger.info('Downloaded datasource to {0} (ID: {1})'.format(download_path, datasource_id))
+        return os.path.abspath(download_path)
 
     # Update datasource
     @api(version="2.0")

--- a/test/test_regression_tests.py
+++ b/test/test_regression_tests.py
@@ -1,6 +1,9 @@
 import unittest
+from unittest import mock
+
 import tableauserverclient.server.request_factory as factory
 from tableauserverclient.server.endpoint import Endpoint
+from tableauserverclient.filesys_helpers import to_filename, make_download_path
 
 
 class BugFix257(unittest.TestCase):
@@ -21,3 +24,36 @@ class BugFix273(unittest.TestCase):
         server_response = FakeResponse()
 
         self.assertEqual(Endpoint._safe_to_log(server_response), '[Truncated File Contents]')
+
+
+class FileSysHelpers(unittest.TestCase):
+    def test_to_filename(self):
+        invalid = [
+            "23brhafbjrjhkbbea.txt",
+            'a_b_C.txt',
+            'windows space.txt',
+            'abc#def.txt',
+            't@bL3A()',
+        ]
+
+        valid = [
+            "23brhafbjrjhkbbea.txt",
+            'a_b_C.txt',
+            'windows space.txt',
+            'abcdef.txt',
+            'tbL3A',
+        ]
+
+        self.assertTrue(all([(to_filename(i) == v) for i, v in zip(invalid, valid)]))
+
+    def test_make_download_path(self):
+        no_file_path = (None, 'file.ext')
+        has_file_path_folder = ('/root/folder/', 'file.ext')
+        has_file_path_file = ('out', 'file.ext')
+
+        self.assertEquals('file.ext', make_download_path(*no_file_path))
+        self.assertEquals('out.ext', make_download_path(*has_file_path_file))
+
+        with mock.patch('os.path.isdir') as mocked_isdir:
+            mocked_isdir.return_value = True
+            self.assertEquals('/root/folder/file.ext', make_download_path(*has_file_path_folder))

--- a/test/test_regression_tests.py
+++ b/test/test_regression_tests.py
@@ -1,5 +1,9 @@
 import unittest
-from unittest import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import tableauserverclient.server.request_factory as factory
 from tableauserverclient.server.endpoint import Endpoint


### PR DESCRIPTION
There was a subtle bug where a non-folder filename would clobber the extension, for mass-download scripts this makes it hard to know what file you've downloaded (I rename to random guids to avoid name collisions).

This fixes it, and also adds tests for filesystem helpers.