### PR TITLE
Revise datasources.update in api-ref.md

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -676,7 +676,7 @@ datasource.update(datasource_item)
 
 Updates the specified data source. 
 
-REST API: [Update Datasource](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#update_data_source)
+REST API: [Update Data Source](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#update_data_source)
 
 **Parameters**
 

--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -674,7 +674,7 @@ A refreshed `DatasourceItem`.
 datasource.update(datasource_item)
 ```
 
-Updates the owner or project of the specified data source. Data source name cannot be updated.
+Updates the specified data source. 
 
 REST API: [Update Datasource](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#update_data_source)
 


### PR DESCRIPTION
Two Changes:
1. Remove note about rename of datasources not being possible, as a future release of Tableau Server will allow rename of datasource.  
2. Remove details about what can be changed about a datasource, as it is out of date (more than just project and owner can be changed).

In general, I believe its best to let the official REST API documentation (https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm) be the official source of what the REST API can and can't do (correct me if I'm wrong).   The REST API docs will be updated prior to the server release.