### PR TITLE
Unify arguments of sample scripts

### DIFF
--- a/samples/add_default_permission.py
+++ b/samples/add_default_permission.py
@@ -10,7 +10,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -18,27 +17,26 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Add workbook default permissions for a given project.')
-    parser.add_argument('--server', '-s', required=True, help='Server address')
-    parser.add_argument('--username', '-u', required=True, help='Username to sign into server')
-    parser.add_argument('--site', '-S', default=None, help='Site to sign into - default site if not provided')
-    parser.add_argument('-p', default=None, help='Password to sign into server')
-
+    # Common options; please keep those in sync across all samples
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # Sign in
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    # Sign in to server
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
 

--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -7,7 +7,6 @@
 
 
 import argparse
-import getpass
 import logging
 
 from datetime import time
@@ -18,20 +17,26 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Creates a sample user group.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-    args = parser.parse_args()
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
-    password = getpass.getpass("Password: ")
+    args = parser.parse_args()
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         group = TSC.GroupItem('test')
         group = server.groups.create(group)

--- a/samples/create_project.py
+++ b/samples/create_project.py
@@ -8,7 +8,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 import sys
 
@@ -27,28 +26,26 @@ def create_project(server, project_item):
 
 def main():
     parser = argparse.ArgumentParser(description='Create new projects.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None, help='password')
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Use highest Server REST API version available
         server.use_server_version()

--- a/samples/create_schedules.py
+++ b/samples/create_schedules.py
@@ -7,7 +7,6 @@
 
 
 import argparse
-import getpass
 import logging
 
 from datetime import time
@@ -18,20 +17,26 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Creates sample schedules for each type of frequency.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-    args = parser.parse_args()
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
-    password = getpass.getpass("Password: ")
+    args = parser.parse_args()
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Hourly Schedule
         # This schedule will run every 2 hours between 2:30AM and 11:00PM

--- a/samples/download_view_image.py
+++ b/samples/download_view_image.py
@@ -9,7 +9,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -18,34 +17,30 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Download image of a specified view.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--site-id', '-si', required=False,
-                        help='content url for site the view is on')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--view-name', '-v', required=True,
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--view-name', '-vn', required=True,
                         help='name of view to download an image of')
     parser.add_argument('--filepath', '-f', required=True, help='filepath to save the image returned')
     parser.add_argument('--maxage', '-m', required=False, help='max age of the image in the cache in minutes.')
-    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
-                        help='desired logging level (set to error by default)')
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    site_id = args.site_id
-    if not site_id:
-        site_id = ""
-    tableau_auth = TSC.TableauAuth(args.username, password, site_id=site_id)
-    server = TSC.Server(args.server)
-    # The new endpoint was introduced in Version 2.5
-    server.version = "2.5"
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Step 2: Query for the view that we want an image of
         req_option = TSC.RequestOptions()

--- a/samples/explore_datasource.py
+++ b/samples/explore_datasource.py
@@ -10,7 +10,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -19,25 +18,28 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Explore datasource functions supported by the Server API.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--publish', '-p', metavar='FILEPATH', help='path to datasource to publish')
-    parser.add_argument('--download', '-d', metavar='FILEPATH', help='path to save downloaded datasource')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--publish', metavar='FILEPATH', help='path to datasource to publish')
+    parser.add_argument('--download', metavar='FILEPATH', help='path to save downloaded datasource')
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-    server.use_highest_version()
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Query projects for use when demonstrating publishing and updating
         all_projects, pagination_item = server.projects.get()

--- a/samples/explore_webhooks.py
+++ b/samples/explore_webhooks.py
@@ -10,7 +10,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 import os.path
 
@@ -20,35 +19,28 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Explore webhook functions supported by the Server API.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None, help='password')
-    parser.add_argument('--create', '-c', help='create a webhook')
-    parser.add_argument('--delete', '-d', help='delete a webhook', action='store_true')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--create', help='create a webhook')
+    parser.add_argument('--delete', help='delete a webhook', action='store_true')
 
     args = parser.parse_args()
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
-    print("Signing in to " + args.server + " [" + args.site + "] as " + args.username)
-    server = TSC.Server(args.server)
-
-    # Set http options to disable verifying SSL
-    server.add_http_options({'verify': False})
-
-    server.use_server_version()
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
 
         # Create webhook if create flag is set (-create, -c)

--- a/samples/export.py
+++ b/samples/export.py
@@ -6,7 +6,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -14,13 +13,16 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Export a view as an image, PDF, or CSV')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None)
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--pdf', dest='type', action='store_const', const=('populate_pdf', 'PDFRequestOptions', 'pdf',
                                                                           'pdf'))
