### PR TITLE
Switch to release Python 3.10 release for CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
3.10 was released in early October. 3.6 is still supported so we'll leave that one as well.