### PR TITLE
Fixes default permissions urls and adds return value to update endpoints

### DIFF
--- a/samples/add_default_permission.py
+++ b/samples/add_default_permission.py
@@ -1,0 +1,84 @@
+####
+# This script demonstrates how to add default permissions using TSC
+# To run the script, you must have installed Python 3.5 and later.
+#
+# In order to demonstrate adding a new default permission, this sample will create
+# a new project and add a new capability to the new project, for the default "All users" group.
+#
+# Example usage: 'python add_default_permission.py -s
+#       https://10ax.online.tableau.com --site devSite123 -u tabby@tableau.com'
+####
+
+import argparse
+import getpass
+import logging
+
+import tableauserverclient as TSC
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Add workbook default permission for a given project')
+    parser.add_argument('--server', '-s', required=True, help='Server address')
+    parser.add_argument('--username', '-u', required=True, help='Username to sign into server')
+    parser.add_argument('--site', '-S', default=None, help='Site to sign into - default site if not provided')
+    parser.add_argument('-p', default=None, help='Password to sign into server')
+
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
+
+    args = parser.parse_args()
+
+    if args.p is None:
+        password = getpass.getpass("Password: ")
+    else:
+        password = args.p
+
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
+
+    # Sign in
+    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    server = TSC.Server(args.server, use_server_version=True)
+    with server.auth.sign_in(tableau_auth):
+
+        # Create a sample project
+        project = TSC.ProjectItem("sample_project")
+        project = server.projects.create(project)
+
+        # Query for existing workbook default-permissions
+        server.projects.populate_workbook_default_permissions(project)
+        default_permissions = project.default_workbook_permissions[0]  # new projects have 1 grantee group
+
+        # Add "ExportXml (Allow)" workbook capability to "All Users" default group if it does not already exist
+        if TSC.Permission.Capability.ExportXml not in default_permissions.capabilities:
+            new_capabilities = {TSC.Permission.Capability.ExportXml: TSC.Permission.Mode.Allow}
+
+            # Each PermissionRule in the list contains a grantee and a dict of capabilities
+            new_rules = [TSC.PermissionsRule(
+                grantee=default_permissions.grantee,
+                capabilities=new_capabilities
+            )]
+
+            new_default_permissions = server.projects.update_workbook_default_permissions(project, new_rules)
+
+            # Print result from adding a new default permission
+            for permission in new_default_permissions:
+                grantee = permission.grantee
+                capabilities = permission.capabilities
+                print("\nCapabilities for {0} {1}:".format(grantee.tag_name, grantee.id))
+
+                for capability in capabilities:
+                    print("\t{0} - {1}".format(capability, capabilities[capability]))
+
+        # Uncomment lines below to DELETE the new capability and the new project
+        # rules_to_delete = TSC.PermissionsRule(
+        #     grantee=default_permissions.grantee,
+        #     capabilities=new_capabilities
+        # )
+        # server.projects.delete_workbook_default_permissions(project, rules_to_delete)
+        # server.projects.delete(project.id)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/query_permissions.py
+++ b/samples/query_permissions.py
@@ -1,0 +1,75 @@
+####
+# This script demonstrates how to query for permissions using TSC
+# To run the script, you must have installed Python 3.5 and later.
+#
+# Example usage: 'python query_permissions.py -s https://10ax.online.tableau.com --site
+#       devSite123 -u tabby@tableau.com workbook b4065286-80f0-11ea-af1b-cb7191f48e45'
+####
+
+import argparse
+import getpass
+import logging
+
+import tableauserverclient as TSC
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Query permissions of a given resource')
+    parser.add_argument('--server', '-s', required=True, help='Server address')
+    parser.add_argument('--username', '-u', required=True, help='Username to sign into server')
+    parser.add_argument('--site', '-S', default=None, help='Site to sign into - default site if not provided')
+    parser.add_argument('-p', default=None, help='Password to sign into server')
+
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
+
+    parser.add_argument('resource_type', choices=['workbook', 'datasource', 'flow', 'table', 'database'])
+    parser.add_argument('resource_id')
+
+    args = parser.parse_args()
+
+    if args.p is None:
+        password = getpass.getpass("Password: ")
+    else:
+        password = args.p
+
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
+
+    # Sign in
+    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    server = TSC.Server(args.server, use_server_version=True)
+    with server.auth.sign_in(tableau_auth):
+
+        # Mapping to grab the handler for the user-inputted resource type
+        endpoint = {
+            'workbook': server.workbooks,
+            'datasource': server.datasources,
+            'flow': server.flows,
+            'table': server.tables,
+            'database': server.databases
+        }.get(args.resource_type)
+
+        # Get the resource by its ID
+        resource = endpoint.get_by_id(args.resource_id)
+
+        # Populate permissions for the resource
+        endpoint.populate_permissions(resource)
+        permissions = resource.permissions
+
+        # Print result
+        print("\n{0} permission rule(s) found for {1} {2}."
+              .format(len(permissions), args.resource_type, args.resource_id))
+
+        for permission in permissions:
+            grantee = permission.grantee
+            capabilities = permission.capabilities
+            print("\nCapabilities for {0} {1}:".format(grantee.tag_name, grantee.id))
+
+            for capability in capabilities:
+                print("\t{0} - {1}".format(capability, capabilities[capability]))
+
+
+if __name__ == '__main__':
+    main()

