### PR TITLE
Fixed moving projects to root

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -249,7 +249,7 @@ class ProjectRequest(object):
             project_element.attrib['description'] = project_item.description
         if project_item.content_permissions:
             project_element.attrib['contentPermissions'] = project_item.content_permissions
-        if project_item.parent_id:
+        if project_item.parent_id is not None:
             project_element.attrib['parentProjectId'] = project_item.parent_id
         return ET.tostring(xml_request)
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -249,6 +249,8 @@ class ProjectRequest(object):
             project_element.attrib['description'] = project_item.description
         if project_item.content_permissions:
             project_element.attrib['contentPermissions'] = project_item.content_permissions
+        if project_item.parent_id:
+            project_element.attrib['parentProjectId'] = project_item.parent_id
         return ET.tostring(xml_request)
 
     def create_req(self, project_item):


### PR DESCRIPTION
I am terribly sorry but in my previous pull request I made a mistake that made the projects unable to move to the root. Tableau API moves a project to the root if the proper parameter is set to empty string and doesn't change anything if it is not present. Now the project will move to the root if ProjectItem's `parent_id` is set to empty string, and does not change anything if it's None.