### PR TITLE
Fix minor bug in request factory

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -487,8 +487,9 @@ class WorkbookRequest(object):
             materialized_views_element = ET.SubElement(workbook_element, 'materializedViewsEnablementConfig')
             materialized_views_element.attrib['materializedViewsEnabled'] = str(materialized_views_config
                                                                                 ["materialized_views_enabled"]).lower()
-            materialized_views_element.attrib['materializeNow'] = str(materialized_views_config
-                                                                      ["run_materialization_now"]).lower()
+            if "run_materialization_now" in materialized_views_config:
+                materialized_views_element.attrib['materializeNow'] = str(materialized_views_config
+                                                                          ["run_materialization_now"]).lower()
 
         return ET.tostring(xml_request)
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -481,8 +481,7 @@ class WorkbookRequest(object):
             owner_element = ET.SubElement(workbook_element, 'owner')
             owner_element.attrib['id'] = workbook_item.owner_id
         if workbook_item.materialized_views_config is not None and \
-                'materialized_views_enabled' in workbook_item.materialized_views_config and \
-                'run_materialization_now' in workbook_item.materialized_views_config:
+                'materialized_views_enabled' in workbook_item.materialized_views_config:
             materialized_views_config = workbook_item.materialized_views_config
             materialized_views_element = ET.SubElement(workbook_element, 'materializedViewsEnablementConfig')
             materialized_views_element.attrib['materializedViewsEnabled'] = str(materialized_views_config

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -480,8 +480,9 @@ class WorkbookRequest(object):
         if workbook_item.owner_id:
             owner_element = ET.SubElement(workbook_element, 'owner')
             owner_element.attrib['id'] = workbook_item.owner_id
-        if workbook_item.materialized_views_config['materialized_views_enabled'] \
-                and workbook_item.materialized_views_config['run_materialization_now']:
+        if workbook_item.materialized_views_config is not None and \
+                'materialized_views_enabled' in workbook_item.materialized_views_config and \
+                'run_materialization_now' in workbook_item.materialized_views_config:
             materialized_views_config = workbook_item.materialized_views_config
             materialized_views_element = ET.SubElement(workbook_element, 'materializedViewsEnablementConfig')
             materialized_views_element.attrib['materializedViewsEnabled'] = str(materialized_views_config


### PR DESCRIPTION
Currently, the materialized views setting for a workbook can only be updated when materialized_views_enabled and run_materialization_now are both true. This prevents the workbooks from enabled and disabled correctly. The fix is to check if the materialized view config is not null and contains materialized_views_enabled and run_materialization_now.