### PR TITLE
Prep for v0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.12 (10 July 2020)
 
-* Added hidden_views parameter workbook publish (#614)
+* Added hidden_views parameter to workbook publish method (#614)
 * Added simple paging endpoint for GraphQL/Metadata API (#623)
 * Added endpoints to Metadata API for retrieving backfill/eventing status (#626)
 * Added maxage parameter to CSV and PDF export options (#635)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12 (10 July 2020)
+
+* Added hidden_views parameter workbook publish (#614)
+* Added simple paging endpoint for GraphQL/Metadata API (#623)
+* Added endpoints to Metadata API for retrieving backfill/eventing status (#626)
+* Added maxage parameter to CSV and PDF export options (#635)
+* Added support for querying, adding, and deleting favorites (#638)
+* Added a sample for publishing datasources (#644)
+
 ## 0.11 (1 May 2020)
 
 * Added more fields to Data Acceleration config (#588)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ The following people have contributed to this project to make it possible, and w
 * [Geraldine Zanolli](https://github.com/illonage)
 * [Jordan Woods](https://github.com/jorwoods)
 * [Reba Magier](https://github.com/rmagier1)
+* [Stephen Mitchell](https://github.com/scuml)
 
 ## Core Team
 


### PR DESCRIPTION
v0.12
* Added hidden_views parameter workbook publish (#614)
* Added simple paging endpoint for GraphQL/Metadata API (#623)
* Added endpoints to Metadata API for retrieving backfill/eventing status (#626)
* Added maxage parameter to CSV and PDF export options (#635)
* Added support for querying, adding, and deleting favorites (#638)
* Added a sample for publishing datasources (#644)