### PR TITLE
Updates datasource_item with new fields

### DIFF
--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -28,6 +28,7 @@ class DatasourceItem(object):
         self._updated_at = None
         self._use_remote_query_agent = None
         self._webpage_url = None
+        self.description = None
         self.name = name
         self.owner_id = None
         self.project_id = project_id

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -138,17 +138,17 @@ class DatasourceItem(object):
         if not isinstance(datasource_xml, ET.Element):
             datasource_xml = ET.fromstring(datasource_xml).find('.//t:datasource', namespaces=ns)
         if datasource_xml is not None:
-            (ask_data_enablement, certified, certification_note, _, _, _, encrypt_extracts, has_extracts,
-             _, _,owner_id, project_id, project_name, _, updated_at, use_remote_query_agent,
+            (ask_data_enablement, certified, certification_note, _, _, _, _, encrypt_extracts, has_extracts,
+             _, _, owner_id, project_id, project_name, _, updated_at, use_remote_query_agent,
              webpage_url) = self._parse_element(datasource_xml, ns)
-            self._set_values(ask_data_enablement, certified, certification_note, None, None, None, encrypt_extracts,
-                             has_extracts, None, None, owner_id, project_id, project_name, None, updated_at,
-                             use_remote_query_agent, webpage_url)
+            self._set_values(ask_data_enablement, certified, certification_note, None, None, None, None,
+                             encrypt_extracts, has_extracts, None, None, owner_id, project_id, project_name, None,
+                             updated_at, use_remote_query_agent, webpage_url)
         return self
 
     def _set_values(self, ask_data_enablement, certified, certification_note, content_url, created_at, datasource_type,
-                    encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags, updated_at,
-                    use_remote_query_agent, webpage_url):
+                    description, encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags,
+                    updated_at, use_remote_query_agent, webpage_url):
         if ask_data_enablement is not None:
             self._ask_data_enablement = ask_data_enablement
         if certification_note:
@@ -160,6 +160,8 @@ class DatasourceItem(object):
             self._created_at = created_at
         if datasource_type:
             self._datasource_type = datasource_type
+        if description:
+            self.description = description
         if encrypt_extracts is not None:
             self.encrypt_extracts = str(encrypt_extracts).lower() == 'true'
         if has_extracts is not None:
@@ -181,9 +183,8 @@ class DatasourceItem(object):
             self._updated_at = updated_at
         if use_remote_query_agent is not None:
             self._use_remote_query_agent = str(use_remote_query_agent).lower() == 'true'
-        if webpage_url is not None:
+        if webpage_url:
             self._webpage_url = webpage_url
-
 
     @classmethod
     def from_response(cls, resp, ns):
@@ -193,12 +194,13 @@ class DatasourceItem(object):
 
         for datasource_xml in all_datasource_xml:
             (ask_data_enablement, certified, certification_note, content_url, created_at, datasource_type,
-             encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags, updated_at,
-             use_remote_query_agent, webpage_url) = cls._parse_element(datasource_xml, ns)
+             description, encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags,
+             updated_at, use_remote_query_agent, webpage_url) = cls._parse_element(datasource_xml, ns)
             datasource_item = cls(project_id)
-            datasource_item._set_values(ask_data_enablement, certified, certification_note, content_url, created_at,
-                                        datasource_type, encrypt_extracts, has_extracts, id_, name, owner_id,
-                                        None, project_name, tags, updated_at, use_remote_query_agent, webpage_url)
+            datasource_item._set_values(ask_data_enablement, certified, certification_note, content_url,
+                                        created_at, datasource_type, description, encrypt_extracts,
+                                        has_extracts, id_, name, owner_id, None, project_name, tags, updated_at,
+                                        use_remote_query_agent, webpage_url)
             all_datasource_items.append(datasource_item)
         return all_datasource_items
 
@@ -209,6 +211,7 @@ class DatasourceItem(object):
         content_url = datasource_xml.get('contentUrl', None)
         created_at = parse_datetime(datasource_xml.get('createdAt', None))
         datasource_type = datasource_xml.get('type', None)
