### PR TITLE
Unspecified PDF request option

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -141,6 +141,7 @@ class PDFRequestOptions(_FilterOptionsBase):
         Note = "note"
         Quarto = "quarto"
         Tabloid = "tabloid"
+        Unspecified = "unspecified"
 
     class Orientation:
         Portrait = "portrait"


### PR DESCRIPTION
This is the only pagetype not available via tableau api for PDF. The 'Unspecified' pagetype is available for download using tableau online and desktop so I really don't see an issue adding this. Can this kindly be amended as the workaround for this requires downloading an image and converting to pdf which results in poorer quality and larger data size.