### PR TITLE
Add Get View by ID

### DIFF
--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -36,6 +36,16 @@ class Views(QuerysetEndpoint):
         all_view_items = ViewItem.from_response(server_response.content, self.parent_srv.namespace)
         return all_view_items, pagination_item
 
+    @api(version="3.1")
+    def get_by_id(self, view_id):
+        if not view_id:
+            error = "View item missing ID."
+            raise MissingRequiredFieldError(error)
+        logger.info('Querying single view (ID: {0})'.format(view_id))
+        url = "{0}/{1}".format(self.baseurl, view_id)
+        server_response = self.get_request(url)
+        return ViewItem.from_response(server_response.content, self.parent_srv.namespace)[0]
+
     @api(version="2.0")
     def populate_preview_image(self, view_item):
         if not view_item.id or not view_item.workbook_id:

--- a/test/assets/view_get_id.xml
+++ b/test/assets/view_get_id.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <view id="d79634e1-6063-4ec9-95ff-50acbf609ff5" name="ENDANGERED SAFARI" contentUrl="SafariSample/sheets/ENDANGEREDSAFARI" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story">
+        <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" />
+        <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        <project id="5241e88d-d384-4fd7-9c2f-648b5247efc5" />
+        <tags>
+            <tag label="tag1" />
+            <tag label="tag2" />
+        </tags>
+    </view>
+</tsResponse>

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -10,6 +10,7 @@ TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), 'assets')
 
 ADD_TAGS_XML = os.path.join(TEST_ASSET_DIR, 'view_add_tags.xml')
 GET_XML = os.path.join(TEST_ASSET_DIR, 'view_get.xml')
+GET_XML_ID = os.path.join(TEST_ASSET_DIR, 'view_get_id.xml')
 GET_XML_USAGE = os.path.join(TEST_ASSET_DIR, 'view_get_usage.xml')
 POPULATE_PREVIEW_IMAGE = os.path.join(TEST_ASSET_DIR, 'Sample View Image.png')
 POPULATE_PDF = os.path.join(TEST_ASSET_DIR, 'populate_pdf.pdf')
@@ -59,6 +60,27 @@ class ViewTests(unittest.TestCase):
         self.assertEqual('2002-05-30T09:00:00Z', format_datetime(all_views[1].created_at))
         self.assertEqual('2002-06-05T08:00:59Z', format_datetime(all_views[1].updated_at))
         self.assertEqual('story', all_views[1].sheet_type)
+
+    def test_get_by_id(self):
+        with open(GET_XML_ID, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + '/d79634e1-6063-4ec9-95ff-50acbf609ff5', text=response_xml)
+            view = self.server.views.get_by_id('d79634e1-6063-4ec9-95ff-50acbf609ff5')
+
+        self.assertEqual('d79634e1-6063-4ec9-95ff-50acbf609ff5', view.id)
+        self.assertEqual('ENDANGERED SAFARI', view.name)
+        self.assertEqual('SafariSample/sheets/ENDANGEREDSAFARI', view.content_url)
+        self.assertEqual('3cc6cd06-89ce-4fdc-b935-5294135d6d42', view.workbook_id)
+        self.assertEqual('5de011f8-5aa9-4d5b-b991-f462c8dd6bb7', view.owner_id)
+        self.assertEqual('5241e88d-d384-4fd7-9c2f-648b5247efc5', view.project_id)
+        self.assertEqual(set(['tag1', 'tag2']), view.tags)
+        self.assertEqual('2002-05-30T09:00:00Z', format_datetime(view.created_at))
+        self.assertEqual('2002-06-05T08:00:59Z', format_datetime(view.updated_at))
+        self.assertEqual('story', view.sheet_type)
+
+    def test_get_by_id_missing_id(self):
+        self.assertRaises(TSC.MissingRequiredFieldError, self.server.views.get_by_id, None)
 
     def test_get_with_usage(self):
         with open(GET_XML_USAGE, 'rb') as f:


### PR DESCRIPTION
Re-implementing @t8y8 #680 from latest development branch and adding a couple of tests.

@shinchris can you confirm the API version this was added because the [docs](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#get_view) say it was 2.0? Through testing I do believe the server minimum is 3.1, so the REST API docs might be wrong.

I have a separate docs PR ready to go once we confirm.