@@ -36,16 +38,11 @@ def main():
 
     args = parser.parse_args()
 
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
-
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         views = filter(lambda x: x.id == args.resource_id,

--- a/samples/filter_sort_groups.py
+++ b/samples/filter_sort_groups.py
@@ -7,7 +7,6 @@
 
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -25,29 +24,27 @@ def create_example_group(group_name='Example Group', server=None):
 
 def main():
     parser = argparse.ArgumentParser(description='Filter and sort groups.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-    parser.add_argument('-p', default=None)
-    args = parser.parse_args()
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
+    args = parser.parse_args()
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
-        # Determine and use the highest api version for the server
-        server.use_server_version()
 
         group_name = 'SALES NORTHWEST'
         # Try to create a group named "SALES NORTHWEST"

--- a/samples/filter_sort_projects.py
+++ b/samples/filter_sort_projects.py
@@ -6,7 +6,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -26,28 +25,26 @@ def create_example_project(name='Example Project', content_permissions='LockedTo
 
 def main():
     parser = argparse.ArgumentParser(description='Filter and sort projects.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None)
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Use highest Server REST API version available
         server.use_server_version()

--- a/samples/initialize_server.py
+++ b/samples/initialize_server.py
@@ -5,7 +5,6 @@
 ####
 
 import argparse
-import getpass
 import glob
 import logging
 import tableauserverclient as TSC
@@ -13,17 +12,21 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Initialize a server with content.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--datasources-folder', '-df', required=True, help='folder containing datasources')
-    parser.add_argument('--workbooks-folder', '-wf', required=True, help='folder containing workbooks')
-    parser.add_argument('--site-id', '-sid', required=False, default='', help='site id of the site to use')
-    parser.add_argument('--project', '-p', required=False, default='Default', help='project to use')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-    args = parser.parse_args()
+    # Options specific to this sample
+    parser.add_argument('--datasources-folder', '-df', required=True, help='folder containing datasources')
+    parser.add_argument('--workbooks-folder', '-wf', required=True, help='folder containing workbooks')
+    parser.add_argument('--project', required=False, default='Default', help='project to use')
 
-    password = getpass.getpass("Password: ")
+    args = parser.parse_args()
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
@@ -32,9 +35,8 @@ def main():
     ################################################################################
     # Step 1: Sign in to server.
     ################################################################################
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
 
         ################################################################################

--- a/samples/kill_all_jobs.py
+++ b/samples/kill_all_jobs.py
@@ -5,7 +5,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -13,27 +12,25 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Cancel all of the running background jobs.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--site', '-S', default=None, help='site to log into, do not specify for default site')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--password', '-p', default=None, help='password for the user')
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    if args.password is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.password
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         req = TSC.RequestOptions()

--- a/samples/list.py
+++ b/samples/list.py
@@ -5,7 +5,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 import os
 import sys
@@ -15,28 +14,26 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='List out the names and LUIDs for different resource types.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--site', '-S', default="", help='site to log into, do not specify for default site')
-    parser.add_argument('--token-name', '-n', required=True, help='username to signin under')
-    parser.add_argument('--token', '-t', help='personal access token for logging in')
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-n', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
+    # Options specific to this sample
     parser.add_argument('resource_type', choices=['workbook', 'datasource', 'project', 'view', 'job', 'webhooks'])
 
     args = parser.parse_args()
-    token = os.environ.get('TOKEN', args.token)
-    if not token:
-        print("--token or TOKEN environment variable needs to be set")
-        sys.exit(1)
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # SIGN IN
-    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, token, site_id=args.site)
+    # Sign in to server
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         endpoint = {

--- a/samples/login.py
+++ b/samples/login.py
@@ -13,16 +13,17 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Logs in to the server.')
-
+    # This command is special, as it doesn't take `token-value` and it offer both token-based and password based authentication.
+    # Please still try to keep common options like `server` and `site` consistent across samples
+    # Common options:
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--site', '-S', help='site name')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
-    parser.add_argument('--server', '-s', required=True, help='server address')
-
+    # Options specific to this sample
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--username', '-u', help='username to sign into the server')
     group.add_argument('--token-name', '-n', help='name of the personal access token used to sign into the server')
-    parser.add_argument('--sitename', '-S', default='')
 
     args = parser.parse_args()
 
@@ -37,8 +38,8 @@ def main():
         # Trying to authenticate using username and password.
         password = getpass.getpass("Password: ")
 
-        print("\nSigning in...\nServer: {}\nSite: {}\nUsername: {}".format(args.server, args.sitename, args.username))
-        tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.sitename)
+        print("\nSigning in...\nServer: {}\nSite: {}\nUsername: {}".format(args.server, args.site, args.username))
+        tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.site)
         with server.auth.sign_in(tableau_auth):
             print('Logged in successfully')
 
