### PR TITLE
Add support for getting groups that a user belongs to

### DIFF
--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -43,6 +43,7 @@ class UserItem(object):
         self._last_login = None
         self._workbooks = None
         self._favorites = None
+        self._groups = None
         self.email = None
         self.fullname = None
         self.name = name
@@ -107,11 +108,21 @@ class UserItem(object):
             raise UnpopulatedPropertyError(error)
         return self._favorites
 
+    @property
+    def groups(self):
+        if self._groups is None:
+            error = "User item must be populated with groups first."
+            raise UnpopulatedPropertyError(error)
+        return self._groups()
+
     def to_reference(self):
         return ResourceReference(id_=self.id, tag_name=self.tag_name)
 
     def _set_workbooks(self, workbooks):
         self._workbooks = workbooks
+
+    def _set_groups(self, groups):
+        self._groups = groups
 
     def _parse_common_tags(self, user_xml, ns):
         if not isinstance(user_xml, ET.Element):

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -104,10 +104,10 @@ class Users(QuerysetEndpoint):
             error = "User item missing ID."
             raise MissingRequiredFieldError(error)
 
-        def wb_pager():
+        def groups_for_user_pager():
             return Pager(lambda options: self._get_groups_for_user(user_item, options), req_options)
 
-        user_item._set_groups(wb_pager)
+        user_item._set_groups(groups_for_user_pager)
 
     def _get_groups_for_user(self, user_item, req_options=None):
         url = "{0}/{1}/groups".format(self.baseurl, user_item.id)

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -1,6 +1,6 @@
 from .endpoint import QuerysetEndpoint, api
 from .exceptions import MissingRequiredFieldError
-from .. import RequestFactory, RequestOptions, UserItem, WorkbookItem, PaginationItem
+from .. import RequestFactory, RequestOptions, UserItem, WorkbookItem, PaginationItem, GroupItem
 from ..pager import Pager
 
 import copy
@@ -96,3 +96,23 @@ class Users(QuerysetEndpoint):
 
     def populate_favorites(self, user_item):
         self.parent_srv.favorites.get(user_item)
+
+    # Get groups for user
+    @api(version="3.7")
+    def populate_groups(self, user_item, req_options=None):
+        if not user_item.id:
+            error = "User item missing ID."
+            raise MissingRequiredFieldError(error)
+
+        def wb_pager():
+            return Pager(lambda options: self._get_groups_for_user(user_item, options), req_options)
+
+        user_item._set_groups(wb_pager)
+
+    def _get_groups_for_user(self, user_item, req_options=None):
+        url = "{0}/{1}/groups".format(self.baseurl, user_item.id)
+        server_response = self.get_request(url, req_options)
+        logger.info('Populated groups for user (ID: {0})'.format(user_item.id))
+        group_item = GroupItem.from_response(server_response.content, self.parent_srv.namespace)
+        pagination_item = PaginationItem.from_response(server_response.content, self.parent_srv.namespace)
+        return group_item, pagination_item

--- a/test/assets/user_populate_groups.xml
+++ b/test/assets/user_populate_groups.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-3.7.xsd">
+    <pagination pageNumber="1" pageSize="100" totalAvailable="3" />
+    <groups>
+        <group id="ef8b19c0-43b6-11e6-af50-63f5805dbe3c" name="All Users">
+            <domain name="local" />
+        </group>
+        <group id="e7833b48-c6f7-47b5-a2a7-36e7dd232758" name="Another group">
+            <domain name="local" />
+        </group>
+        <group id="86a66d40-f289-472a-83d0-927b0f954dc8" name="TableauExample">
+            <domain name="local" />
+        </group>
+    </groups>
+</tsResponse>


### PR DESCRIPTION
This adds support for getting the groups that a user belongs to.

https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_usersgroups.htm#get_groups_for_a_user