### PR TITLE
Improve debug logging by including put/post request contents (limited to first 1000 chars)

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -50,6 +50,10 @@ class Endpoint(object):
         if content is not None:
             parameters['data'] = content
 
+        logger.debug(u'request {}, url: {}'.format(method.__name__, url))
+        if content:
+            logger.debug(u'request content: {}'.format(content))
+
         server_response = method(url, **parameters)
         self.parent_srv._namespace.detect(server_response.content)
         self._check_status(server_response)
@@ -62,7 +66,8 @@ class Endpoint(object):
         return server_response
 
     def _check_status(self, server_response):
-        logger.debug(self._safe_to_log(server_response))
+        if len(server_response.content) > 0:
+            logger.debug(self._safe_to_log(server_response))
         if server_response.status_code >= 500:
             raise InternalServerError(server_response)
         elif server_response.status_code not in Success_codes:

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -52,7 +52,7 @@ class Endpoint(object):
 
         logger.debug(u'request {}, url: {}'.format(method.__name__, url))
         if content:
-            logger.debug(u'request content: {}'.format(content))
+            logger.debug(u'request content: {}'.format(content[:1000]))
 
         server_response = method(url, **parameters)
         self.parent_srv._namespace.detect(server_response.content)
@@ -60,14 +60,12 @@ class Endpoint(object):
 
         # This check is to determine if the response is a text response (xml or otherwise)
         # so that we do not attempt to log bytes and other binary data.
-        if server_response.encoding:
+        if len(server_response.content) > 0 and server_response.encoding:
             logger.debug(u'Server response from {0}:\n\t{1}'.format(
                 url, server_response.content.decode(server_response.encoding)))
         return server_response
 
     def _check_status(self, server_response):
-        if len(server_response.content) > 0:
-            logger.debug(self._safe_to_log(server_response))
         if server_response.status_code >= 500:
             raise InternalServerError(server_response)
         elif server_response.status_code not in Success_codes:


### PR DESCRIPTION
- show contents of methods such as put, post
- for empty responses, don't try to print them (avoid [Truncated File Contents] which might appear like an error)