### PR TITLE
Add Personal Access Token to the Auth page

### DIFF
--- a/docs/sign-in-out.md
+++ b/docs/sign-in-out.md
@@ -10,7 +10,7 @@ import tableauserverclient as TSC
 
 tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD', `SITENAME`)
 # or for a personal access token
-# tableau_auth = TSC.TableauAuth('TOKEN_NAME', 'TOKEN_VALUE', 'SITENAME')
+# tableau_auth = TSC.PersonalAccessTokenAuth('TOKEN_NAME', 'TOKEN_VALUE', 'SITENAME')
 server = TSC.Server('https://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):

--- a/docs/sign-in-out.md
+++ b/docs/sign-in-out.md
@@ -9,6 +9,8 @@ To sign in and out of Tableau Server, call the server's `.auth.signin` method in
 import tableauserverclient as TSC
 
 tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD', `SITENAME`)
+# or for a personal access token
+# tableau_auth = TSC.TableauAuth('TOKEN_NAME', 'TOKEN_VALUE', 'SITENAME')
 server = TSC.Server('https://SERVER_URL')
 
 with server.auth.sign_in(tableau_auth):
@@ -18,6 +20,8 @@ with server.auth.sign_in(tableau_auth):
 `SERVER_URL` is the URL of your Tableau server without subpaths. For local Tableau servers, an example would be:      `https://www.MY_SERVER.com`. For Tableau Online, an example would be: `https://10ax.online.tableau.com/`.
 
 `SITENAME` is the subpath of your full site URL (also called `contentURL` in the REST API). `MYSITE` would be the site name of `https://10ax.online.tableau.com/MYSITE`. This parameter can be omitted when signing in to the Default site of an in premise Tableau server.
+
+'TOKEN_NAME' and 'TOKEN_VALUE' are your <a href="https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm">Personal Access Token</a> values, generated in your Account Settings. 
 
 Optionally, you can override the version of Tableau API you are authorizing against by adding `server.version = '<VERSION_NUMBER>'` before the `auth.signin` call. 
 
@@ -33,7 +37,7 @@ An alternative to using a `with` block is to call the `Auth.sign_in` and `Auth.s
 ```py
 import tableauserverclient as TSC
 
-tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD')
+tableau_auth = TSC.TableauAuth('USERNAME', 'PASSWORD') # with no site name, this will try to log the user into the Default site
 server = TSC.Server('http://SERVER_URL')
 
 server.auth.sign_in(tableau_auth)


### PR DESCRIPTION
Added an example line using the PAT auth, and also a link to what a PAT is.