### PR TITLE
Removes manual query param generation

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -41,9 +41,9 @@ class Endpoint(object):
 
     def _make_request(self, method, url, content=None, request_object=None,
                       auth_token=None, content_type=None, parameters=None):
-        if request_object is not None:
-            url = request_object.apply_query_params(url)
         parameters = parameters or {}
+        if request_object is not None:
+            parameters["params"] = request_object.get_query_params()
         parameters.update(self.parent_srv.http_options)
         parameters['headers'] = Endpoint._make_common_headers(auth_token, content_type)
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -2,6 +2,22 @@ from ..models.property_decorators import property_is_int
 
 
 class RequestOptionsBase(object):
+    def apply_query_params(self, url):
+        import warnings
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn('apply_query_params is deprecated, please use get_query_params instead.', DeprecationWarning)
+        try:
+            params = self.get_query_params()
+            params_list = ["{}={}".format(k, v) for (k, v) in params.items()]
+
+            if '?' in url:
+                url, existing_params = url.split('?')
+                params_list.append(existing_params)
+
+            return "{0}?{1}".format(url, '&'.join(params_list))
+        except NotImplementedError:
+            raise
+
     def get_query_params(self):
         raise NotImplementedError()
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -2,7 +2,7 @@ from ..models.property_decorators import property_is_int
 
 
 class RequestOptionsBase(object):
-    def apply_query_params(self, url):
+    def get_query_params(self):
         raise NotImplementedError()
 
 
@@ -61,27 +61,21 @@ class RequestOptions(RequestOptionsBase):
         self.pagenumber = page_number
         return self
 
-    def apply_query_params(self, url):
-        params = []
-
-        if '?' in url:
-            url, existing_params = url.split('?')
-            params.append(existing_params)
-
-        if self.page_number:
-            params.append('pageNumber={0}'.format(self.pagenumber))
-        if self.page_size:
-            params.append('pageSize={0}'.format(self.pagesize))
+    def get_query_params(self):
+        params = {}
+        if self.pagenumber:
+            params['pageNumber'] = self.pagenumber
+        if self.pagesize:
+            params['pageSize'] = self.pagesize
         if len(self.sort) > 0:
             sort_options = (str(sort_item) for sort_item in self.sort)
             ordered_sort_options = sorted(sort_options)
-            params.append('sort={}'.format(','.join(ordered_sort_options)))
+            params['sort'] = ','.join(ordered_sort_options)
         if len(self.filter) > 0:
             filter_options = (str(filter_item) for filter_item in self.filter)
             ordered_filter_options = sorted(filter_options)
-            params.append('filter={}'.format(','.join(ordered_filter_options)))
-
-        return "{0}?{1}".format(url, '&'.join(params))
+            params['filter'] = ','.join(ordered_filter_options)
+        return params
 
 
 class _FilterOptionsBase(RequestOptionsBase):
@@ -90,7 +84,7 @@ class _FilterOptionsBase(RequestOptionsBase):
     def __init__(self):
         self.view_filters = []
 
-    def apply_query_params(self, url):
+    def get_query_params(self):
         raise NotImplementedError()
 
     def vf(self, name, value):
@@ -99,7 +93,7 @@ class _FilterOptionsBase(RequestOptionsBase):
 
     def _append_view_filters(self, params):
         for name, value in self.view_filters:
-            params.append('vf_{}={}'.format(name, value))
+            params['vf_' + name] = value
 
 
 class CSVRequestOptions(_FilterOptionsBase):
@@ -116,13 +110,13 @@ class CSVRequestOptions(_FilterOptionsBase):
     def max_age(self, value):
         self._max_age = value
 
-    def apply_query_params(self, url):
-        params = []
+    def get_query_params(self):
+        params = {}
         if self.max_age != -1:
-            params.append('maxAge={0}'.format(self.max_age))
+            params['maxAge'] = self.max_age
 
         self._append_view_filters(params)
-        return "{0}?{1}".format(url, '&'.join(params))
+        return params
 
 
 class ImageRequestOptions(_FilterOptionsBase):
@@ -144,16 +138,14 @@ class ImageRequestOptions(_FilterOptionsBase):
     def max_age(self, value):
         self._max_age = value
 
-    def apply_query_params(self, url):
-        params = []
+    def get_query_params(self):
+        params = {}
         if self.image_resolution:
-            params.append('resolution={0}'.format(self.image_resolution))
+            params['resolution'] = self.image_resolution
         if self.max_age != -1:
-            params.append('maxAge={0}'.format(self.max_age))
-
+            params['maxAge'] = self.max_age
         self._append_view_filters(params)
-
-        return "{0}?{1}".format(url, '&'.join(params))
+        return params
 
 
 class PDFRequestOptions(_FilterOptionsBase):
@@ -191,17 +183,17 @@ class PDFRequestOptions(_FilterOptionsBase):
     def max_age(self, value):
         self._max_age = value
 
-    def apply_query_params(self, url):
-        params = []
+    def get_query_params(self):
+        params = {}
         if self.page_type:
-            params.append('type={0}'.format(self.page_type))
+            params['type'] = self.page_type
 
         if self.orientation:
-            params.append('orientation={0}'.format(self.orientation))
+            params['orientation'] = self.orientation
 
         if self.max_age != -1:
-            params.append('maxAge={0}'.format(self.max_age))
+            params['maxAge'] = self.max_age
 
         self._append_view_filters(params)
 
-        return "{0}?{1}".format(url, '&'.join(params))
+        return params

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -115,7 +115,7 @@ class RequestOptionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
             url = "http://test/api/2.3/sites/12345/views?queryParamExists=true"
-            opts = TSC.RequestOptions(pagesize=13, pagenumber=13)
+            opts = TSC.RequestOptions()
 
             opts.filter.add(TSC.Filter(TSC.RequestOptions.Field.Tags,
                                        TSC.RequestOptions.Operator.In,
@@ -127,8 +127,8 @@ class RequestOptionTests(unittest.TestCase):
                                                        request_object=opts,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
-            self.assertEqual(resp.request.query,
-                             'queryparamexists=true&pagenumber=13&pagesize=13&filter=tags%3ain%3a%5bstocks%2cmarket%5d')
+            self.assertTrue(re.search('queryparamexists=true', resp.request.query))
+            self.assertTrue(re.search('filter=tags%3ain%3a%5bstocks%2cmarket%5d', resp.request.query))
 
     def test_vf(self):
         with requests_mock.mock() as m:

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import requests
 import requests_mock
 import tableauserverclient as TSC
 
@@ -107,3 +108,40 @@ class RequestOptionTests(unittest.TestCase):
             for _ in range(100):
                 matching_workbooks, pagination_item = self.server.workbooks.get(req_option)
                 self.assertEqual(3, pagination_item.total_available)
+
+    # Test req_options if url already has query params
+    def test_double_query_params(self):
+        with requests_mock.mock() as m:
+            m.get(requests_mock.ANY)
+            url = "http://test/api/2.3/sites/12345/views?queryParamExists=true"
+            opts = TSC.RequestOptions(pagesize=13, pagenumber=13)
+
+            opts.filter.add(TSC.Filter(TSC.RequestOptions.Field.Tags,
+                                       TSC.RequestOptions.Operator.In,
+                                       ['stocks', 'market']))
+
+            resp = self.server.workbooks._make_request(requests.get,
+                                                       url,
+                                                       content=None,
+                                                       request_object=opts,
+                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
+                                                       content_type='text/xml')
+            self.assertEqual(resp.request.query,
+                             'queryparamexists=true&pagenumber=13&pagesize=13&filter=tags%3ain%3a%5bstocks%2cmarket%5d')
+
+    def test_vf(self):
+        with requests_mock.mock() as m:
+            m.get(requests_mock.ANY)
+            url = "http://test/api/2.3/sites/123/views/456/data"
+            opts = TSC.PDFRequestOptions()
+            opts.vf("name1#", "value1")
+            opts.vf("name2$", "value2")
+            opts.page_type = TSC.PDFRequestOptions.PageType.Tabloid
+
+            resp = self.server.workbooks._make_request(requests.get,
+                                                       url,
+                                                       content=None,
+                                                       request_object=opts,
+                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
+                                                       content_type='text/xml')
+            self.assertEqual(resp.request.query, 'type=tabloid&vf_name1%23=value1&vf_name2%24=value2')

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import re
 import requests
 import requests_mock
 import tableauserverclient as TSC
@@ -144,4 +145,6 @@ class RequestOptionTests(unittest.TestCase):
                                                        request_object=opts,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
-            self.assertEqual(resp.request.query, 'type=tabloid&vf_name1%23=value1&vf_name2%24=value2')
+            self.assertTrue(re.search('vf_name1%23=value1', resp.request.query))
+            self.assertTrue(re.search('vf_name2%24=value2', resp.request.query))
+            self.assertTrue(re.search('type=tabloid', resp.request.query))

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -1,5 +1,5 @@
 import unittest
-
+import re
 import requests
 import requests_mock
 
@@ -22,7 +22,7 @@ class RequestTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
             url = "http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/workbooks"
-            opts = TSC.RequestOptions(pagesize=13, pagenumber=13)
+            opts = TSC.RequestOptions(pagesize=13, pagenumber=15)
             resp = self.server.workbooks._make_request(requests.get,
                                                        url,
                                                        content=None,
@@ -30,9 +30,8 @@ class RequestTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13')
-            self.assertEqual(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')
-            self.assertEqual(resp.request.headers['content-type'], 'text/xml')
+            self.assertTrue(re.search('pagesize=13', resp.request.query))
+            self.assertTrue(re.search('pagenumber=15', resp.request.query))
 
     def test_make_post_request(self):
         with requests_mock.mock() as m:

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -31,7 +31,7 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=name:eq:superstore')
+            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=name%3aeq%3asuperstore')
 
     def test_filter_equals_list(self):
         with self.assertRaises(ValueError) as cm:
@@ -57,7 +57,7 @@ class SortTests(unittest.TestCase):
                                                        request_object=opts,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags:in:%5bstocks,market%5d')
+            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags%3ain%3a%5bstocks%2cmarket%5d')
 
     def test_sort_asc(self):
         with requests_mock.mock() as m:
@@ -74,7 +74,7 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&sort=name:asc')
+            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&sort=name%3aasc')
 
     def test_filter_combo(self):
         with requests_mock.mock() as m:
@@ -97,7 +97,8 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            expected = 'pagenumber=13&pagesize=13&filter=lastlogin:gte:2017-01-15t00:00:00:00z,siterole:eq:publisher'
+            expected = 'pagenumber=13&pagesize=13&filter=lastlogin%3agte%3a' \
+                       '2017-01-15t00%3a00%3a00%3a00z%2csiterole%3aeq%3apublisher'
 
             self.assertEqual(resp.request.query, expected)
 

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -1,5 +1,5 @@
 import unittest
-import os
+import re
 import requests
 import requests_mock
 import tableauserverclient as TSC
@@ -31,7 +31,9 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=name%3aeq%3asuperstore')
+            self.assertTrue(re.search('pagenumber=13', resp.request.query))
+            self.assertTrue(re.search('pagesize=13', resp.request.query))
+            self.assertTrue(re.search('filter=name%3aeq%3asuperstore', resp.request.query))
 
     def test_filter_equals_list(self):
         with self.assertRaises(ValueError) as cm:
@@ -57,7 +59,9 @@ class SortTests(unittest.TestCase):
                                                        request_object=opts,
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&filter=tags%3ain%3a%5bstocks%2cmarket%5d')
+            self.assertTrue(re.search('pagenumber=13', resp.request.query))
+            self.assertTrue(re.search('pagesize=13', resp.request.query))
+            self.assertTrue(re.search('filter=tags%3ain%3a%5bstocks%2cmarket%5d', resp.request.query))
 
     def test_sort_asc(self):
         with requests_mock.mock() as m:
@@ -74,7 +78,9 @@ class SortTests(unittest.TestCase):
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='text/xml')
 
-            self.assertEqual(resp.request.query, 'pagenumber=13&pagesize=13&sort=name%3aasc')
+            self.assertTrue(re.search('pagenumber=13', resp.request.query))
+            self.assertTrue(re.search('pagesize=13', resp.request.query))
+            self.assertTrue(re.search('sort=name%3aasc', resp.request.query))
 
     def test_filter_combo(self):
         with requests_mock.mock() as m:
@@ -100,7 +106,11 @@ class SortTests(unittest.TestCase):
             expected = 'pagenumber=13&pagesize=13&filter=lastlogin%3agte%3a' \
                        '2017-01-15t00%3a00%3a00%3a00z%2csiterole%3aeq%3apublisher'
 
-            self.assertEqual(resp.request.query, expected)
+            self.assertTrue(re.search('pagenumber=13', resp.request.query))
+            self.assertTrue(re.search('pagesize=13', resp.request.query))
+            self.assertTrue(re.search(
+                'filter=lastlogin%3agte%3a2017-01-15t00%3a00%3a00%3a00z%2csiterole%3aeq%3apublisher',
+                resp.request.query))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Removing manual query param generation in req_options, and delegating that step to the requests library.
By doing this, the requests library will encode the url for us, fixing #418, #516, #578.

Some endpoints have their own query params added, like workbook publish overwrite flag. The requests library will append new query params to the existing one in this case.