+        description = datasource_xml.get('description', None)
         encrypt_extracts = datasource_xml.get('encryptExtracts', None)
         has_extracts = datasource_xml.get('hasExtracts', None)
         id_ = datasource_xml.get('id', None)
@@ -240,5 +243,5 @@ class DatasourceItem(object):
             ask_data_enablement = ask_data_elem.get('enablement', None)
 
         return (ask_data_enablement, certified, certification_note, content_url, created_at,
-                datasource_type, encrypt_extracts, has_extracts, id_, name, owner_id,
+                datasource_type, description, encrypt_extracts, has_extracts, id_, name, owner_id,
                 project_id, project_name, tags, updated_at, use_remote_query_agent, webpage_url)

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,29 +1,48 @@
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
-from .property_decorators import property_not_nullable, property_is_boolean
+from .property_decorators import property_not_nullable, property_is_boolean, property_is_enum
 from .tag_item import TagItem
 from ..datetime_helpers import parse_datetime
 import copy
 
 
 class DatasourceItem(object):
+    class AskDataEnablement:
+        Enabled = 'Enabled'
+        Disabled = 'Disabled'
+        SiteDefault = 'SiteDefault'
+
     def __init__(self, project_id, name=None):
+        self._ask_data_enablement = None
+        self._certified = None
+        self._certification_note = None
         self._connections = None
         self._content_url = None
         self._created_at = None
         self._datasource_type = None
+        self._encrypt_extracts = None
+        self._has_extracts = None
         self._id = None
         self._initial_tags = set()
         self._project_name = None
         self._updated_at = None
-        self._certified = None
-        self._certification_note = None
+        self._use_remote_query_agent = None
+        self._webpage_url = None
         self.name = name
         self.owner_id = None
         self.project_id = project_id
         self.tags = set()
 
         self._permissions = None
+
+    @property
+    def ask_data_enablement(self):
+        return self._ask_data_enablement
+
+    @ask_data_enablement.setter
+    @property_is_enum(AskDataEnablement)
+    def ask_data_enablement(self, value):
+        self._ask_data_enablement = value
 
     @property
     def connections(self):
@@ -66,6 +85,15 @@ class DatasourceItem(object):
         self._certification_note = value
 
     @property
+    def encrypt_extracts(self):
+        return self._encrypt_extracts
+
+    @encrypt_extracts.setter
+    @property_is_boolean
+    def encrypt_extracts(self, value):
+        self._encrypt_extracts = value
+
+    @property
     def id(self):
         return self._id
 
@@ -90,6 +118,15 @@ class DatasourceItem(object):
     def updated_at(self):
         return self._updated_at
 
+    @property
+    def use_remote_query_agent(self):
+        return self._use_remote_query_agent
+
+    @use_remote_query_agent.setter
+    @property_is_boolean
+    def use_remote_query_agent(self, value):
+        self._use_remote_query_agent = value
+
     def _set_connections(self, connections):
         self._connections = connections
 
@@ -100,38 +137,52 @@ class DatasourceItem(object):
         if not isinstance(datasource_xml, ET.Element):
             datasource_xml = ET.fromstring(datasource_xml).find('.//t:datasource', namespaces=ns)
         if datasource_xml is not None:
-            (_, _, _, _, _, updated_at, _, project_id, project_name, owner_id,
-             certified, certification_note) = self._parse_element(datasource_xml, ns)
-            self._set_values(None, None, None, None, None, updated_at, None, project_id,
-                             project_name, owner_id, certified, certification_note)
+            (ask_data_enablement, certified, certification_note, _, _, _, encrypt_extracts, has_extracts,
+             _, _,owner_id, project_id, project_name, _, updated_at, use_remote_query_agent,
+             webpage_url) = self._parse_element(datasource_xml, ns)
+            self._set_values(ask_data_enablement, certified, certification_note, None, None, None, encrypt_extracts,
+                             has_extracts, None, None, owner_id, project_id, project_name, None, updated_at,
+                             use_remote_query_agent, webpage_url)
         return self
 