@@ -47,9 +48,9 @@ def main():
         personal_access_token = getpass.getpass("Personal Access Token: ")
 
         print("\nSigning in...\nServer: {}\nSite: {}\nToken name: {}"
-              .format(args.server, args.sitename, args.token_name))
+              .format(args.server, args.site, args.token_name))
         tableau_auth = TSC.PersonalAccessTokenAuth(token_name=args.token_name,
-                                                   personal_access_token=personal_access_token, site_id=args.sitename)
+                                                   personal_access_token=personal_access_token, site_id=args.site)
         with server.auth.sign_in_with_personal_access_token(tableau_auth):
             print('Logged in successfully')
 

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -8,7 +8,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -17,25 +16,28 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Move one workbook from the default project to another.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
-    parser.add_argument('--destination-project', '-d', required=True, help='name of project to move workbook into')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
+    parser.add_argument('--destination-project', '-d', required=True, help='name of project to move workbook into')
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         # Step 2: Query workbook to move
         req_option = TSC.RequestOptions()

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -8,7 +8,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 import shutil
 import tempfile
@@ -21,23 +20,28 @@ def main():
     parser = argparse.ArgumentParser(description="Move one workbook from the"
                                                  "default project of the default site to"
                                                  "the default project of another site.")
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
-    parser.add_argument('--destination-site', '-d', required=True, help='name of site to move workbook into')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--workbook-name', '-w', required=True, help='name of workbook to move')
+    parser.add_argument('--destination-site', '-d', required=True, help='name of site to move workbook into')
+
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to both sites on server
-    tableau_auth = TSC.TableauAuth(args.username, password)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
 
     source_server = TSC.Server(args.server)
     dest_server = TSC.Server(args.server)

--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -10,7 +10,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 import os.path
 
@@ -20,26 +19,28 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='Demonstrate pagination on the list of workbooks on the server.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-n', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # SIGN IN
-
-    tableau_auth = TSC.TableauAuth(args.username, password)
-    server = TSC.Server(args.server)
-
+    # Sign in to server
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Pager returns a generator that yields one item at a time fetching
         # from Server only when necessary. Pager takes a server Endpoint as its
         # first parameter. It will call 'get' on that endpoint. To get workbooks

--- a/samples/publish_datasource.py
+++ b/samples/publish_datasource.py
@@ -26,15 +26,17 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Publish a datasource to server.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--site', '-i', help='site name')
+    parser.add_argument('--site', '-S', help='site name')
     parser.add_argument('--token-name', '-p', required=True,
                         help='name of the personal access token used to sign into the server')
     parser.add_argument('--token-value', '-v', required=True,
                         help='value of the personal access token used to sign into the server')
-    parser.add_argument('--filepath', '-f', required=True, help='filepath to the datasource to publish')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--file', '-f', required=True, help='filepath to the datasource to publish')
     parser.add_argument('--project', help='Project within which to publish the datasource')
     parser.add_argument('--async', '-a', help='Publishing asynchronously', dest='async_', action='store_true')
     parser.add_argument('--conn-username', help='connection username')

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -15,7 +15,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -25,29 +24,30 @@ from tableauserverclient import ConnectionCredentials, ConnectionItem
 def main():
 
     parser = argparse.ArgumentParser(description='Publish a workbook to server.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--filepath', '-f', required=True, help='computer filepath of the workbook to publish')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('--file', '-f', required=True, help='local filepath of the workbook to publish')
     parser.add_argument('--as-job', '-a', help='Publishing asynchronously', action='store_true')
     parser.add_argument('--skip-connection-check', '-c', help='Skip live connection check', action='store_true')
-    parser.add_argument('--site', '-S', default='', help='id (contentUrl) of site to sign into')
+
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    tableau_auth = TSC.TableauAuth(args.username, password, site_id=args.site)
-    server = TSC.Server(args.server)
-
-    overwrite_true = TSC.Server.PublishMode.Overwrite
-
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
 
         # Step 2: Get all the projects on server, then look for the default one.
@@ -68,6 +68,7 @@ def main():
         all_connections.append(connection2)
 
         # Step 3: If default project is found, form a new workbook item and publish.
+        overwrite_true = TSC.Server.PublishMode.Overwrite
         if default_project is not None:
             new_workbook = TSC.WorkbookItem(default_project.id)
             if args.as_job:

--- a/samples/query_permissions.py
+++ b/samples/query_permissions.py
@@ -7,7 +7,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -15,30 +14,27 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Query permissions of a given resource.')
-    parser.add_argument('--server', '-s', required=True, help='Server address')
-    parser.add_argument('--username', '-u', required=True, help='Username to sign into server')
-    parser.add_argument('--site', '-S', default=None, help='Site to sign into - default site if not provided')
-    parser.add_argument('-p', default=None, help='Password to sign into server')
-
+    # Common options; please keep those in sync across all samples
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
+    # Options specific to this sample
     parser.add_argument('resource_type', choices=['workbook', 'datasource', 'flow', 'table', 'database'])
     parser.add_argument('resource_id')
 
     args = parser.parse_args()
