### PR TITLE
Allow wb/ds item or id in refresh

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -147,7 +147,8 @@ class Datasources(Endpoint):
         return connection
 
     def refresh(self, datasource_item):
-        url = "{0}/{1}/refresh".format(self.baseurl, datasource_item.id)
+        id_ = getattr(datasource_item, 'id', datasource_item)
+        url = "{0}/{1}/refresh".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -35,7 +35,8 @@ class Jobs(Endpoint):
 
     @api(version='3.1')
     def cancel(self, job_id):
-        url = '{0}/{1}'.format(self.baseurl, job_id)
+        id_ = getattr(job_id, 'id', job_id)
+        url = '{0}/{1}'.format(self.baseurl, id_)
         return self.put_request(url)
 
     @api(version='2.6')

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -57,7 +57,8 @@ class Workbooks(Endpoint):
 
     @api(version="2.8")
     def refresh(self, workbook_id):
-        url = "{0}/{1}/refresh".format(self.baseurl, workbook_id)
+        id_ = getattr(workbook_id, 'id', workbook_id)
+        url = "{0}/{1}/refresh".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]


### PR DESCRIPTION
Allows refresh method on datasource and workbook endpoints to accept either the object or their id. Allows for a flexible and consistent api.