### PR TITLE
Remove `basestring` hack for Python 2.x compatibility

### DIFF
--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -3,12 +3,6 @@ import re
 from functools import wraps
 from ..datetime_helpers import parse_datetime
 
-try:
-    basestring
-except NameError:
-    # In case we are in python 3 the string check is different
-    basestring = str
-
 
 def property_is_enum(enum_type):
     def property_type_decorator(func):
@@ -134,7 +128,7 @@ def property_is_datetime(func):
     def wrapper(self, value):
         if isinstance(value, datetime.datetime):
             return func(self, value)
-        if not isinstance(value, basestring):
+        if not isinstance(value, str):
             raise ValueError(
                 "Cannot convert {} into a datetime, cannot update {}".format(value.__class__.__name__, func.__name__)
             )

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -6,12 +6,6 @@ from ...exponential_backoff import ExponentialBackoffTimer
 
 import logging
 
-try:
-    basestring
-except NameError:
-    # In case we are in python 3 the string check is different
-    basestring = str
-
 logger = logging.getLogger("tableau.endpoint.jobs")
 
 class Jobs(Endpoint):
@@ -22,7 +16,7 @@ class Jobs(Endpoint):
     @api(version="2.6")
     def get(self, job_id=None, req_options=None):
         # Backwards Compatibility fix until we rev the major version
-        if job_id is not None and isinstance(job_id, basestring):
+        if job_id is not None and isinstance(job_id, str):
             import warnings
 
             warnings.warn("Jobs.get(job_id) is deprecated, update code to use Jobs.get_by_id(job_id)")


### PR DESCRIPTION
TSC only supports Python 3.5+ and Python 2.7 reached end-of-life already on Jan 1st, 2020.
Let's remove that hack from our code, and move on...