-
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Sign in
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
 

--- a/samples/refresh.py
+++ b/samples/refresh.py
@@ -5,7 +5,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -13,30 +12,26 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Trigger a refresh task on a workbook or datasource.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('--password', '-p', default=None, help='if not specified, you will be prompted')
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
+    # Options specific to this sample
     parser.add_argument('resource_type', choices=['workbook', 'datasource'])
     parser.add_argument('resource_id')
 
     args = parser.parse_args()
 
-    if args.password is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.password
-
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         if args.resource_type == "workbook":

--- a/samples/refresh_tasks.py
+++ b/samples/refresh_tasks.py
@@ -6,7 +6,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -30,14 +29,16 @@ def handle_info(server, args):
 
 def main():
     parser = argparse.ArgumentParser(description='Get all of the refresh tasks available on a server')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None)
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
+    # Options specific to this sample
     subcommands = parser.add_subparsers()
 
     list_arguments = subcommands.add_parser('list')
@@ -53,19 +54,13 @@ def main():
 
     args = parser.parse_args()
 
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
-
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
-    server = TSC.Server(args.server)
-    server.version = '2.6'
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         args.func(server, args)
 

--- a/samples/set_http_options.py
+++ b/samples/set_http_options.py
@@ -6,7 +6,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -15,21 +14,26 @@ import tableauserverclient as TSC
 def main():
 
     parser = argparse.ArgumentParser(description='List workbooks on site, with option set to ignore SSL verification.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    # This sample has no additional options, yet. If you add some, please add them here
 
     args = parser.parse_args()
-
-    password = getpass.getpass("Password: ")
 
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Create required objects for sign in
-    tableau_auth = TSC.TableauAuth(args.username, password)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server)
 
     # Step 2: Set http options to disable verifying SSL

--- a/samples/set_refresh_schedule.py
+++ b/samples/set_refresh_schedule.py
@@ -7,7 +7,6 @@
 
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -15,11 +14,16 @@ import tableauserverclient as TSC
 
 def usage(args):
     parser = argparse.ArgumentParser(description='Set refresh schedule for a workbook or datasource.')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-    parser.add_argument('--password', '-p', default=None)
+    # Options specific to this sample
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--workbook', '-w')
     group.add_argument('--datasource', '-d')
@@ -61,18 +65,13 @@ def assign_to_schedule(server, workbook_or_datasource, schedule):
 
 
 def run(args):
-    password = args.password
-    if password is None:
-        password = getpass.getpass("Password: ")
-
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
     # Step 1: Sign in to server.
-    tableau_auth = TSC.TableauAuth(args.username, password)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
-
     with server.auth.sign_in(tableau_auth):
         if args.workbook:
             item = get_workbook_by_name(server, args.workbook)

--- a/samples/update_connection.py
+++ b/samples/update_connection.py
@@ -5,7 +5,6 @@
 ####
 
 import argparse
-import getpass
 import logging
 
 import tableauserverclient as TSC
@@ -13,14 +12,16 @@ import tableauserverclient as TSC
 
 def main():
     parser = argparse.ArgumentParser(description='Update a connection on a datasource or workbook to embed credentials')
+    # Common options; please keep those in sync across all samples
     parser.add_argument('--server', '-s', required=True, help='server address')
-    parser.add_argument('--username', '-u', required=True, help='username to sign into server')
-    parser.add_argument('--site', '-S', default=None)
-    parser.add_argument('-p', default=None)
-
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
     parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
                         help='desired logging level (set to error by default)')
-
+    # Options specific to this sample
     parser.add_argument('resource_type', choices=['workbook', 'datasource'])
     parser.add_argument('resource_id')
     parser.add_argument('connection_id')
@@ -29,17 +30,11 @@ def main():
 
     args = parser.parse_args()
 
-    if args.p is None:
-        password = getpass.getpass("Password: ")
-    else:
-        password = args.p
-
     # Set logging level based on user input, or error by default
     logging_level = getattr(logging, args.logging_level.upper())
     logging.basicConfig(level=logging_level)
 
-    # SIGN IN
-    tableau_auth = TSC.TableauAuth(args.username, password, args.site)
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
         endpoint = {


### PR DESCRIPTION
I am pretty new to TSC, and wanted to run some sample scripts to get an
understanding of the library. Doing so, I realized that every sample
had a slightly different command line, even for common arguments:
* Some expected `site`, some `site-id`, some were lacking site-support
  completely (and thereby unusable for Tableau Online)
* Some had a short option `-i`, some had the short option `-S` for the
  site name
* Some expected password-based authentication, some expected personal
  access tokens

This commit fixes all those inconsistencies, so that users don't have
to re-learn the command line options for each individual script.