### PR TITLE
Stop supporting Python 3.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use the Tableau Server Client (TSC) library to increase your productivity as you
 * Create users and groups.
 * Query projects, sites, and more.
 
-This repository contains Python source code and sample files. Python versions 3.5 and up are supported.
+This repository contains Python source code and sample files. Python versions 3.6 and up are supported.
 
 For more information on installing and using TSC, see the documentation:
 <https://tableau.github.io/server-client-python/docs/>

--- a/samples/add_default_permission.py
+++ b/samples/add_default_permission.py
@@ -1,6 +1,6 @@
 ####
 # This script demonstrates how to add default permissions using TSC
-# To run the script, you must have installed Python 3.5 and later.
+# To run the script, you must have installed Python 3.6 or later.
 #
 # In order to demonstrate adding a new default permission, this sample will create
 # a new project and add a new capability to the new project, for the default "All users" group.

--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to create a group using the Tableau
 # Server Client.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 

--- a/samples/create_project.py
+++ b/samples/create_project.py
@@ -4,7 +4,7 @@
 # parent_id.
 #
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/create_schedules.py
+++ b/samples/create_schedules.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to create schedules using the Tableau
 # Server Client.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 

--- a/samples/download_view_image.py
+++ b/samples/download_view_image.py
@@ -5,7 +5,7 @@
 # For more information, refer to the documentations on 'Query View Image'
 # (https://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm)
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/export.py
+++ b/samples/export.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to export a view using the Tableau
 # Server Client.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/export_wb.py
+++ b/samples/export_wb.py
@@ -4,7 +4,7 @@
 #
 # You will need to do `pip install PyPDF2` to use this sample.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 

--- a/samples/filter_sort_groups.py
+++ b/samples/filter_sort_groups.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to filter and sort groups using the Tableau
 # Server Client.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 

--- a/samples/filter_sort_projects.py
+++ b/samples/filter_sort_projects.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to use the Tableau Server Client
 # to filter and sort on the name of the projects present on site.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/kill_all_jobs.py
+++ b/samples/kill_all_jobs.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to kill all of the running jobs
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/list.py
+++ b/samples/list.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to list all of the workbooks or datasources
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/login.py
+++ b/samples/login.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to log in to Tableau Server Client.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/metadata_query.py
+++ b/samples/metadata_query.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to use the metadata API to query information on a published data source
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -4,7 +4,7 @@
 # a workbook that matches a given name and update it to be in
 # the desired project.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -4,7 +4,7 @@
 # a workbook that matches a given name, download the workbook,
 # and then publish it to the destination site.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/publish_datasource.py
+++ b/samples/publish_datasource.py
@@ -15,7 +15,7 @@
 # more information on personal access tokens, refer to the documentations:
 # (https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm)
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -11,7 +11,7 @@
 # For more information, refer to the documentations on 'Publish Workbook'
 # (https://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm)
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/query_permissions.py
+++ b/samples/query_permissions.py
@@ -1,6 +1,6 @@
 ####
 # This script demonstrates how to query for permissions using TSC
-# To run the script, you must have installed Python 3.5 and later.
+# To run the script, you must have installed Python 3.6 or later.
 #
 # Example usage: 'python query_permissions.py -s https://10ax.online.tableau.com --site
 #       devSite123 -u tabby@tableau.com workbook b4065286-80f0-11ea-af1b-cb7191f48e45'

--- a/samples/refresh.py
+++ b/samples/refresh.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to use trigger a refresh on a datasource or workbook
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/refresh_tasks.py
+++ b/samples/refresh_tasks.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to use the Tableau Server Client
 # to query extract refresh tasks and run them as needed.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/set_http_options.py
+++ b/samples/set_http_options.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to set http options. It will set the option
 # to not verify SSL certificate, and query all workbooks on site.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse

--- a/samples/set_refresh_schedule.py
+++ b/samples/set_refresh_schedule.py
@@ -2,7 +2,7 @@
 # This script demonstrates how to set the refresh schedule for
 # a workbook or datasource.
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 

--- a/samples/update_connection.py
+++ b/samples/update_connection.py
@@ -1,7 +1,7 @@
 ####
 # This script demonstrates how to update a connections credentials on a server to embed the credentials
 #
-# To run the script, you must have installed Python 3.5 or later.
+# To run the script, you must have installed Python 3.6 or later.
 ####
 
 import argparse


### PR DESCRIPTION
Python 3.5 is already end-of-life and no longer receives security patches for over a year now.
Also, I recently added an f-string because all Python versions which are still in support, also
support f-strings. I was unpleasantly surprised when I had to realize that we still claim to
support Python 3.5 which doesn't have f-strings...