### PR TITLE
Extract operations to match tabcmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13 (19 Aug 2020)
+* Add support for basic Extract operations - Create, Delete, en/re/decrypt for site
+
 ## 0.12.1 (22 July 2020)
 
 * Fixed login.py sample to properly handle sitename (#652)

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -244,13 +244,13 @@ class Datasources(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, permission_item):
-                import warnings	
-        warnings.warn('Server.datasources.update_permission is deprecated, '	
-                      'please use Server.datasources.update_permissions instead.',	
-                      DeprecationWarning)	
-        self._permissions.update(item, permission_item)	
+        import warnings
+        warnings.warn('Server.datasources.update_permission is deprecated, '
+                      'please use Server.datasources.update_permissions instead.',
+                      DeprecationWarning)
+        self._permissions.update(item, permission_item)
 
-    @api(version='2.0')	
+    @api(version='2.0')
     def update_permissions(self, item, permission_item):
         self._permissions.update(item, permission_item)
 

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -244,6 +244,14 @@ class Datasources(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, permission_item):
+                import warnings	
+        warnings.warn('Server.datasources.update_permission is deprecated, '	
+                      'please use Server.datasources.update_permissions instead.',	
+                      DeprecationWarning)	
+        self._permissions.update(item, permission_item)	
+
+    @api(version='2.0')	
+    def update_permissions(self, item, permission_item):
         self._permissions.update(item, permission_item)
 
     @api(version='2.0')

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -151,6 +151,23 @@ class Datasources(Endpoint):
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job
+    
+    @api(version='3.5')
+    def create_extract(self, datasource_item, encrypt=False):
+        id_ = getattr(datasource_item, 'id', datasource_item)
+        url = "{0}/{1}/createExtract?encrypt={2}".format(self.baseurl, id_, encrypt)
+        empty_req = RequestFactory.Empty.empty_req()
+        server_response = self.post_request(url, empty_req)
+        new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
+        return new_job
+
+    @api(version='3.5')
+    def delete_extract(self, datasource_item):
+        id_ = getattr(datasource_item, 'id', datasource_item)
+        url = "{0}/{1}/deleteExtract".format(self.baseurl, id_)
+        empty_req = RequestFactory.Empty.empty_req()
+        self.post_request(url, empty_req)
+        
 
     # Publish datasource
     @api(version="2.0")
@@ -227,14 +244,6 @@ class Datasources(Endpoint):
 
     @api(version='2.0')
     def update_permission(self, item, permission_item):
-        import warnings
-        warnings.warn('Server.datasources.update_permission is deprecated, '
-                      'please use Server.datasources.update_permissions instead.',
-                      DeprecationWarning)
-        self._permissions.update(item, permission_item)
-
-    @api(version='2.0')
-    def update_permissions(self, item, permission_item):
         self._permissions.update(item, permission_item)
 
     @api(version='2.0')

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -151,7 +151,7 @@ class Datasources(Endpoint):
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job
-    
+
     @api(version='3.5')
     def create_extract(self, datasource_item, encrypt=False):
         id_ = getattr(datasource_item, 'id', datasource_item)
@@ -167,7 +167,6 @@ class Datasources(Endpoint):
         url = "{0}/{1}/deleteExtract".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         self.post_request(url, empty_req)
-        
 
     # Publish datasource
     @api(version="2.0")

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -111,8 +111,7 @@ class Sites(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}/encrypt-extracts".format(self.baseurl, site_id)
         empty_req = RequestFactory.Empty.empty_req()
-        self.post_request(url,empty_req)
-
+        self.post_request(url, empty_req)
 
     @api(version="3.5")
     def decrypt_extracts(self, site_id):
@@ -121,8 +120,7 @@ class Sites(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}/decrypt-extracts".format(self.baseurl, site_id)
         empty_req = RequestFactory.Empty.empty_req()
-        self.post_request(url,empty_req)
-
+        self.post_request(url, empty_req)
 
     @api(version="3.5")
     def re_encrypt_extracts(self, site_id):
@@ -130,6 +128,6 @@ class Sites(Endpoint):
             error = "Site ID undefined."
             raise ValueError(error)
         url = "{0}/{1}/reencrypt-extracts".format(self.baseurl, site_id)
-        
+
         empty_req = RequestFactory.Empty.empty_req()
-        self.post_request(url,empty_req)
+        self.post_request(url, empty_req)

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -103,3 +103,33 @@ class Sites(Endpoint):
         new_site = SiteItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         logger.info('Created new site (ID: {0})'.format(new_site.id))
         return new_site
+
+    @api(version="3.5")
+    def encrypt_extracts(self, site_id):
+        if not site_id:
+            error = "Site ID undefined."
+            raise ValueError(error)
+        url = "{0}/{1}/encrypt-extracts".format(self.baseurl, site_id)
+        empty_req = RequestFactory.Empty.empty_req()
+        self.post_request(url,empty_req)
+
+
+    @api(version="3.5")
+    def decrypt_extracts(self, site_id):
+        if not site_id:
+            error = "Site ID undefined."
+            raise ValueError(error)
+        url = "{0}/{1}/decrypt-extracts".format(self.baseurl, site_id)
+        empty_req = RequestFactory.Empty.empty_req()
+        self.post_request(url,empty_req)
+
+
+    @api(version="3.5")
+    def re_encrypt_extracts(self, site_id):
+        if not site_id:
+            error = "Site ID undefined."
+            raise ValueError(error)
+        url = "{0}/{1}/reencrypt-extracts".format(self.baseurl, site_id)
+        
+        empty_req = RequestFactory.Empty.empty_req()
+        self.post_request(url,empty_req)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -61,6 +61,26 @@ class Workbooks(Endpoint):
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job
 
+    
+    @api(version='3.5')
+    def create_extract(self, workbook_item, encrypt=False, includeAll=True, datasources=None):
+        id_ = getattr(workbook_item, 'id', workbook_item)
+        url = "{0}/{1}/createExtract?encrypt={2}".format(self.baseurl, id_, encrypt)
+
+        datasource_req = RequestFactory.WorkbookR.embedded_extract_req(includeAll, datasources)
+        
+        server_response = self.post_request(url, datasource_req)
+        new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
+        return new_job
+
+    @api(version='3.5')
+    def delete_extract(self, workbook_item):
+        id_ = getattr(workbook_item, 'id', workbook_item)
+        url = "{0}/{1}/deleteExtract".format(self.baseurl, id_)
+        empty_req = RequestFactory.Empty.empty_req()
+        server_response = self.post_request(url, empty_req)
+        
+
     # Delete 1 workbook by id
     @api(version="2.0")
     def delete(self, workbook_id):

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -61,25 +61,24 @@ class Workbooks(Endpoint):
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job
 
-    
+    # create one or more extracts on 1 workbook, optionally encrypted
     @api(version='3.5')
     def create_extract(self, workbook_item, encrypt=False, includeAll=True, datasources=None):
         id_ = getattr(workbook_item, 'id', workbook_item)
         url = "{0}/{1}/createExtract?encrypt={2}".format(self.baseurl, id_, encrypt)
 
         datasource_req = RequestFactory.Workbook.embedded_extract_req(includeAll, datasources)
-        
         server_response = self.post_request(url, datasource_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job
 
+    # delete all the extracts on 1 workbook
     @api(version='3.5')
     def delete_extract(self, workbook_item):
         id_ = getattr(workbook_item, 'id', workbook_item)
         url = "{0}/{1}/deleteExtract".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
-        
 
     # Delete 1 workbook by id
     @api(version="2.0")

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -67,7 +67,7 @@ class Workbooks(Endpoint):
         id_ = getattr(workbook_item, 'id', workbook_item)
         url = "{0}/{1}/createExtract?encrypt={2}".format(self.baseurl, id_, encrypt)
 
-        datasource_req = RequestFactory.WorkbookR.embedded_extract_req(includeAll, datasources)
+        datasource_req = RequestFactory.Workbook.embedded_extract_req(includeAll, datasources)
         
         server_response = self.post_request(url, datasource_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -568,12 +568,11 @@ class WorkbookRequest(object):
         parts = {'request_payload': ('', xml_request, 'text/xml')}
         return _add_multipart(parts)
 
-
     @_tsrequest_wrapped
     def embedded_extract_req(self, xml_request, include_all=True, datasources=None):
         list_element = ET.SubElement(xml_request, 'datasources')
         if include_all:
-            list_element.attrib['includeAll']="true"
+            list_element.attrib['includeAll'] = "true"
         else:
             for datasource_item in datasources:
                 datasource_element = list_element.SubElement(xml_request, 'datasource')

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -569,6 +569,17 @@ class WorkbookRequest(object):
         return _add_multipart(parts)
 
 
+    @_tsrequest_wrapped
+    def embedded_extract_req(self, xml_request, include_all=True, datasources=None):
+        list_element = ET.SubElement(xml_request, 'datasources')
+        if include_all:
+            list_element.attrib['includeAll']="true"
+        else:
+            for datasource_item in datasources:
+                datasource_element = list_element.SubElement(xml_request, 'datasource')
+                datasource_element.attrib['id'] = datasource_item.id
+
+
 class Connection(object):
     @_tsrequest_wrapped
     def update_req(self, xml_request, connection_item):
@@ -623,7 +634,7 @@ class WebhookRequest(object):
         webhook.attrib['name'] = webhook_item.name
 
         source = ET.SubElement(webhook, 'webhook-source')
-        event = ET.SubElement(source, webhook_item._event)
+        ET.SubElement(source, webhook_item._event)
 
         destination = ET.SubElement(webhook, 'webhook-destination')
         post = ET.SubElement(destination, 'webhook-destination-http')

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -381,3 +381,30 @@ class DatasourceTests(unittest.TestCase):
             self.assertRaisesRegex(InternalServerError, 'Please use asynchronous publishing to avoid timeouts.',
                                    self.server.datasources.publish, new_datasource,
                                    asset('SampleDS.tds'), publish_mode)
+
+    def test_delete_extracts(self):
+        self.server.version = "3.10"
+        self.baseurl = self.server.datasources.baseurl
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/deleteExtract', status_code=200)
+            self.server.datasources.delete_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
+
+    def test_create_extracts(self):
+        self.server.version = "3.10"
+        self.baseurl = self.server.datasources.baseurl
+        
+        response_xml = read_xml_asset(PUBLISH_XML_ASYNC)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            self.server.datasources.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
+
+    def test_create_extracts_encrypted(self):
+        self.server.version = "3.10"
+        self.baseurl = self.server.datasources.baseurl
+        
+        response_xml = read_xml_asset(PUBLISH_XML_ASYNC)
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            self.server.datasources.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42', True)
+
+

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -392,19 +392,19 @@ class DatasourceTests(unittest.TestCase):
     def test_create_extracts(self):
         self.server.version = "3.10"
         self.baseurl = self.server.datasources.baseurl
-        
+
         response_xml = read_xml_asset(PUBLISH_XML_ASYNC)
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract',
+                   status_code=200, text=response_xml)
             self.server.datasources.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
 
     def test_create_extracts_encrypted(self):
         self.server.version = "3.10"
         self.baseurl = self.server.datasources.baseurl
-        
+
         response_xml = read_xml_asset(PUBLISH_XML_ASYNC)
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract',
+                   status_code=200, text=response_xml)
             self.server.datasources.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42', True)
-
-

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -151,7 +151,7 @@ class SiteTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/0626857c-1def-4503-a7d8-7907c3ff9d9f/reencrypt-extracts', status_code=200)
             self.server.sites.re_encrypt_extracts('0626857c-1def-4503-a7d8-7907c3ff9d9f')
-            
+
     def test_decrypt(self):
         with requests_mock.mock() as m:
             m.post(self.baseurl + '/0626857c-1def-4503-a7d8-7907c3ff9d9f/decrypt-extracts', status_code=200)

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -15,6 +15,7 @@ CREATE_XML = os.path.join(TEST_ASSET_DIR, 'site_create.xml')
 class SiteTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
+        self.server.version = "3.10"
 
         # Fake signin
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
@@ -140,3 +141,18 @@ class SiteTests(unittest.TestCase):
 
     def test_delete_missing_id(self):
         self.assertRaises(ValueError, self.server.sites.delete, '')
+
+    def test_encrypt(self):
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/0626857c-1def-4503-a7d8-7907c3ff9d9f/encrypt-extracts', status_code=200)
+            self.server.sites.encrypt_extracts('0626857c-1def-4503-a7d8-7907c3ff9d9f')
+
+    def test_recrypt(self):
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/0626857c-1def-4503-a7d8-7907c3ff9d9f/reencrypt-extracts', status_code=200)
+            self.server.sites.re_encrypt_extracts('0626857c-1def-4503-a7d8-7907c3ff9d9f')
+            
+    def test_decrypt(self):
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + '/0626857c-1def-4503-a7d8-7907c3ff9d9f/decrypt-extracts', status_code=200)
+            self.server.sites.decrypt_extracts('0626857c-1def-4503-a7d8-7907c3ff9d9f')

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -471,10 +471,8 @@ class WorkbookTests(unittest.TestCase):
 
             request_body = m._adapter.request_history[0]._request.body
             # order of attributes in xml is unspecified
