### PR TITLE
Change update_permission endpoint for consistency

### DIFF
--- a/tableauserverclient/server/endpoint/databases_endpoint.py
+++ b/tableauserverclient/server/endpoint/databases_endpoint.py
@@ -89,6 +89,14 @@ class Databases(Endpoint):
 
     @api(version='3.5')
     def update_permission(self, item, rules):
+        import warnings
+        warnings.warn('Server.databases.update_permission is deprecated, '
+                      'please use Server.databases.update_permissions instead.',
+                      DeprecationWarning)
+        return self._permissions.update(item, rules)
+
+    @api(version='3.5')
+    def update_permissions(self, item, rules):
         return self._permissions.update(item, rules)
 
     @api(version='3.5')

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -227,6 +227,14 @@ class Datasources(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, permission_item):
+        import warnings
+        warnings.warn('Server.datasources.update_permission is deprecated, '
+                      'please use Server.datasources.update_permissions instead.',
+                      DeprecationWarning)
+        self._permissions.update(item, permission_item)
+
+    @api(version='2.0')
+    def update_permissions(self, item, permission_item):
         self._permissions.update(item, permission_item)
 
     @api(version='2.0')

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -204,6 +204,14 @@ class Flows(Endpoint):
 
     @api(version='3.3')
     def update_permission(self, item, permission_item):
+        import warnings
+        warnings.warn('Server.flows.update_permission is deprecated, '
+                      'please use Server.flows.update_permissions instead.',
+                      DeprecationWarning)
+        self._permissions.update(item, permission_item)
+
+    @api(version='3.3')
+    def update_permissions(self, item, permission_item):
         self._permissions.update(item, permission_item)
 
     @api(version='3.3')

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -67,6 +67,14 @@ class Projects(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, rules):
+        import warnings
+        warnings.warn('Server.projects.update_permission is deprecated, '
+                      'please use Server.projects.update_permissions instead.',
+                      DeprecationWarning)
+        return self._permissions.update(item, rules)
+
+    @api(version='2.0')
+    def update_permissions(self, item, rules):
         return self._permissions.update(item, rules)
 
     @api(version='2.0')

--- a/tableauserverclient/server/endpoint/tables_endpoint.py
+++ b/tableauserverclient/server/endpoint/tables_endpoint.py
@@ -100,6 +100,14 @@ class Tables(Endpoint):
 
     @api(version='3.5')
     def update_permission(self, item, rules):
+        import warnings
+        warnings.warn('Server.tables.update_permission is deprecated, '
+                      'please use Server.tables.update_permissions instead.',
+                      DeprecationWarning)
+        return self._permissions.update(item, rules)
+
+    @api(version='3.5')
+    def update_permissions(self, item, rules):
         return self._permissions.update(item, rules)
 
     @api(version='3.5')


### PR DESCRIPTION
Endpoints for workbooks and views use `update_permissions`, while endpoints for projects and datasources use `update_permission`. This PR deprecates the inconsistent API.