### PR TITLE
Users endpoint favorites

### DIFF
--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -90,4 +90,4 @@ class Users(Endpoint):
         return workbook_item, pagination_item
 
     def populate_favorites(self, user_item):
-        raise NotImplementedError('REST API currently does not support the ability to query favorites')
+        self.parent_srv.favorites.get(user_item)


### PR DESCRIPTION
Patch the `server.users.populate_favorites` endpoint to be a passthrough to utilize the `server.favorites.get` endpoint. The alternative is to remove the method.