-    def _set_values(self, id, name, datasource_type, content_url, created_at,
-                    updated_at, tags, project_id, project_name, owner_id, certified, certification_note):
-        if id is not None:
-            self._id = id
-        if name:
-            self.name = name
-        if datasource_type:
-            self._datasource_type = datasource_type
+    def _set_values(self, ask_data_enablement, certified, certification_note, content_url, created_at, datasource_type,
+                    encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags, updated_at,
+                    use_remote_query_agent, webpage_url):
+        if ask_data_enablement is not None:
+            self._ask_data_enablement = ask_data_enablement
+        if certification_note:
+            self.certification_note = certification_note
+        self.certified = certified  # Always True/False, not conditional
         if content_url:
             self._content_url = content_url
         if created_at:
             self._created_at = created_at
-        if updated_at:
-            self._updated_at = updated_at
-        if tags:
-            self.tags = tags
-            self._initial_tags = copy.copy(tags)
+        if datasource_type:
+            self._datasource_type = datasource_type
+        if encrypt_extracts is not None:
+            self.encrypt_extracts = str(encrypt_extracts).lower() == 'true'
+        if has_extracts is not None:
+            self._has_extracts = str(has_extracts).lower() == 'true'
+        if id_ is not None:
+            self._id = id_
+        if name:
+            self.name = name
+        if owner_id:
+            self.owner_id = owner_id
         if project_id:
             self.project_id = project_id
         if project_name:
             self._project_name = project_name
-        if owner_id:
-            self.owner_id = owner_id
-        if certification_note:
-            self.certification_note = certification_note
-        self.certified = certified  # Always True/False, not conditional
+        if tags:
+            self.tags = tags
+            self._initial_tags = copy.copy(tags)
+        if updated_at:
+            self._updated_at = updated_at
+        if use_remote_query_agent is not None:
+            self._use_remote_query_agent = str(use_remote_query_agent).lower() == 'true'
+        if webpage_url is not None:
+            self._webpage_url = webpage_url
+
 
     @classmethod
     def from_response(cls, resp, ns):
@@ -140,25 +191,30 @@ class DatasourceItem(object):
         all_datasource_xml = parsed_response.findall('.//t:datasource', namespaces=ns)
 
         for datasource_xml in all_datasource_xml:
-            (id_, name, datasource_type, content_url, created_at, updated_at,
-             tags, project_id, project_name, owner_id,
-             certified, certification_note) = cls._parse_element(datasource_xml, ns)
+            (ask_data_enablement, certified, certification_note, content_url, created_at, datasource_type,
+             encrypt_extracts, has_extracts, id_, name, owner_id, project_id, project_name, tags, updated_at,
+             use_remote_query_agent, webpage_url) = cls._parse_element(datasource_xml, ns)
             datasource_item = cls(project_id)
-            datasource_item._set_values(id_, name, datasource_type, content_url, created_at, updated_at,
-                                        tags, None, project_name, owner_id, certified, certification_note)
+            datasource_item._set_values(ask_data_enablement, certified, certification_note, content_url, created_at,
+                                        datasource_type, encrypt_extracts, has_extracts, id_, name, owner_id,
+                                        None, project_name, tags, updated_at, use_remote_query_agent, webpage_url)
             all_datasource_items.append(datasource_item)
         return all_datasource_items
 
     @staticmethod
     def _parse_element(datasource_xml, ns):
-        id_ = datasource_xml.get('id', None)
-        name = datasource_xml.get('name', None)
-        datasource_type = datasource_xml.get('type', None)
-        content_url = datasource_xml.get('contentUrl', None)
-        created_at = parse_datetime(datasource_xml.get('createdAt', None))
-        updated_at = parse_datetime(datasource_xml.get('updatedAt', None))
         certification_note = datasource_xml.get('certificationNote', None)
         certified = str(datasource_xml.get('isCertified', None)).lower() == 'true'
