### PR TITLE
Add support for scheduling Data Update jobs

### DIFF
--- a/samples/update_datasource_data.py
+++ b/samples/update_datasource_data.py
@@ -1,0 +1,74 @@
+####
+# This script demonstrates how to update the data within a published
+# live-to-Hyper datasource on server.
+#
+# The sample is hardcoded against the `World Indicators` dataset and
+# expects to receive the LUID of a published datasource containing
+# that data. To create such a published datasource, you can use:
+#   ./publish_datasource.py --file ../test/assets/World\ Indicators.hyper
+# which will print you the LUID of the datasource.
+#
+# Before running this script, the datasource will contain a region `Europe`.
+# After running this script, that region will be gone.
+#
+####
+
+import argparse
+import uuid
+import logging
+
+import tableauserverclient as TSC
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Delete the `Europe` region from a published `World Indicators` datasource.')
+    # Common options; please keep those in sync across all samples
+    parser.add_argument('--server', '-s', required=True, help='server address')
+    parser.add_argument('--site', '-S', help='site name')
+    parser.add_argument('--token-name', '-p', required=True,
+                        help='name of the personal access token used to sign into the server')
+    parser.add_argument('--token-value', '-v', required=True,
+                        help='value of the personal access token used to sign into the server')
+    parser.add_argument('--logging-level', '-l', choices=['debug', 'info', 'error'], default='error',
+                        help='desired logging level (set to error by default)')
+    # Options specific to this sample
+    parser.add_argument('datasource_id', help="The LUID of the `World Indicators` datasource")
+
+    args = parser.parse_args()
+
+    # Set logging level based on user input, or error by default
+    logging_level = getattr(logging, args.logging_level.upper())
+    logging.basicConfig(level=logging_level)
+
+    tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
+    server = TSC.Server(args.server, use_server_version=True)
+    with server.auth.sign_in(tableau_auth):
+        # We use a unique `request_id` for every request.
+        # In case the submission of the update job fails, we won't know wether the job was submitted
+        # or not. It could be that the server received the request, changed the data, but then the
+        # network connection broke down.
+        # If you want to have a way to retry, e.g., inserts while making sure they aren't duplicated,
+        # you need to use `request_id` for that purpose.
+        # In our case, we don't care about retries. And the delete is idempotent anyway.
+        # Hence, we simply use a randomly generated request id.
+        request_id = str(uuid.uuid4())
+
+        # This action will delete all rows with `Region=Europe` from the published data source.
+        # Other actions (inserts, updates, ...) are also available. For more information see
+        # https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_how_to_update_data_to_hyper.htm
+        actions = [
+            {
+                "action": "delete",
+                "target-table": "Extract",
+                "target-schema": "Extract",
+                "condition": {"op": "eq", "target-col": "Region", "const": {"type": "string", "v": "Europe"}}
+            }
+        ]
+
+        job = server.datasources.update_data(args.datasource_id, request_id=request_id, actions=actions)
+
+        # TODO: Add a flag that will poll and wait for the returned job to be done
+        print(job)
+
+if __name__ == '__main__':
+    main()

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -55,7 +55,9 @@ class Endpoint(object):
     ):
         parameters = parameters or {}
         parameters.update(self.parent_srv.http_options)
-        parameters["headers"] = Endpoint._make_common_headers(auth_token, content_type)
+        if not "headers" in parameters:
+            parameters["headers"] = {}
+        parameters["headers"].update(Endpoint._make_common_headers(auth_token, content_type))
 
         if content is not None:
             parameters["data"] = content
@@ -118,18 +120,29 @@ class Endpoint(object):
         # We don't return anything for a delete
         self._make_request(self.parent_srv.session.delete, url, auth_token=self.parent_srv.auth_token)
 
-    def put_request(self, url, xml_request=None, content_type="text/xml"):
+    def put_request(self, url, xml_request=None, content_type="text/xml", parameters=None):
         return self._make_request(
             self.parent_srv.session.put,
             url,
             content=xml_request,
             auth_token=self.parent_srv.auth_token,
             content_type=content_type,
+            parameters=parameters,
         )
 
     def post_request(self, url, xml_request, content_type="text/xml", parameters=None):
         return self._make_request(
             self.parent_srv.session.post,
+            url,
+            content=xml_request,
+            auth_token=self.parent_srv.auth_token,
+            content_type=content_type,
+            parameters=parameters,
+        )
+
+    def patch_request(self, url, xml_request, content_type="text/xml", parameters=None):
+        return self._make_request(
+            self.parent_srv.session.patch,
             url,
             content=xml_request,
             auth_token=self.parent_srv.auth_token,

--- a/test/assets/datasource_data_update.xml
+++ b/test/assets/datasource_data_update.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_14.xsd">
+  <job id="5c0ba560-c959-424e-b08a-f32ef0bfb737" mode="Asynchronous" type="UpdateUploadedFile" createdAt="2021-09-18T09:40:12Z">
+    <updateUploadedFileJob>
+      <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="test datasource"/>
+      <connectionLuid>7ecaccd8-39b0-4875-a77d-094f6e930019</connectionLuid>
+    </updateUploadedFileJob>
+  </job>
+</tsResponse>


### PR DESCRIPTION
To test this proposed interface locally, you can install my branch using
```
 pip install git+https://github.com/vogelsgesang/server-client-python.git@update-jobs
 ```
 
 You can find the documentation for this method at https://vogelsgesang.github.io/server-client-python/docs/api-ref#datasourceupdate_data
 
 **Commit Description**

This commit adds support for the `datasources/<id>/data` endpoint
through which one can schedule jobs to update the data within a
published live-to-Hyper datasource on the server.

The new `datasources.update_data` expects the arguments:
* a datasource or a connection: If the datasource only contains a
  single connections, the datasource is sufficient to identify which
  Hyper file should be updated. Otherwise, for datasources with
  multiple connections, the connections has to be provided. This
  distinction happens on the server, so the client library only needs
  to provide a way to specify either of both.
* a `request_id` which will be used to ensure idempotency on the server.
  This parameter is simply passed as a HTTP header .
* an `actions` list, specifying how exactly the data on the server
  should be modified. We expect the caller to provide list following
  the structure documented in the REST API documentation. TSC does
  not validate this object and simply passes it through to the server.
* an optional `payload` file: For actions like `insert`, one can
  provide a Hyper file which contains the newly inserted tuples or
  other payload data. TSC will upload this file to the server and then
  hand it over to the update-API endpoint.

Besides the addition of the `datasources.update_data` itself, this
commit also adds some infrastructure changes, e.g., to enable sending
PATCH requests and headers.

The documentation for the REST endpoint can be found at
https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_how_to_update_data_to_hyper.htm