### PR TITLE
Add warnings when adding workbook to schedule

### DIFF
--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -162,10 +162,7 @@ class ScheduleItem(object):
 
     @classmethod
     def from_element(cls, parsed_response, ns):
-        all_warning_xml = parsed_response.findall('.//t:warning', namespaces=ns)
-        warnings = list() if len(all_warning_xml) > 0 else None
-        for warning_xml in all_warning_xml:
-            warnings.append(warning_xml.get('message', None))
+        warnings = cls._read_warnings(parsed_response, ns)
 
         all_schedule_items = []
         all_schedule_xml = parsed_response.findall('.//t:schedule', namespaces=ns)
@@ -248,3 +245,22 @@ class ScheduleItem(object):
 
         return id, name, state, created_at, updated_at, schedule_type, \
             next_run_at, end_schedule_at, execution_order, priority, interval_item
+
+    @staticmethod
+    def parse_add_to_schedule_response(response, ns):
+        parsed_response = ET.fromstring(response.content)
+        warnings = ScheduleItem._read_warnings(parsed_response, ns)
+        all_task_xml = parsed_response.findall('.//t:task', namespaces=ns)
+
+        error = "Status {}: {}".format(response.status_code, response.reason) \
+            if response.status_code < 200 or response.status_code >= 300 else None
+        task_created = len(all_task_xml) > 0
+        return error, warnings, task_created
+
+    @staticmethod
+    def _read_warnings(parsed_response, ns):
+        all_warning_xml = parsed_response.findall('.//t:warning', namespaces=ns)
+        warnings = list() if len(all_warning_xml) > 0 else None
+        for warning_xml in all_warning_xml:
+            warnings.append(warning_xml.get('message', None))
+        return warnings

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 
 logger = logging.getLogger('tableau.endpoint.schedules')
 # Oh to have a first class Result concept in Python...
-AddResponse = namedtuple('AddResponse', ('result', 'error', 'warnings'))
-OK = AddResponse(result=True, error=None, warnings=None)
+AddResponse = namedtuple('AddResponse', ('result', 'error', 'warnings', 'task_created'))
+OK = AddResponse(result=True, error=None, warnings=None, task_created=None)
 
 
 class Schedules(Endpoint):
@@ -71,26 +71,21 @@ class Schedules(Endpoint):
     @api(version="2.8")
     def add_to_schedule(self, schedule_id, workbook=None, datasource=None,
                         task_type=TaskItem.Type.ExtractRefresh):
-        def read_warnings(response):
-            parsed_response = ET.fromstring(response)
-            all_warning_xml = parsed_response.findall('.//t:warning', namespaces=self.parent_srv.namespace)
-            warnings = list() if len(all_warning_xml) > 0 else None
-            for warning_xml in all_warning_xml:
-                warnings.append(warning_xml.get('message', None))
-            return warnings
-
         def add_to(resource, type_, req_factory):
             id_ = resource.id
             url = "{0}/{1}/{2}s".format(self.siteurl, schedule_id, type_)
             add_req = req_factory(id_, task_type=task_type)
             response = self.put_request(url, add_req)
-            warnings = read_warnings(response.content)
-            if response.status_code < 200 or response.status_code >= 300 or warnings:
-                return AddResponse(result=False,
-                                   error="Status {}: {}".format(response.status_code, response.reason),
-                                   warnings=warnings)
-            logger.info("Added {} to {} to schedule {}".format(type_, id_, schedule_id))
-            return OK
+
+            error, warnings, task_created = ScheduleItem.parse_add_to_schedule_response(
+                response, self.parent_srv.namespace)
+            if task_created:
+                logger.info("Added {} to {} to schedule {}".format(type_, id_, schedule_id))
+
+            if error is not None or warnings is not None:
+                return AddResponse(result=False, error=error, warnings=warnings, task_created=task_created)
+            else:
+                return OK
 
         items = []
 

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -1,4 +1,3 @@
-import xml.etree.ElementTree as ET
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, PaginationItem, ScheduleItem, WorkbookItem, DatasourceItem, TaskItem

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -276,7 +276,7 @@ class ScheduleRequest(object):
         schedule_element.attrib['frequency'] = interval_item._frequency
         frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
         frequency_element.attrib['start'] = str(interval_item.start_time)
-        if hasattr(interval_item, 'end_time') and interval_item.end_time:
+        if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
             frequency_element.attrib['end'] = str(interval_item.end_time)
         if hasattr(interval_item, 'interval') and interval_item.interval:
             intervals_element = ET.SubElement(frequency_element, 'intervals')

--- a/test/assets/schedule_add_datasource.xml
+++ b/test/assets/schedule_add_datasource.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <task>
+    <extractRefresh>
+      <schedule id="schedule-id" />
+      <datasource id="workbook-id" />
+    </extractRefresh>
+  </task>
+</tsResponse>

--- a/test/assets/schedule_add_datasource.xml
+++ b/test/assets/schedule_add_datasource.xml
@@ -3,7 +3,7 @@
   <task>
     <extractRefresh>
       <schedule id="schedule-id" />
-      <datasource id="workbook-id" />
+      <datasource id="datasource-id" />
     </extractRefresh>
   </task>
 </tsResponse>

--- a/test/assets/schedule_add_workbook.xml
+++ b/test/assets/schedule_add_workbook.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <task>
+    <materializeView>
+      <schedule id="schedule-id" />
+      <workbook id="workbook-id" />
+    </materializeView>
+  </task>
+</tsResponse>

