### PR TITLE
Prepares branch for a new release (v0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.10 (21 Feb 2020)
+
+* Added a way to handle non-xml errors (#515)
+* Added Webhooks endpoints for create, delete, get, list, and test (#523, #532)
+* Added delete method in the tasks endpoint (#524)
+* Added description attribute to WorkbookItem (#533)
+* Added support for materializeViews as schedule and task types (#542)
+* Added warnings to schedules (#550, #551)
+* Added ability to update parent_id attribute of projects (#560, #567)
+* Improved filename behavior for download endpoints (#517)
+* Improved logging (#508)
+* Fixed runtime error in permissions endpoint (#513)
+* Fixed move_workbook_sites sample (#503)
+* Fixed project permissions endpoints (#527)
+* Fixed login.py sample to accept site name (#549)
+
 ## 0.9 (4 Oct 2019)
 
 * Added Metadata API endpoints (#431)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,12 @@ The following people have contributed to this project to make it possible, and w
 * [Christian Oliff](https://github.com/coliff)
 * [Albin Antony](https://github.com/user9747)
 * [prae04](https://github.com/prae04)
+* [Martin Peters](https://github.com/martinbpeters)
+* [Sherman K](https://github.com/shrmnk)
+* [Jorge Fonseca](https://github.com/JorgeFonseca)
+* [Kacper Wolkiewicz](https://github.com/wolkiewiczk)
+* [Dahai Guo](https://github.com/guodah)
+* [Geraldine Zanolli](https://github.com/illonage)
 
 ## Core Team
 
@@ -41,4 +47,3 @@ The following people have contributed to this project to make it possible, and w
 * [Priya Reguraman](https://github.com/preguraman)
 * [Jac Fitzgerald](https://github.com/jacalata)
 * [Dan Zucker](https://github.com/dzucker-tab)
-* [Irwin Dolobowsky](https://github.com/irwando)


### PR DESCRIPTION
* Added a way to handle non-xml errors (#515)
* Added Webhooks endpoints for create, delete, get, list, and test (#523, #532)
* Added delete method in the tasks endpoint (#524)
* Added description attribute to WorkbookItem (#533)
* Added support for materializeViews as schedule and task types (#542)
* Added warnings to schedules (#550, #551)
* Added ability to update parent_id attribute of projects (#560, #567)
* Improved filename behavior for download endpoints (#517)
* Improved logging (#508)
* Fixed runtime error in permissions endpoint (#513)
* Fixed move_workbook_sites sample (#503)
* Fixed project permissions endpoints (#527)
* Fixed login.py sample to accept site name (#549)