### PR TITLE
Add flexibility for wkbk/ds id or item in endpoint

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -144,6 +144,7 @@ class Datasources(Endpoint):
                                                                                     connection_item.id))
         return connection
 
+    @api(version="2.8")
     def refresh(self, datasource_item):
         id_ = getattr(datasource_item, 'id', datasource_item)
         url = "{0}/{1}/refresh".format(self.baseurl, id_)

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -145,7 +145,8 @@ class Datasources(Endpoint):
         return connection
 
     def refresh(self, datasource_item):
-        url = "{0}/{1}/refresh".format(self.baseurl, datasource_item.id)
+        id_ = getattr(datasource_item, 'id', datasource_item)
+        url = "{0}/{1}/refresh".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -35,7 +35,8 @@ class Jobs(Endpoint):
 
     @api(version='3.1')
     def cancel(self, job_id):
-        url = '{0}/{1}'.format(self.baseurl, job_id)
+        id_ = getattr(job_id, 'id', job_id)
+        url = '{0}/{1}'.format(self.baseurl, id_)
         return self.put_request(url)
 
     @api(version='2.6')

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -56,7 +56,8 @@ class Workbooks(Endpoint):
 
     @api(version="2.8")
     def refresh(self, workbook_id):
-        url = "{0}/{1}/refresh".format(self.baseurl, workbook_id)
+        id_ = getattr(workbook_id, 'id', workbook_id)
+        url = "{0}/{1}/refresh".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/test/assets/datasource_refresh.xml
+++ b/test/assets/datasource_refresh.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <job id="7c3d599e-949f-44c3-94a1-f30ba85757e4" mode="Asynchronous" type="RefreshExtract" createdAt="2020-03-05T22:05:32Z">
+    <extractRefreshJob>
+      <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="datasource-name" />
+    </extractRefreshJob>
+  </job>
+</tsResponse>

--- a/test/assets/workbook_refresh.xml
+++ b/test/assets/workbook_refresh.xml
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-  <job id="7c3d599e-949f-44c3-94a1-f30ba85757e4" mode="Asynchronous" type="RefreshExtract" createdAt="2020-03-05T22:05:32">
+  <job id="7c3d599e-949f-44c3-94a1-f30ba85757e4" mode="Asynchronous" type="RefreshExtract" createdAt="2020-03-05T22:05:32Z">
     <extractRefreshJob>
       <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" name="workbook-name" />
     </extractRefreshJob>
+  </job>
 </tsResponse>

--- a/test/assets/workbook_refresh.xml
+++ b/test/assets/workbook_refresh.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <job id="7c3d599e-949f-44c3-94a1-f30ba85757e4" mode="Asynchronous" type="RefreshExtract" createdAt="2020-03-05T22:05:32">
+    <extractRefreshJob>
+      <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" name="workbook-name" />
+    </extractRefreshJob>
+</tsResponse>

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -16,6 +16,7 @@ POPULATE_CONNECTIONS_XML = 'datasource_populate_connections.xml'
 POPULATE_PERMISSIONS_XML = 'datasource_populate_permissions.xml'
 PUBLISH_XML = 'datasource_publish.xml'
 PUBLISH_XML_ASYNC = 'datasource_publish_async.xml'
+REFRESH_XML = 'datasource_refresh.xml'
 UPDATE_XML = 'datasource_update.xml'
 UPDATE_CONNECTION_XML = 'datasource_connection_update.xml'
 
@@ -248,6 +249,26 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('0', new_job.progress)
         self.assertEqual('2018-06-30T00:54:54Z', format_datetime(new_job.created_at))
         self.assertEqual('1', new_job.finish_code)
+
+    def test_refresh_id(self):
+        self.server.version = '2.8'
+        self.baseurl = self.server.datasources.baseurl
+        response_xml = read_xml_asset(REFRESH_XML)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/refresh',
+                   status_code=202, text=response_xml)
+            self.server.datasources.refresh('9dbd2263-16b5-46e1-9c43-a76bb8ab65fb')
+
+    def test_refresh_object(self):
+        self.server.version = '2.8'
+        self.baseurl = self.server.datasources.baseurl
+        datasource = TSC.DatasourceItem('')
+        datasource._id = '9dbd2263-16b5-46e1-9c43-a76bb8ab65fb'
+        response_xml = read_xml_asset(REFRESH_XML)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/refresh',
+                   status_code=202, text=response_xml)
+            self.server.datasources.refresh(datasource)
 
     def test_delete(self):
         with requests_mock.mock() as m:

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -45,7 +45,16 @@ class JobTests(unittest.TestCase):
         self.server._auth_token = None
         self.assertRaises(TSC.NotSignedInError, self.server.jobs.get)
 