--- a/test/assets/schedule_add_workbook_with_warnings.xml
+++ b/test/assets/schedule_add_workbook_with_warnings.xml
@@ -1,0 +1,12 @@
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <task>
+    <materializeView>
+      <schedule id="schedule-id" />
+      <workbook id="workbook-id" />
+    </materializeView>
+  </task>
+  <warnings>
+     <warning message="warning 1"/>
+     <warning message="warning 2"/>
+  </warnings>
+</tsResponse>

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -214,7 +214,6 @@ class ScheduleTests(unittest.TestCase):
         with open(ADD_WORKBOOK_TO_SCHEDULE, "rb") as f:
             add_workbook_response = f.read().decode("utf-8")
         with requests_mock.mock() as m:
-            #  TODO: Replace with real response
             m.get(self.server.workbooks.baseurl + '/bar', text=workbook_response)
             m.put(baseurl + '/foo/workbooks', text=add_workbook_response)
             workbook = self.server.workbooks.get_by_id("bar")

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -14,6 +14,9 @@ CREATE_DAILY_XML = os.path.join(TEST_ASSET_DIR, "schedule_create_daily.xml")
 CREATE_WEEKLY_XML = os.path.join(TEST_ASSET_DIR, "schedule_create_weekly.xml")
 CREATE_MONTHLY_XML = os.path.join(TEST_ASSET_DIR, "schedule_create_monthly.xml")
 UPDATE_XML = os.path.join(TEST_ASSET_DIR, "schedule_update.xml")
+ADD_WORKBOOK_TO_SCHEDULE = os.path.join(TEST_ASSET_DIR, "schedule_add_workbook.xml")
+ADD_WORKBOOK_TO_SCHEDULE_WITH_WARNINGS = os.path.join(TEST_ASSET_DIR, "schedule_add_workbook_with_warnings.xml")
+ADD_DATASOURCE_TO_SCHEDULE = os.path.join(TEST_ASSET_DIR, "schedule_add_datasource.xml")
 
 WORKBOOK_GET_BY_ID_XML = os.path.join(TEST_ASSET_DIR, 'workbook_get_by_id.xml')
 DATASOURCE_GET_BY_ID_XML = os.path.join(TEST_ASSET_DIR, 'datasource_get_by_id.xml')
@@ -208,13 +211,31 @@ class ScheduleTests(unittest.TestCase):
 
         with open(WORKBOOK_GET_BY_ID_XML, "rb") as f:
             workbook_response = f.read().decode("utf-8")
+        with open(ADD_WORKBOOK_TO_SCHEDULE, "rb") as f:
+            add_workbook_response = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             #  TODO: Replace with real response
             m.get(self.server.workbooks.baseurl + '/bar', text=workbook_response)
-            m.put(baseurl + '/foo/workbooks', text="OK")
+            m.put(baseurl + '/foo/workbooks', text=add_workbook_response)
             workbook = self.server.workbooks.get_by_id("bar")
             result = self.server.schedules.add_to_schedule('foo', workbook=workbook)
         self.assertEqual(0, len(result), "Added properly")
+
+    def test_add_workbook_with_warnings(self):
+        self.server.version = "2.8"
+        baseurl = "{}/sites/{}/schedules".format(self.server.baseurl, self.server.site_id)
+
+        with open(WORKBOOK_GET_BY_ID_XML, "rb") as f:
+            workbook_response = f.read().decode("utf-8")
+        with open(ADD_WORKBOOK_TO_SCHEDULE_WITH_WARNINGS, "rb") as f:
+            add_workbook_response = f.read().decode("utf-8")
+        with requests_mock.mock() as m:
+            m.get(self.server.workbooks.baseurl + '/bar', text=workbook_response)
+            m.put(baseurl + '/foo/workbooks', text=add_workbook_response)
+            workbook = self.server.workbooks.get_by_id("bar")
+            result = self.server.schedules.add_to_schedule('foo', workbook=workbook)
+        self.assertEqual(1, len(result), "Not added properly")
+        self.assertEqual(2, len(result[0].warnings))
 
     def test_add_datasource(self):
         self.server.version = "2.8"
@@ -222,10 +243,11 @@ class ScheduleTests(unittest.TestCase):
 
         with open(DATASOURCE_GET_BY_ID_XML, "rb") as f:
             datasource_response = f.read().decode("utf-8")
+        with open(ADD_DATASOURCE_TO_SCHEDULE, "rb") as f:
+            add_datasource_response = f.read().decode("utf-8")
         with requests_mock.mock() as m:
-            #  TODO: Replace with real response
             m.get(self.server.datasources.baseurl + '/bar', text=datasource_response)
-            m.put(baseurl + '/foo/datasources', text="OK")
+            m.put(baseurl + '/foo/datasources', text=add_datasource_response)
             datasource = self.server.datasources.get_by_id("bar")
             result = self.server.schedules.add_to_schedule('foo', datasource=datasource)
         self.assertEqual(0, len(result), "Added properly")


### PR DESCRIPTION
The recent changes in the server side code may add warnings when add a workbook to a schedule. Here is an example response with such warnings:

<tsResponse>
    <warnings>
        <warning message="Workbook with id 29,354 uses only embedded extract(s) and does not need explicit scheduling for acceleration. It was enabled for acceleration but not attached to the given schedule."/>
    </warnings>
</tsResponse>

This PR add client code for receiving such warnings.