### PR TITLE
Fixes groups.update to match server requests/responses

### DIFF
--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -83,17 +83,18 @@ class GroupItem(object):
             name = group_xml.get('name', None)
             group_item = cls(name)
             group_item._id = group_xml.get('id', None)
-            # AD groups have an extra element under this
+
+            # Domain name is returned in a domain element for some calls
+            domain_elem = group_xml.find('.//t:domain', namespaces=ns)
+            if domain_elem is not None:
+                group_item.domain_name = domain_elem.get('name', None)
+
+            # Import element is returned for both local and AD groups (2020.3+)
             import_elem = group_xml.find('.//t:import', namespaces=ns)
-            if (import_elem is not None):
-                group_item.domain_name = import_elem.get('domainName')
-                group_item.license_mode = import_elem.get('grantLicenseMode')
-                group_item.minimum_site_role = import_elem.get('siteRole')
-            else:
-                # local group, we will just have two extra attributes here
-                group_item.domain_name = 'local'
-                group_item.license_mode = group_xml.get('grantLicenseMode')
-                group_item.minimum_site_role = group_xml.get('siteRole')
+            if import_elem is not None:
+                group_item.domain_name = import_elem.get('domainName', None)
+                group_item.license_mode = import_elem.get('grantLicenseMode', None)
+                group_item.minimum_site_role = import_elem.get('siteRole', None)
 
             all_group_items.append(group_item)
         return all_group_items

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -299,17 +299,30 @@ class GroupRequest(object):
         return ET.tostring(xml_request)
 
     def update_req(self, group_item, default_site_role=None):
+        # (1/8/2021): Deprecated starting v0.15
         if default_site_role is not None:
+            import warnings
+            warnings.simplefilter('always', DeprecationWarning)
+            warnings.warn('RequestFactory.Group.update_req(...default_site_role="") is deprecated, '
+                          'please set the minimum_site_role field of GroupItem',
+                          DeprecationWarning)
             group_item.minimum_site_role = default_site_role
+
         xml_request = ET.Element('tsRequest')
         group_element = ET.SubElement(xml_request, 'group')
         group_element.attrib['name'] = group_item.name
-        if group_item.domain_name != 'local':
-            project_element = ET.SubElement(group_element, 'import')
-            project_element.attrib['source'] = "ActiveDirectory"
-            project_element.attrib['domainName'] = group_item.domain_name
-            project_element.attrib['siteRole'] = group_item.minimum_site_role
-            project_element.attrib['grantLicenseMode'] = group_item.license_mode
+        if group_item.domain_name is not None and group_item.domain_name != 'local':
+            # Import element is only accepted in the request for AD groups
+            import_element = ET.SubElement(group_element, 'import')
+            import_element.attrib['source'] = "ActiveDirectory"
+            import_element.attrib['domainName'] = group_item.domain_name
+            import_element.attrib['siteRole'] = group_item.minimum_site_role
+            if group_item.license_mode is not None:
+                import_element.attrib['grantLicenseMode'] = group_item.license_mode
+        else:
+            # Local group request does not accept an 'import' element
+            if group_item.minimum_site_role is not None:
+                group_element.attrib['minimumSiteRole'] = group_item.minimum_site_role
 
         return ET.tostring(xml_request)
 

--- a/test/assets/group_update.xml
+++ b/test/assets/group_update.xml
@@ -2,7 +2,7 @@
 <tsResponse xmlns="http://tableau.com/api"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-    <group id="ef8b19c0-43b6-11e6-af50-63f5805dbe3c" name="Group updated name"
-        siteRole="ExplorerCanPublish"
-        grantLicenseMode='onLogin'/>/>
+    <group id="ef8b19c0-43b6-11e6-af50-63f5805dbe3c" name="Group updated name">
+        <import domainName="local" siteRole="ExplorerCanPublish" grantLicenseMode="onLogin" />
+    </group>
 </tsResponse>

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -224,3 +224,13 @@ class GroupTests(unittest.TestCase):
         self.assertEqual('Group updated name', group.name)
         self.assertEqual('ExplorerCanPublish', group.minimum_site_role)
         self.assertEqual('onLogin', group.license_mode)
+
+    # async update is not supported for local groups
+    def test_update_local_async(self):
+        group = TSC.GroupItem("myGroup")
+        group._id = 'ef8b19c0-43b6-11e6-af50-63f5805dbe3c'
+        self.assertRaises(ValueError, self.server.groups.update, group, as_job=True)
+
+        # mimic group returned from server where domain name is set to 'local'
+        group.domain_name = "local"
+        self.assertRaises(ValueError, self.server.groups.update, group, as_job=True)


### PR DESCRIPTION
Included in this PR:

1. Response parsing: [Rest api docs](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_usersgroups.htm#update_group) are wildly wrong about the local group update request/response (will file a doc bug) starting 3.9+ (2020.3+). Import element is returned starting 3.9+, for both local and AD groups. Query calls will return a domain element for all versions, but won't return it for create/update calls.
2. Update endpoint was taking in a `default_site_role`, which would always override the minimum_site_role field of the group_item with Unlicensed. TSC standard is to set that value in the resource item itself.
3. Updating local groups don't support async, so it would error in the parser if you tried.
4. Allows local groups to update minimum site role now