### PR TITLE
Encode tag-name before deleting

### DIFF
--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 from ..datetime_helpers import parse_datetime
 from .exceptions import UnpopulatedPropertyError
 from .tag_item import TagItem
+import copy
 
 
 class ViewItem(object):
@@ -158,7 +159,7 @@ class ViewItem(object):
             if tags_elem is not None:
                 tags = TagItem.from_xml_element(tags_elem, ns)
                 view_item.tags = tags
-                view_item._initial_tags = tags
+                view_item._initial_tags = copy.copy(tags)
 
             all_view_items.append(view_item)
         return all_view_items

--- a/tableauserverclient/server/endpoint/resource_tagger.py
+++ b/tableauserverclient/server/endpoint/resource_tagger.py
@@ -4,6 +4,7 @@ from .. import RequestFactory
 from ...models.tag_item import TagItem
 import logging
 import copy
+import urllib.parse
 
 logger = logging.getLogger('tableau.endpoint.resource_tagger')
 
@@ -18,21 +19,23 @@ class _ResourceTagger(Endpoint):
             server_response = self.put_request(url, add_req)
             return TagItem.from_response(server_response.content, self.parent_srv.namespace)
         except ServerResponseError as e:
-            if e.code == "404003":
+            if e.code == "404008":
                 error = "Adding tags to this resource type is only available with REST API version 2.6 and later."
                 raise EndpointUnavailableError(error)
             raise  # Some other error
 
     # Delete a resource's tag by name
     def _delete_tag(self, baseurl, resource_id, tag_name):
-        url = "{0}/{1}/tags/{2}".format(baseurl, resource_id, tag_name)
+        encoded_tag_name = urllib.parse.quote(tag_name)
+        url = "{0}/{1}/tags/{2}".format(baseurl, resource_id, encoded_tag_name)
 
         try:
             self.delete_request(url)
         except ServerResponseError as e:
-            if e.code == "404003":
+            if e.code == "404008":
                 error = "Deleting tags from this resource type is only available with REST API version 2.6 and later."
                 raise EndpointUnavailableError(error)
+            raise  # Some other error
 
     # Remove and add tags to match the resource item's tag set
     def update_tags(self, baseurl, resource_item):


### PR DESCRIPTION
Encodes tag-name in the request URL for deleting a tag, #675.
Note that tag names with forward slashes will not work.

Also fixes tag add/delete bug for views, #622.