### PR TITLE
Improves group creation for both local and AD

### DIFF
--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -9,13 +9,17 @@ class GroupItem(object):
 
     tag_name = 'group'
 
-    def __init__(self, name=None):
-        self._domain_name = None
+    class LicenseMode:
+        onLogin = 'onLogin'
+        onSync = 'onSync'
+
+    def __init__(self, name=None, domain_name=None):
         self._id = None
-        self._users = None
-        self.name = name
         self._license_mode = None
         self._minimum_site_role = None
+        self._users = None
+        self.name = name
+        self.domain_name = domain_name
 
     @property
     def domain_name(self):
@@ -43,8 +47,8 @@ class GroupItem(object):
         return self._license_mode
 
     @license_mode.setter
+    @property_is_enum(LicenseMode)
     def license_mode(self, value):
-        # valid values = onSync, onLogin
         self._license_mode = value
 
     @property

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -277,10 +277,8 @@ class GroupRequest(object):
         xml_request = ET.Element('tsRequest')
         group_element = ET.SubElement(xml_request, 'group')
         group_element.attrib['name'] = group_item.name
-        if group_item.license_mode is not None:
-            group_element.attrib['grantLicenseMode'] = group_item.license_mode
         if group_item.minimum_site_role is not None:
-            group_element.attrib['SiteRole'] = group_item.minimum_site_role
+            group_element.attrib['minimumSiteRole'] = group_item.minimum_site_role
         return ET.tostring(xml_request)
 
     def create_ad_req(self, group_item):
@@ -295,9 +293,9 @@ class GroupRequest(object):
 
         import_element.attrib['domainName'] = group_item.domain_name
         if group_item.license_mode is not None:
-            import_element.attrib['grantLicenseMode'] = group_item.license
+            import_element.attrib['grantLicenseMode'] = group_item.license_mode
         if group_item.minimum_site_role is not None:
-            import_element.attrib['SiteRole'] = group_item.minimum_site_role
+            import_element.attrib['siteRole'] = group_item.minimum_site_role
         return ET.tostring(xml_request)
 
     def update_req(self, group_item, default_site_role=None):

--- a/test/test_group_model.py
+++ b/test/test_group_model.py
@@ -12,3 +12,13 @@ class GroupModelTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             group.name = ""
+
+    def test_invalid_minimum_site_role(self):
+        group = TSC.GroupItem("grp")
+        with self.assertRaises(ValueError):
+            group.minimum_site_role = "Captain"
+
+    def test_invalid_license_mode(self):
+        group = TSC.GroupItem("grp")
+        with self.assertRaises(ValueError):
+            group.license_mode = "off"


### PR DESCRIPTION
- Adds domain name to group_item constructor (#730)
- Adds enum for license modes
- Removes licenseMode from local group creation (not used by server, need to also update rest api docs)
- Fixes field name for siteRole (need to also update rest api docs)

TSC documentation - #771 

Internal 1210383