### PR TITLE
Fix logger statement in User.add

### DIFF
--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -65,7 +65,7 @@ class Users(Endpoint):
         add_req = RequestFactory.User.add_req(user_item)
         server_response = self.post_request(url, add_req)
         new_user = UserItem.from_response(server_response.content, self.parent_srv.namespace).pop()
-        logger.info('Added new user (ID: {0})'.format(user_item.id))
+        logger.info('Added new user (ID: {0})'.format(new_user.id))
         return new_user
 
     # Get workbooks for user


### PR DESCRIPTION
The logger statement is using the parameter to output the id of the user, but that isnt set until line 67 and saved to a new variable. We want the logger statement to use that new user because it currently always prints None. 

Issue link #609 