### PR TITLE
Removes constraint that required interval when updating schedule

### DIFF
--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -43,9 +43,6 @@ class Schedules(Endpoint):
         if not schedule_item.id:
             error = "Schedule item missing ID."
             raise MissingRequiredFieldError(error)
-        if schedule_item.interval_item is None:
-            error = "Interval item must be defined."
-            raise MissingRequiredFieldError(error)
 
         url = "{0}/{1}".format(self.baseurl, schedule_item.id)
         update_req = RequestFactory.Schedule.update_req(schedule_item)

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -398,19 +398,21 @@ class ScheduleRequest(object):
             schedule_element.attrib['executionOrder'] = schedule_item.execution_order
         if schedule_item.state:
             schedule_element.attrib['state'] = schedule_item.state
+
         interval_item = schedule_item.interval_item
-        if interval_item._frequency:
-            schedule_element.attrib['frequency'] = interval_item._frequency
-        frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
-        frequency_element.attrib['start'] = str(interval_item.start_time)
-        if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
-            frequency_element.attrib['end'] = str(interval_item.end_time)
-        intervals_element = ET.SubElement(frequency_element, 'intervals')
-        if hasattr(interval_item, 'interval'):
-            for interval in interval_item._interval_type_pairs():
-                (expression, value) = interval
-                single_interval_element = ET.SubElement(intervals_element, 'interval')
-                single_interval_element.attrib[expression] = value
+        if interval_item is not None:
+            if interval_item._frequency:
+                schedule_element.attrib['frequency'] = interval_item._frequency
+            frequency_element = ET.SubElement(schedule_element, 'frequencyDetails')
+            frequency_element.attrib['start'] = str(interval_item.start_time)
+            if hasattr(interval_item, 'end_time') and interval_item.end_time is not None:
+                frequency_element.attrib['end'] = str(interval_item.end_time)
+            intervals_element = ET.SubElement(frequency_element, 'intervals')
+            if hasattr(interval_item, 'interval'):
+                for interval in interval_item._interval_type_pairs():
+                    (expression, value) = interval
+                    single_interval_element = ET.SubElement(intervals_element, 'interval')
+                    single_interval_element.attrib[expression] = value
         return ET.tostring(xml_request)
 
     def _add_to_req(self, id_, target_type, task_type=TaskItem.Type.ExtractRefresh):

--- a/test/assets/schedule_update.xml
+++ b/test/assets/schedule_update.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-    <schedule id="7bea1766-1543-4052-9753-9d224bc069b5" name="weekly-schedule-1" state="Active" priority="90" createdAt="2016-09-15T23:49:53Z" updatedAt="2016-09-15T23:50:02Z" type="Extract" frequency="Weekly" nextRunAt="2016-09-16T14:00:00Z" executionOrder="Parallel">
+    <schedule id="7bea1766-1543-4052-9753-9d224bc069b5" name="weekly-schedule-1" state="Suspended" priority="90" createdAt="2016-09-15T23:49:53Z" updatedAt="2016-09-15T23:50:02Z" type="Extract" frequency="Weekly" nextRunAt="2016-09-16T14:00:00Z" executionOrder="Parallel">
         <frequencyDetails start="07:00:00">
             <intervals>
                 <interval weekDay="Monday" />


### PR DESCRIPTION
Attributes of a schedule can be updated without needing an interval attribute. We previously had a check to make sure that a schedule item contained an interval item when updating. This PR removes that check.