### PR TITLE
Accept `None` as parameter for the `site_id` of `TableauAuth` and `PersonalAccessTokenAuth`

### DIFF
--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -3,7 +3,7 @@ class PersonalAccessTokenAuth(object):
         self.token_name = token_name
         self.personal_access_token = personal_access_token
         self.site_id = site_id if site_id is not None else ''
-        # Personal Access Tokens doesn't support impersonation.
+        # Personal Access Tokens doesn't support impersonation
         self.user_id_to_impersonate = None
 
     @property

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -3,7 +3,7 @@ class PersonalAccessTokenAuth(object):
         self.token_name = token_name
         self.personal_access_token = personal_access_token
         self.site_id = site_id if site_id is not None else ''
-        # Personal Access Tokens doesn't support impersonation
+        # Personal Access Tokens doesn't support impersonation.
         self.user_id_to_impersonate = None
 
     @property

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -2,7 +2,7 @@ class PersonalAccessTokenAuth(object):
     def __init__(self, token_name, personal_access_token, site_id=None):
         self.token_name = token_name
         self.personal_access_token = personal_access_token
-        self.site_id = site_id if site_id is not None else ''
+        self.site_id = site_id if site_id is not None else ""
         # Personal Access Tokens doesn't support impersonation.
         self.user_id_to_impersonate = None
 

--- a/tableauserverclient/models/personal_access_token_auth.py
+++ b/tableauserverclient/models/personal_access_token_auth.py
@@ -1,8 +1,8 @@
 class PersonalAccessTokenAuth(object):
-    def __init__(self, token_name, personal_access_token, site_id=""):
+    def __init__(self, token_name, personal_access_token, site_id=None):
         self.token_name = token_name
         self.personal_access_token = personal_access_token
-        self.site_id = site_id
+        self.site_id = site_id if site_id is not None else ''
         # Personal Access Tokens doesn't support impersonation.
         self.user_id_to_impersonate = None
 

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -1,17 +1,17 @@
 class TableauAuth(object):
-    def __init__(self, username, password, site=None, site_id="", user_id_to_impersonate=None):
+    def __init__(self, username, password, site=None, site_id=None, user_id_to_impersonate=None):
         if site is not None:
             import warnings
 
             warnings.warn(
-                'TableauAuth(...site=""...) is deprecated, ' 'please use TableauAuth(...site_id=""...) instead.',
+                'TableauAuth(..., site=...) is deprecated, ' 'please use TableauAuth(..., site_id=...) instead.',
                 DeprecationWarning,
             )
             site_id = site
 
         self.user_id_to_impersonate = user_id_to_impersonate
         self.password = password
-        self.site_id = site_id
+        self.site_id = site_id if site_id is not None else ''
         self.username = username
 
     @property

--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -4,14 +4,14 @@ class TableauAuth(object):
             import warnings
 
             warnings.warn(
-                'TableauAuth(..., site=...) is deprecated, ' 'please use TableauAuth(..., site_id=...) instead.',
+                "TableauAuth(..., site=...) is deprecated, " "please use TableauAuth(..., site_id=...) instead.",
                 DeprecationWarning,
             )
             site_id = site
 
         self.user_id_to_impersonate = user_id_to_impersonate
         self.password = password
-        self.site_id = site_id if site_id is not None else ''
+        self.site_id = site_id if site_id is not None else ""
         self.username = username
 
     @property


### PR DESCRIPTION
As part of #889, I changed the default value for the `site` argument to be `None`
instead of an empty string. This accidentally broke auth, as `TableauAuth`
expected an empty string instead of `None` to signify an absent `site` argument.

This commit fixes the issue by now actually accepting `None` as `site_id` in
`TableauAuth` and `PersonalAccessTokenAuth`, thereby making our interface more
intuitive, at least in my opinion. 

Fixes #924