### PR TITLE
Fix minor bug in request factory due to bool(time(0,0))==False in Python 3.4

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -302,7 +302,7 @@ class ScheduleRequest(object):
             schedule_element.attrib['frequency'] = interval_item._frequency
         frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
         frequency_element.attrib['start'] = str(interval_item.start_time)
-        if hasattr(interval_item, 'end_time') and interval_item.end_time:
+        if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
             frequency_element.attrib['end'] = str(interval_item.end_time)
         intervals_element = ET.SubElement(frequency_element, 'intervals')
         if hasattr(interval_item, 'interval'):

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -276,7 +276,7 @@ class ScheduleRequest(object):
         schedule_element.attrib['frequency'] = interval_item._frequency
         frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
         frequency_element.attrib['start'] = str(interval_item.start_time)
-        if hasattr(interval_item, 'end_time') and interval_item.end_time:
+        if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
             frequency_element.attrib['end'] = str(interval_item.end_time)
         if hasattr(interval_item, 'interval') and interval_item.interval:
             intervals_element = ET.SubElement(frequency_element, 'intervals')


### PR DESCRIPTION
Currently, it will fail if someone tries to create a schedule with an end_time being time(0,0) using Python 3.4. Looks there is a bug in Python 3.4 (https://stackoverflow.com/questions/28116931/datetime-time0-0-evaluates-as-false-in-boolean-context) which evaluates bool(time(0,0)) to False. 

But https://tableau.github.io/server-client-python/docs/ states it supports Python 3.3 or higher.

The fix is just to explicitly check if end_time is None.