+        content_url = datasource_xml.get('contentUrl', None)
+        created_at = parse_datetime(datasource_xml.get('createdAt', None))
+        datasource_type = datasource_xml.get('type', None)
+        encrypt_extracts = datasource_xml.get('encryptExtracts', None)
+        has_extracts = datasource_xml.get('hasExtracts', None)
+        id_ = datasource_xml.get('id', None)
+        name = datasource_xml.get('name', None)
+        updated_at = parse_datetime(datasource_xml.get('updatedAt', None))
+        use_remote_query_agent = datasource_xml.get('useRemoteQueryAgent', None)
+        webpage_url = datasource_xml.get('webpageUrl', None)
 
         tags = None
         tags_elem = datasource_xml.find('.//t:tags', namespaces=ns)
@@ -177,5 +233,11 @@ class DatasourceItem(object):
         if owner_elem is not None:
             owner_id = owner_elem.get('id', None)
 
-        return (id_, name, datasource_type, content_url, created_at, updated_at, tags, project_id,
-                project_name, owner_id, certified, certification_note)
+        ask_data_enablement = None
+        ask_data_elem = datasource_xml.find('.//t:askData', namespaces=ns)
+        if ask_data_elem is not None:
+            ask_data_enablement = ask_data_elem.get('enablement', None)
+
+        return (ask_data_enablement, certified, certification_note, content_url, created_at,
+                datasource_type, encrypt_extracts, has_extracts, id_, name, owner_id,
+                project_id, project_name, tags, updated_at, use_remote_query_agent, webpage_url)

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -131,6 +131,15 @@ class DatasourceRequest(object):
         xml_request = ET.Element('tsRequest')
         datasource_element = ET.SubElement(xml_request, 'datasource')
         datasource_element.attrib['name'] = datasource_item.name
+        if datasource_item.description:
+            datasource_element.attrib['description'] = str(datasource_item.description)
+        if datasource_item.use_remote_query_agent is not None:
+            datasource_element.attrib['useRemoteQueryAgent'] = str(datasource_item.use_remote_query_agent).lower()
+
+        if datasource_item.ask_data_enablement:
+            ask_data_element = ET.SubElement(datasource_element, 'askData')
+            ask_data_element.attrib['enablement'] = datasource_item.ask_data_enablement
+
         project_element = ET.SubElement(datasource_element, 'project')
         project_element.attrib['id'] = datasource_item.project_id
 
@@ -149,6 +158,9 @@ class DatasourceRequest(object):
     def update_req(self, datasource_item):
         xml_request = ET.Element('tsRequest')
         datasource_element = ET.SubElement(xml_request, 'datasource')
+        if datasource_item.ask_data_enablement:
+            ask_data_element = ET.SubElement(datasource_element, 'askData')
+            ask_data_element.attrib['enablement'] = datasource_item.ask_data_enablement
         if datasource_item.project_id:
             project_element = ET.SubElement(datasource_element, 'project')
             project_element.attrib['id'] = datasource_item.project_id
@@ -160,6 +172,8 @@ class DatasourceRequest(object):
 
         if datasource_item.certification_note:
             datasource_element.attrib['certificationNote'] = str(datasource_item.certification_note)
+        if datasource_item.encrypt_extracts is not None:
+            datasource_element.attrib['encryptExtracts'] = str(datasource_item.encrypt_extracts).lower()
 
         return ET.tostring(xml_request)
 

--- a/test/assets/datasource_get.xml
+++ b/test/assets/datasource_get.xml
@@ -2,12 +2,12 @@
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
     <pagination pageNumber="1" pageSize="100" totalAvailable="2" />
     <datasources>
-        <datasource id="e76a1461-3b1d-4588-bf1b-17551a879ad9" name="SampleDS" contentUrl="SampleDS" type="dataengine" createdAt="2016-08-11T21:22:40Z" updatedAt="2016-08-11T21:34:17Z">
+        <datasource id="e76a1461-3b1d-4588-bf1b-17551a879ad9" name="SampleDS" contentUrl="SampleDS" type="dataengine" createdAt="2016-08-11T21:22:40Z" updatedAt="2016-08-11T21:34:17Z" encryptExtracts="false" hasExtracts="true" useRemoteQueryAgent="false" webpageUrl="https://web.com">
             <project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <tags />
         </datasource>
