### PR TITLE
Receiving warnings in schedule creation

### DIFF
--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -103,6 +103,10 @@ class ScheduleItem(object):
     def updated_at(self):
         return self._updated_at
 
+    @property
+    def warnings(self):
+        return self._warnings
+
     def _parse_common_tags(self, schedule_xml, ns):
         if not isinstance(schedule_xml, ET.Element):
             schedule_xml = ET.fromstring(schedule_xml).find('.//t:schedule', namespaces=ns)
@@ -125,7 +129,7 @@ class ScheduleItem(object):
         return self
 
     def _set_values(self, id_, name, state, created_at, updated_at, schedule_type,
-                    next_run_at, end_schedule_at, execution_order, priority, interval_item):
+                    next_run_at, end_schedule_at, execution_order, priority, interval_item, warnings=None):
         if id_ is not None:
             self._id = id_
         if name:
@@ -148,6 +152,8 @@ class ScheduleItem(object):
             self._priority = priority
         if interval_item:
             self._interval_item = interval_item
+        if warnings:
+            self._warnings = warnings
 
     @classmethod
     def from_response(cls, resp, ns):
@@ -156,6 +162,11 @@ class ScheduleItem(object):
 
     @classmethod
     def from_element(cls, parsed_response, ns):
+        all_warning_xml = parsed_response.findall('.//t:warning', namespaces=ns)
+        warnings = list() if len(all_warning_xml) > 0 else None
+        for warning_xml in all_warning_xml:
+            warnings.append(warning_xml.get('message', None))
+
         all_schedule_items = []
         all_schedule_xml = parsed_response.findall('.//t:schedule', namespaces=ns)
         for schedule_xml in all_schedule_xml:
@@ -174,7 +185,8 @@ class ScheduleItem(object):
                                       end_schedule_at=end_schedule_at,
                                       execution_order=None,
                                       priority=None,
-                                      interval_item=None)
+                                      interval_item=None,
+                                      warnings=warnings)
 
             all_schedule_items.append(schedule_item)
         return all_schedule_items

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -276,7 +276,7 @@ class ScheduleRequest(object):
         schedule_element.attrib['frequency'] = interval_item._frequency
         frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
         frequency_element.attrib['start'] = str(interval_item.start_time)
-        if hasattr(interval_item, 'end_time') and interval_item.end_time:
+        if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
             frequency_element.attrib['end'] = str(interval_item.end_time)
         if hasattr(interval_item, 'interval') and interval_item.interval:
             intervals_element = ET.SubElement(frequency_element, 'intervals')

--- a/test/assets/schedule_create_weekly.xml
+++ b/test/assets/schedule_create_weekly.xml
@@ -9,4 +9,8 @@
             </intervals>
         </frequencyDetails>
     </schedule>
+    <warnings>
+        <warning message="warning 1"/>
+        <warning message="warning 2"/>
+    </warnings>
 </tsResponse>

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -153,6 +153,9 @@ class ScheduleTests(unittest.TestCase):
         self.assertEqual(time(9, 15), new_schedule.interval_item.start_time)
         self.assertEqual(("Monday", "Wednesday", "Friday"),
                          new_schedule.interval_item.interval)
+        self.assertEqual(2, len(new_schedule.warnings))
+        self.assertEqual("warning 1", new_schedule.warnings[0])
+        self.assertEqual("warning 2", new_schedule.warnings[1])
 
     def test_create_monthly(self):
         with open(CREATE_MONTHLY_XML, "rb") as f:


### PR DESCRIPTION
The recent changes in the server side code may add warnings when creating schedules. Here is an example response with such warnings:

<tsResponse>
    <schedule> ...  </schedule>
    <warnings>
        <warning message="The recurrence interval of the given schedule is larger than Vizql server data refresh interval of 720 minutes."/>
    </warnings>
</tsResponse>

This PR adds client code for receiving such warnings.
