### PR TITLE
Fixed Assert in line 459 for test_workbook.py

### DIFF
--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -457,7 +457,7 @@ class WorkbookTests(unittest.TestCase):
 
             request_body = m._adapter.request_history[0]._request.body
             self.assertIn(
-                b'<views><view hidden="true" name="GDP per capita" /></views>', request_body)
+                b'<views><view name="GDP per capita" hidden="true" /></views>', request_body)
 
     def test_publish_async(self):
         self.server.version = '3.0'


### PR DESCRIPTION
When testing for the first time was getting an assert error in test_workbook.py line 459.

Replaced the request_body message and now all tests pass.