--- a/tableauserverclient/server/endpoint/databases_endpoint.py
+++ b/tableauserverclient/server/endpoint/databases_endpoint.py
@@ -93,7 +93,7 @@ class Databases(Endpoint):
 
     @api(version='3.5')
     def delete_permission(self, item, rules):
-        return self._permissions.delete(item, rules)
+        self._permissions.delete(item, rules)
 
     @api(version='3.5')
     def populate_table_default_permissions(self, item):
@@ -101,7 +101,7 @@ class Databases(Endpoint):
 
     @api(version='3.5')
     def update_table_default_permissions(self, item):
-        self._default_permissions.update_default_permissions(item, Permission.Resource.Table)
+        return self._default_permissions.update_default_permissions(item, Permission.Resource.Table)
 
     @api(version='3.5')
     def delete_table_default_permissions(self, item):

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -27,7 +27,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
         self.owner_baseurl = owner_baseurl
 
     def update_default_permissions(self, resource, permissions, content_type):
-        url = '{0}/{1}/default-permissions/{2}'.format(self.owner_baseurl(), resource.id, content_type)
+        url = '{0}/{1}/default-permissions/{2}'.format(self.owner_baseurl(), resource.id, content_type + 's')
         update_req = RequestFactory.Permission.add_req(permissions)
         response = self.put_request(url, update_req)
         permissions = PermissionsRule.from_response(response.content,
@@ -44,7 +44,7 @@ class _DefaultPermissionsEndpoint(Endpoint):
                 .format(
                     baseurl=self.owner_baseurl(),
                     content_id=resource.id,
-                    content_type=content_type,
+                    content_type=content_type + 's',
                     grantee_type=rule.grantee.tag_name + 's',
                     grantee_id=rule.grantee.id,
                     cap=capability,

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -71,7 +71,7 @@ class Projects(Endpoint):
 
     @api(version='2.0')
     def delete_permission(self, item, rules):
-        return self._permissions.delete(item, rules)
+        self._permissions.delete(item, rules)
 
     @api(version='2.1')
     def populate_workbook_default_permissions(self, item):
@@ -87,15 +87,15 @@ class Projects(Endpoint):
 
     @api(version='2.1')
     def update_workbook_default_permissions(self, item, rules):
-        self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Workbook)
+        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Workbook)
 
     @api(version='2.1')
     def update_datasource_default_permissions(self, item, rules):
-        self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Datasource)
+        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Datasource)
 
     @api(version='3.4')
     def update_flow_default_permissions(self, item, rules):
-        self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Flow)
+        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Flow)
 
     @api(version='2.1')
     def delete_workbook_default_permissions(self, item, rule):

