### PR TITLE
Update publish_workbook.py

### DIFF
--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -27,10 +27,11 @@ def main():
     parser = argparse.ArgumentParser(description='Publish a workbook to server.')
     parser.add_argument('--server', '-s', required=True, help='server address')
     parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--filepath', '-f', required=True, help='filepath to the workbook to publish')
+    parser.add_argument('--filepath', '-f', required=True, help='computer filepath of the workbook to publish')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
     parser.add_argument('--as-job', '-a', help='Publishing asynchronously', action='store_true')
+    parser.add_argument('--sitename', '-S', default='', help='sitename required')
 
     args = parser.parse_args()
 
@@ -41,7 +42,7 @@ def main():
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    tableau_auth = TSC.TableauAuth(args.username, password)
+    tableau_auth = TSC.TableauAuth(args.username, password,site_id=args.sitename)
     server = TSC.Server(args.server)
 
     overwrite_true = TSC.Server.PublishMode.Overwrite

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
     parser.add_argument('--as-job', '-a', help='Publishing asynchronously', action='store_true')
-    parser.add_argument('--sitename', '-S', default='', help='sitename required')
+    parser.add_argument('--site', '-S', default='', help='id (contentUrl) of site to sign into')
 
     args = parser.parse_args()
 
@@ -42,7 +42,7 @@ def main():
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    tableau_auth = TSC.TableauAuth(args.username, password,site_id=args.sitename)
+    tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.sitename)
     server = TSC.Server(args.server)
 
     overwrite_true = TSC.Server.PublishMode.Overwrite

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -42,7 +42,7 @@ def main():
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.sitename)
+    tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.site)
     server = TSC.Server(args.server)
 
     overwrite_true = TSC.Server.PublishMode.Overwrite


### PR DESCRIPTION
Added below SiteName arguments, without this there is a Signin error on publishing a test file to Tableau Online.

parser.add_argument('--sitename', '-S', default='', help='sitename required')
tableau_auth = TSC.TableauAuth(args.username, password,site_id=args.sitename)

![image](https://user-images.githubusercontent.com/64155057/93400059-e87e0f80-f84c-11ea-9da4-06ea02dafd38.png)
