### PR TITLE
[Tasks] Translate task type from server to TSC enum

### DIFF
--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -77,4 +77,3 @@ class TaskItem(object):
             return TaskItem._TASK_TYPE_MAPPING[task_type]
         else:
             return task_type
-

--- a/test/assets/tasks_no_workbook_or_datasource.xml
+++ b/test/assets/tasks_no_workbook_or_datasource.xml
@@ -4,17 +4,17 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.6.xsd">
     <tasks>
         <task>
-            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="b60b4efd-a6f7-4599-beb3-cb677e7abac1" name="Refresh daily [23:00 - 01:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:42:55Z" updatedAt="2017-07-12T06:00:06Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T06:00:00Z" />
             </extractRefresh>
         </task>
         <task>
-            <extractRefresh id="6e8255f1-142b-4e17-bd9a-9fe6736812a1" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="6e8255f1-142b-4e17-bd9a-9fe6736812a1" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="82974721-6831-4c78-875c-b7c2d5237bc2" name="Refresh daily [15:00 - 17:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:39:39Z" updatedAt="2017-07-12T22:00:05Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T22:00:00Z" />
             </extractRefresh>
         </task>
         <task>
-            <extractRefresh id="90cbc49a-b668-4355-9321-46f7fefd4197" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="90cbc49a-b668-4355-9321-46f7fefd4197" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="c39a5a41-ab5b-4661-90f6-78384916748c" name="Refresh daily [00:00 - 02:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:33:51Z" updatedAt="2017-07-12T07:00:08Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T07:00:00Z" />
             </extractRefresh>
         </task>

--- a/test/assets/tasks_with_dataacceleration_task.xml
+++ b/test/assets/tasks_with_dataacceleration_task.xml
@@ -2,7 +2,7 @@
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.8.xsd">
     <tasks>
         <task>
-            <dataAcceleration id="2b217acb-194a-4291-ae90-7d5ec360395d" consecutiveFailedCount="0" type="DataAccelerationTask">
+            <dataAcceleration id="2b217acb-194a-4291-ae90-7d5ec360395d" consecutiveFailedCount="0" type="MaterializeViewsTask">
                 <schedule id="b22190b4-6ac2-4eed-9563-4afc03444413" name="Hourly4-Schedule" state="Active" priority="75" createdAt="2019-12-06T03:27:35Z" updatedAt="2019-12-09T20:30:59Z" type="DataAcceleration" frequency="Hourly" nextRunAt="2019-12-09T22:30:00Z">
                     <frequencyDetails start="02:30:00" end="23:00:00">
                         <intervals>

--- a/test/assets/tasks_with_datasource.xml
+++ b/test/assets/tasks_with_datasource.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.6.xsd">
     <tasks>
         <task>
-            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="b60b4efd-a6f7-4599-beb3-cb677e7abac1" name="Refresh daily [23:00 - 01:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:42:55Z" updatedAt="2017-07-12T06:00:06Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T06:00:00Z" />
                 <datasource id="c7a9327e-1cda-4504-b026-ddb43b976d1d" />
             </extractRefresh>

--- a/test/assets/tasks_with_workbook.xml
+++ b/test/assets/tasks_with_workbook.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.6.xsd">
     <tasks>
         <task>
-            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="b60b4efd-a6f7-4599-beb3-cb677e7abac1" name="Refresh daily [23:00 - 01:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:42:55Z" updatedAt="2017-07-12T06:00:06Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T06:00:00Z" />
                 <workbook id="c7a9327e-1cda-4504-b026-ddb43b976d1d" />
             </extractRefresh>

--- a/test/assets/tasks_with_workbook_and_datasource.xml
+++ b/test/assets/tasks_with_workbook_and_datasource.xml
@@ -4,19 +4,19 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.6.xsd">
     <tasks>
         <task>
-            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="b60b4efd-a6f7-4599-beb3-cb677e7abac1" name="Refresh daily [23:00 - 01:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:42:55Z" updatedAt="2017-07-12T06:00:06Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T06:00:00Z" />
                 <workbook id="c7a9327e-1cda-4504-b026-ddb43b976d1d" />
             </extractRefresh>
         </task>
         <task>
-            <extractRefresh id="6e8255f1-142b-4e17-bd9a-9fe6736812a1" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="6e8255f1-142b-4e17-bd9a-9fe6736812a1" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="82974721-6831-4c78-875c-b7c2d5237bc2" name="Refresh daily [15:00 - 17:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:39:39Z" updatedAt="2017-07-12T22:00:05Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T22:00:00Z" />
                 <datasource id="61334430-fb0c-43af-a5a3-8db3323644b6" />
             </extractRefresh>
         </task>
         <task>
-            <extractRefresh id="90cbc49a-b668-4355-9321-46f7fefd4197" priority="50" consecutiveFailedCount="0" type="REFRESH_EXTRACT">
+            <extractRefresh id="90cbc49a-b668-4355-9321-46f7fefd4197" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
                 <schedule id="c39a5a41-ab5b-4661-90f6-78384916748c" name="Refresh daily [00:00 - 02:00, Pacific US]" state="Active" priority="50" createdAt="2016-02-11T01:33:51Z" updatedAt="2017-07-12T07:00:08Z" type="Extract" frequency="Daily" nextRunAt="2017-07-13T07:00:00Z" />
                 <workbook id="952663f4-1bb4-4fed-91f8-5967f48c533a" />
             </extractRefresh>

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -104,6 +104,7 @@ class TaskTests(unittest.TestCase):
         self.assertEqual('b22190b4-6ac2-4eed-9563-4afc03444413', task.schedule_id)
         self.assertEqual(parse_datetime('2019-12-09T22:30:00Z'), task.schedule_item.next_run_at)
         self.assertEqual(parse_datetime('2019-12-09T20:45:04Z'), task.last_run_at)
+        self.assertEqual(TSC.TaskItem.Type.DataAcceleration, task.task_type)
 
     def test_delete_data_acceleration(self):
         with requests_mock.mock() as m:
@@ -124,6 +125,7 @@ class TaskTests(unittest.TestCase):
         self.assertEqual('c7a9327e-1cda-4504-b026-ddb43b976d1d', task.target.id)
         self.assertEqual('workbook', task.target.type)
         self.assertEqual('b60b4efd-a6f7-4599-beb3-cb677e7abac1', task.schedule_id)
+        self.assertEqual(TSC.TaskItem.Type.ExtractRefresh, task.task_type)
 
     def test_run_now(self):
         task_id = 'f84901ac-72ad-4f9b-a87e-7a3500402ad6'


### PR DESCRIPTION
We have enums in task_item.py to represent the 2 task types supported by the REST API - these are used in the URLs.
However, the server response returns different values, so we need to translate them into TSC enums. 

Not quite sure why the test xml responses had different values - checked old versions of tableau server but didn't see them used anywhere.