### PR TITLE
Bugfix for maxage

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -103,7 +103,7 @@ class _FilterOptionsBase(RequestOptionsBase):
 
 
 class CSVRequestOptions(_FilterOptionsBase):
-    def __init__(self, maxage=None):
+    def __init__(self, maxage=-1):
         super(CSVRequestOptions, self).__init__()
         self.max_age = maxage
 
@@ -112,13 +112,13 @@ class CSVRequestOptions(_FilterOptionsBase):
         return self._max_age
 
     @max_age.setter
-    @property_is_int(range=(0, 240))
+    @property_is_int(range=(0, 240), allowed=[-1])
     def max_age(self, value):
         self._max_age = value
 
     def apply_query_params(self, url):
         params = []
-        if self.max_age != 0:
+        if self.max_age != -1:
             params.append('maxAge={0}'.format(self.max_age))
 
         self._append_view_filters(params)
@@ -130,7 +130,7 @@ class ImageRequestOptions(_FilterOptionsBase):
     class Resolution:
         High = 'high'
 
-    def __init__(self, imageresolution=None, maxage=None):
+    def __init__(self, imageresolution=None, maxage=-1):
         super(ImageRequestOptions, self).__init__()
         self.image_resolution = imageresolution
         self.max_age = maxage
@@ -140,7 +140,7 @@ class ImageRequestOptions(_FilterOptionsBase):
         return self._max_age
 
     @max_age.setter
-    @property_is_int(range=(0, 240))
+    @property_is_int(range=(0, 240), allowed=[-1])
     def max_age(self, value):
         self._max_age = value
 
@@ -148,7 +148,7 @@ class ImageRequestOptions(_FilterOptionsBase):
         params = []
         if self.image_resolution:
             params.append('resolution={0}'.format(self.image_resolution))
-        if self.max_age != 0:
+        if self.max_age != -1:
             params.append('maxAge={0}'.format(self.max_age))
 
         self._append_view_filters(params)
@@ -176,7 +176,7 @@ class PDFRequestOptions(_FilterOptionsBase):
         Portrait = "portrait"
         Landscape = "landscape"
 
-    def __init__(self, page_type=None, orientation=None, maxage=0):
+    def __init__(self, page_type=None, orientation=None, maxage=-1):
         super(PDFRequestOptions, self).__init__()
         self.page_type = page_type
         self.orientation = orientation
@@ -187,7 +187,7 @@ class PDFRequestOptions(_FilterOptionsBase):
         return self._max_age
 
     @max_age.setter
-    @property_is_int(range=(0, 240))
+    @property_is_int(range=(0, 240), allowed=[-1])
     def max_age(self, value):
         self._max_age = value
 
@@ -199,7 +199,7 @@ class PDFRequestOptions(_FilterOptionsBase):
         if self.orientation:
             params.append('orientation={0}'.format(self.orientation))
 
-        if self.max_age != 0:
+        if self.max_age != -1:
             params.append('maxAge={0}'.format(self.max_age))
 
         self._append_view_filters(params)

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -170,6 +170,18 @@ class ViewTests(unittest.TestCase):
             csv_file = b"".join(single_view.csv)
             self.assertEqual(response, csv_file)
 
+    def test_populate_csv_default_maxage(self):
+        with open(POPULATE_CSV, 'rb') as f:
+            response = f.read()
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/d79634e1-6063-4ec9-95ff-50acbf609ff5/data', content=response)
+            single_view = TSC.ViewItem()
+            single_view._id = 'd79634e1-6063-4ec9-95ff-50acbf609ff5'
+            self.server.views.populate_csv(single_view)
+
+            csv_file = b"".join(single_view.csv)
+            self.assertEqual(response, csv_file)
+
     def test_populate_image_missing_id(self):
         single_view = TSC.ViewItem()
         single_view._id = None


### PR DESCRIPTION
With #635, I realized that 0 is actually a valid value. Adding -1 as the default value for when no maxAge is set. 240 is the maximum value server allows. Doc change to follow.

Image export maxage is available in all supported versions of Tableau server. PDF and CSV maxage params are supported for versions 2019.2.13+. 

Addresses #628 and #581. 