-            self.assertTrue(
-                (b'<views><view hidden="true" name="GDP per capita" /></views>' in request_body)
-                or
-                (b'<views><view name="GDP per capita" hidden="true" /></views>' in request_body))
+            self.assertTrue(re.search(rb'<views><view.*?hidden=\"true\".*?\/><\/views>', request_body))
+            self.assertTrue(re.search(rb'<views><view.*?name=\"GDP per capita\".*?\/><\/views>', request_body))
 
     def test_publish_async(self):
         self.server.version = '3.0'

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -580,23 +580,24 @@ class WorkbookTests(unittest.TestCase):
     def test_create_extracts_all(self):
         self.server.version = "3.10"
         self.baseurl = self.server.workbooks.baseurl
-        
+
         with open(PUBLISH_ASYNC_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract',
+                   status_code=200, text=response_xml)
             self.server.workbooks.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42')
-
 
     def test_create_extracts_one(self):
         self.server.version = "3.10"
         self.baseurl = self.server.workbooks.baseurl
-    
+
         datasource = TSC.DatasourceItem('test')
         datasource._id = '1f951daf-4061-451a-9df1-69a8062664f2'
-        
+
         with open(PUBLISH_ASYNC_XML, 'rb') as f:
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
-            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract', status_code=200, text=response_xml)
+            m.post(self.baseurl + '/3cc6cd06-89ce-4fdc-b935-5294135d6d42/createExtract',
+                   status_code=200, text=response_xml)
             self.server.workbooks.create_extract('3cc6cd06-89ce-4fdc-b935-5294135d6d42', False, datasource)


### PR DESCRIPTION
Added endpoints to match tabcmd functionality around create/delete extracts on datasource/workbook, and encrypt/decrypt/reencrypt extracts for a site. 


- a bunch of whitespace fixes to come that will make pycodestyle happier