-    def test_cancel(self):
+    def test_cancel_id(self):
         with requests_mock.mock() as m:
             m.put(self.baseurl + '/ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', status_code=204)
             self.server.jobs.cancel('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+
+    def test_cancel_item(self):
+        created_at = datetime(2018, 5, 22, 13, 0, 29, tzinfo=utc)
+        started_at = datetime(2018, 5, 22, 13, 0, 37, tzinfo=utc)
+        job = TSC.JobItem('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', 'backgroundJob',
+                          0, created_at, started_at, None, 0)
+        with requests_mock.mock() as m:
+            m.put(self.baseurl + '/ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', status_code=204)
+            self.server.jobs.cancel(job)

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -121,10 +121,10 @@ class WorkbookTests(unittest.TestCase):
         with open(REFRESH_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh', 
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh',
                    status_code=202, text=response_xml)
             self.server.workbooks.refresh('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
-        
+
     def test_refresh_object(self):
         self.server.version = '2.8'
         self.baseurl = self.server.workbooks.baseurl
@@ -133,10 +133,9 @@ class WorkbookTests(unittest.TestCase):
         with open(REFRESH_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh', 
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh',
                    status_code=202, text=response_xml)
             self.server.workbooks.refresh(workbook)
-        
 
     def test_delete(self):
         with requests_mock.mock() as m:
@@ -528,4 +527,3 @@ class WorkbookTests(unittest.TestCase):
 
             self.assertRaisesRegex(InternalServerError, 'Please use asynchronous publishing to avoid timeouts',
                                    self.server.workbooks.publish, new_workbook, asset('SampleWB.twbx'), publish_mode)
-

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -27,6 +27,7 @@ POPULATE_VIEWS_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_views.xml')
 POPULATE_VIEWS_USAGE_XML = os.path.join(TEST_ASSET_DIR, 'workbook_populate_views_usage.xml')
 PUBLISH_XML = os.path.join(TEST_ASSET_DIR, 'workbook_publish.xml')
 PUBLISH_ASYNC_XML = os.path.join(TEST_ASSET_DIR, 'workbook_publish_async.xml')
+REFRESH_XML = os.path.join(TEST_ASSET_DIR, 'workbook_refresh.xml')
 UPDATE_XML = os.path.join(TEST_ASSET_DIR, 'workbook_update.xml')
 UPDATE_PERMISSIONS = os.path.join(TEST_ASSET_DIR, 'workbook_update_permissions.xml')
 
@@ -113,6 +114,29 @@ class WorkbookTests(unittest.TestCase):
 
     def test_get_by_id_missing_id(self):
         self.assertRaises(ValueError, self.server.workbooks.get_by_id, '')
+
+    def test_refresh_id(self):
+        self.server.version = '2.8'
+        self.baseurl = self.server.workbooks.baseurl
+        with open(REFRESH_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh', 
+                   status_code=202, text=response_xml)
+            self.server.workbooks.refresh('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
+        
+    def test_refresh_object(self):
+        self.server.version = '2.8'
+        self.baseurl = self.server.workbooks.baseurl
+        workbook = TSC.WorkbookItem('')
+        workbook._id = '3cc6cd06-89ce-4fdc-b935-5294135d6d42'
+        with open(REFRESH_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/refresh', 
+                   status_code=202, text=response_xml)
+            self.server.workbooks.refresh(workbook)
+        
 
     def test_delete(self):
         with requests_mock.mock() as m:
@@ -504,3 +528,4 @@ class WorkbookTests(unittest.TestCase):
 
             self.assertRaisesRegex(InternalServerError, 'Please use asynchronous publishing to avoid timeouts',
                                    self.server.workbooks.publish, new_workbook, asset('SampleWB.twbx'), publish_mode)
+


### PR DESCRIPTION
This pull request makes a consistent but backwards compatible API for refreshes that accept either the item or it's id for both datasources and workbooks.

Would resolve #562 