### PR TITLE
Server versions before 2020.1 do not accept encoded query param delimiters

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -82,14 +82,15 @@ class Endpoint(object):
     def get_request(self, url, request_object=None, parameters=None):
         if request_object is not None:
             try:
-                # Query param encoding is not needed for versions before 3.7 (2020.1)
+                # Query param delimiters don't need to be encoded for versions before 3.7 (2020.1)
                 self.parent_srv.assert_at_least_version("3.7")
                 parameters = parameters or {}
                 parameters["params"] = request_object.get_query_params()
             except EndpointUnavailableError:
                 url = request_object.apply_query_params(url)
 
-        return self._make_request(self.parent_srv.session.get, url, auth_token=self.parent_srv.auth_token,
+        return self._make_request(self.parent_srv.session.get, url,
+                                  auth_token=self.parent_srv.auth_token,
                                   parameters=parameters)
 
     def delete_request(self, url):
@@ -97,12 +98,16 @@ class Endpoint(object):
         self._make_request(self.parent_srv.session.delete, url, auth_token=self.parent_srv.auth_token)
 
     def put_request(self, url, xml_request=None, content_type='text/xml'):
-        return self._make_request(self.parent_srv.session.put, url, content=xml_request,
-                                  auth_token=self.parent_srv.auth_token, content_type=content_type)
+        return self._make_request(self.parent_srv.session.put, url,
+                                  content=xml_request,
+                                  auth_token=self.parent_srv.auth_token,
+                                  content_type=content_type)
 
     def post_request(self, url, xml_request, content_type='text/xml'):
-        return self._make_request(self.parent_srv.session.post, url, content=xml_request,
-                                  auth_token=self.parent_srv.auth_token, content_type=content_type)
+        return self._make_request(self.parent_srv.session.post, url,
+                                  content=xml_request,
+                                  auth_token=self.parent_srv.auth_token,
+                                  content_type=content_type)
 
 
 def api(version):

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -2,10 +2,8 @@ from ..models.property_decorators import property_is_int
 
 
 class RequestOptionsBase(object):
+    # This method is used if server api version is below 3.7 (2020.1)
     def apply_query_params(self, url):
-        import warnings
-        warnings.simplefilter('always', DeprecationWarning)
-        warnings.warn('apply_query_params is deprecated, please use get_query_params instead.', DeprecationWarning)
         try:
             params = self.get_query_params()
             params_list = ["{}={}".format(k, v) for (k, v) in params.items()]

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -23,12 +23,7 @@ class RequestTests(unittest.TestCase):
             m.get(requests_mock.ANY)
             url = "http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/workbooks"
             opts = TSC.RequestOptions(pagesize=13, pagenumber=15)
-            resp = self.server.workbooks._make_request(requests.get,
-                                                       url,
-                                                       content=None,
-                                                       request_object=opts,
-                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
-                                                       content_type='text/xml')
+            resp = self.server.workbooks.get_request(url, request_object=opts)
 
             self.assertTrue(re.search('pagesize=13', resp.request.query))
             self.assertTrue(re.search('pagenumber=15', resp.request.query))
@@ -37,10 +32,7 @@ class RequestTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(requests_mock.ANY)
             url = "http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/workbooks"
-            resp = self.server.workbooks._make_request(requests.post,
-                                                       url,
-                                                       content=b'1337',
-                                                       request_object=None,
+            resp = self.server.workbooks._make_request(requests.post, url, content=b'1337',
                                                        auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
                                                        content_type='multipart/mixed')
             self.assertEqual(resp.request.headers['x-tableau-auth'], 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM')

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -8,6 +8,7 @@ import tableauserverclient as TSC
 class SortTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
+        self.server.version = "3.7"
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
         self.baseurl = self.server.workbooks.baseurl
@@ -24,12 +25,7 @@ class SortTests(unittest.TestCase):
                                        TSC.RequestOptions.Operator.Equals,
                                        'Superstore'))
 
-            resp = self.server.workbooks._make_request(requests.get,
-                                                       url,
-                                                       content=None,
-                                                       request_object=opts,
-                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
-                                                       content_type='text/xml')
+            resp = self.server.workbooks.get_request(url, request_object=opts)
 
             self.assertTrue(re.search('pagenumber=13', resp.request.query))
             self.assertTrue(re.search('pagesize=13', resp.request.query))
@@ -53,12 +49,7 @@ class SortTests(unittest.TestCase):
                                        TSC.RequestOptions.Operator.In,
                                        ['stocks', 'market']))
 
-            resp = self.server.workbooks._make_request(requests.get,
-                                                       url,
-                                                       content=None,
-                                                       request_object=opts,
-                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
-                                                       content_type='text/xml')
+            resp = self.server.workbooks.get_request(url, request_object=opts)
             self.assertTrue(re.search('pagenumber=13', resp.request.query))
             self.assertTrue(re.search('pagesize=13', resp.request.query))
             self.assertTrue(re.search('filter=tags%3ain%3a%5bstocks%2cmarket%5d', resp.request.query))
@@ -71,12 +62,7 @@ class SortTests(unittest.TestCase):
             opts.sort.add(TSC.Sort(TSC.RequestOptions.Field.Name,
                                    TSC.RequestOptions.Direction.Asc))
 
-            resp = self.server.workbooks._make_request(requests.get,
-                                                       url,
-                                                       content=None,
-                                                       request_object=opts,
-                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
-                                                       content_type='text/xml')
+            resp = self.server.workbooks.get_request(url, request_object=opts)
 
             self.assertTrue(re.search('pagenumber=13', resp.request.query))
             self.assertTrue(re.search('pagesize=13', resp.request.query))
@@ -96,12 +82,7 @@ class SortTests(unittest.TestCase):
                                        TSC.RequestOptions.Operator.Equals,
                                        'Publisher'))
 
-            resp = self.server.workbooks._make_request(requests.get,
-                                                       url,
-                                                       content=None,
-                                                       request_object=opts,
-                                                       auth_token='j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM',
-                                                       content_type='text/xml')
+            resp = self.server.workbooks.get_request(url, request_object=opts)
 
             expected = 'pagenumber=13&pagesize=13&filter=lastlogin%3agte%3a' \
                        '2017-01-15t00%3a00%3a00%3a00z%2csiterole%3aeq%3apublisher'

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -8,7 +8,7 @@ import tableauserverclient as TSC
 class SortTests(unittest.TestCase):
     def setUp(self):
         self.server = TSC.Server('http://test')
-        self.server.version = "3.7"
+        self.server.version = "3.10"
         self.server._site_id = 'dad65087-b08b-4603-af4e-2887b8aafc67'
         self.server._auth_token = 'j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM'
         self.baseurl = self.server.workbooks.baseurl


### PR DESCRIPTION
Request options are only applied for GET calls, so I've moved the query param generation to the GET-specific request call.
In there, it checks the server version to determine how to append the query params:
- 2020.1 and above - let requests library handle all query params and encoding
- 2019.4 and below - we manually generate the query param string - do not encode delimiters

Addresses #732 