### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, issues]
 
 jobs:
   slack-notifications:
+    continue-on-error: true
     runs-on: ubuntu-20.04
     name: Sends a message to Slack when a push, a pull request or an issue is made
     steps:


### PR DESCRIPTION
This brings over 2 recent workflow changes:
- add Python 3.10 released version
- don't fail the build if Slack notification fails for some reason