--- a/test/assets/project_update_datasource_default_permissions.xml
+++ b/test/assets/project_update_datasource_default_permissions.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.7.xsd">
+    <permissions>
+        <project id="b4065286-80f0-11ea-af1b-cb7191f48e45" name="Default">
+            <owner id="f143dfe3-55e3-490a-9fdb-e98c0ec89171"/>
+        </project>
+        <granteeCapabilities>
+            <group id="b4488bce-80f0-11ea-af1c-976d0c1dab39"/>
+            <capabilities>
+                <capability name="Read" mode="Allow"/>
+                <capability name="Write" mode="Allow"/>
+                <capability name="Connect" mode="Allow"/>
+                <capability name="ExportXml" mode="Deny"/>
+            </capabilities>
+        </granteeCapabilities>
+    </permissions>
+</tsResponse>

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -109,7 +109,6 @@ class ProjectTests(unittest.TestCase):
         self.assertEquals('Allow', updated_capabilities['Write'])
         self.assertEquals('Allow', updated_capabilities['Connect'])
 
-
     def test_update_missing_id(self):
         single_project = TSC.ProjectItem('test')
         self.assertRaises(TSC.MissingRequiredFieldError, self.server.projects.update, single_project)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -12,6 +12,7 @@ UPDATE_XML = asset('project_update.xml')
 CREATE_XML = asset('project_create.xml')
 POPULATE_PERMISSIONS_XML = 'project_populate_permissions.xml'
 POPULATE_WORKBOOK_DEFAULT_PERMISSIONS_XML = 'project_populate_workbook_default_permissions.xml'
+UPDATE_DATASOURCE_DEFAULT_PERMISSIONS_XML = 'project_update_datasource_default_permissions.xml'
 
 
 class ProjectTests(unittest.TestCase):
@@ -78,6 +79,36 @@ class ProjectTests(unittest.TestCase):
         self.assertEqual('Project created for testing', single_project.description)
         self.assertEqual('LockedToProject', single_project.content_permissions)
         self.assertEqual('9a8f2265-70f3-4494-96c5-e5949d7a1120', single_project.parent_id)
+
+    def test_update_datasource_default_permission(self):
+        response_xml = read_xml_asset(UPDATE_DATASOURCE_DEFAULT_PERMISSIONS_XML)
+        with requests_mock.mock() as m:
+            m.put(self.baseurl + '/b4065286-80f0-11ea-af1b-cb7191f48e45/default-permissions/datasources',
+                  text=response_xml)
+            project = TSC.ProjectItem('test-project')
+            project._id = 'b4065286-80f0-11ea-af1b-cb7191f48e45'
+
+            group = TSC.GroupItem('test-group')
+            group._id = 'b4488bce-80f0-11ea-af1c-976d0c1dab39'
+
+            capabilities = {TSC.Permission.Capability.ExportXml: TSC.Permission.Mode.Deny}
+
+            rules = [TSC.PermissionsRule(
+                grantee=group,
+                capabilities=capabilities
+            )]
+
+            new_rules = self.server.projects.update_datasource_default_permissions(project, rules)
+
+        self.assertEquals('b4488bce-80f0-11ea-af1c-976d0c1dab39', new_rules[0].grantee.id)
+
+        updated_capabilities = new_rules[0].capabilities
+        self.assertEquals(4, len(updated_capabilities))
+        self.assertEquals('Deny', updated_capabilities['ExportXml'])
+        self.assertEquals('Allow', updated_capabilities['Read'])
+        self.assertEquals('Allow', updated_capabilities['Write'])
+        self.assertEquals('Allow', updated_capabilities['Connect'])
+
 
     def test_update_missing_id(self):
         single_project = TSC.ProjectItem('test')
@@ -230,7 +261,7 @@ class ProjectTests(unittest.TestCase):
                 capabilities=capabilities
             )
 
-            endpoint = '{}/default-permissions/workbook/groups/{}'.format(single_project._id, single_group._id)
+            endpoint = '{}/default-permissions/workbooks/groups/{}'.format(single_project._id, single_group._id)
             m.delete('{}/{}/Read/Allow'.format(self.baseurl, endpoint), status_code=204)
             m.delete('{}/{}/ExportImage/Allow'.format(self.baseurl, endpoint), status_code=204)
             m.delete('{}/{}/ExportData/Allow'.format(self.baseurl, endpoint), status_code=204)


### PR DESCRIPTION
Default permissions urls for update and delete were missing an 's' after the content types. Also noticed that the update permission methods weren't returning the response from server, while the delete methods were unnecessarily returning something. 

Changes:
- Corrected URLs for update and delete default permissions by appending an s to the content type
- Removed return statements for the delete methods
- Added return statements for the update methods
- Fixed delete default permissions test and added a update default permissions test