-        <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="Sample datasource" contentUrl="Sampledatasource" type="dataengine" createdAt="2016-08-04T21:31:55Z" updatedAt="2016-08-04T21:31:55Z">
+        <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="Sample datasource" contentUrl="Sampledatasource" type="dataengine" createdAt="2016-08-04T21:31:55Z" updatedAt="2016-08-04T21:31:55Z" encryptExtracts="true" hasExtracts="false" useRemoteQueryAgent="true" webpageUrl="https://page.com">
             <project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
             <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
             <tags>

--- a/test/assets/datasource_get_by_id.xml
+++ b/test/assets/datasource_get_by_id.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-    <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="Sample datasource" contentUrl="Sampledatasource" type="dataengine" createdAt="2016-08-04T21:31:55Z" updatedAt="2016-08-04T21:31:55Z">
+    <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="Sample datasource" contentUrl="Sampledatasource" type="dataengine" createdAt="2016-08-04T21:31:55Z" updatedAt="2016-08-04T21:31:55Z" description="test-ds">
         <project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
         <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
         <tags>
@@ -8,5 +8,6 @@
             <tag label="indicators" />
             <tag label="sample" />
         </tags>
+        <askData enablement="SiteDefault" />
     </datasource>
 </tsResponse>

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -47,6 +47,10 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('SampleDS', all_datasources[0].name)
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_datasources[0].project_id)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_datasources[0].owner_id)
+        self.assertEqual('https://web.com', all_datasources[0]._webpage_url)
+        self.assertFalse(all_datasources[0].encrypt_extracts)
+        self.assertTrue(all_datasources[0]._has_extracts)
+        self.assertFalse(all_datasources[0]._use_remote_query_agent)
 
         self.assertEqual('9dbd2263-16b5-46e1-9c43-a76bb8ab65fb', all_datasources[1].id)
         self.assertEqual('dataengine', all_datasources[1].datasource_type)
@@ -58,6 +62,10 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', all_datasources[1].project_id)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', all_datasources[1].owner_id)
         self.assertEqual(set(['world', 'indicators', 'sample']), all_datasources[1].tags)
+        self.assertEqual('https://page.com', all_datasources[1]._webpage_url)
+        self.assertTrue(all_datasources[1].encrypt_extracts)
+        self.assertFalse(all_datasources[1]._has_extracts)
+        self.assertTrue(all_datasources[1]._use_remote_query_agent)
 
     def test_get_before_signin(self):
         self.server._auth_token = None
@@ -88,6 +96,8 @@ class DatasourceTests(unittest.TestCase):
         self.assertEqual('ee8c6e70-43b6-11e6-af4f-f7b0d8e20760', single_datasource.project_id)
         self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', single_datasource.owner_id)
         self.assertEqual(set(['world', 'indicators', 'sample']), single_datasource.tags)
+        self.assertEqual("test-ds", single_datasource.description)
+        self.assertEqual(TSC.DatasourceItem.AskDataEnablement.SiteDefault, single_datasource.ask_data_enablement)
 
     def test_update(self):
         response_xml = read_xml_asset(UPDATE_XML)


### PR DESCRIPTION
Datasource item has been updated to support some new fields. Below are the 6 new fields and the endpoints it affects:
**ask_data_enablement**: publish, update, get_by_id 
**description**: publish, get, get_by_id (only returned if it's set to something)
**encrypt_extracts**: update, get, get_by_id
**has_extracts**: get, get_by_id (2020.2+, v3.8+ with next MR)
**use_remote_query_agent**: publish, get, get_by_id
**webpage_url**: get, get_by_id

This change also alphabetizes the fields in datasource_item to make it a bit more readable. Doc updates coming