### PR TITLE
Add back old format for setting hidden views on publish

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -77,4 +77,8 @@ black --line-length 120 tableauserverclient --check
 
 # this will format the directory and code for you
 black --line-length 120 tableauserverclient
+
+# this will run type checking
+pip install mypy
+mypy --show-error-codes --disable-error-code misc --disable-error-code import tableauserverclient test
 ```

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -389,6 +389,7 @@ class Workbooks(QuerysetEndpoint):
                 workbook_item,
                 connection_credentials=conn_creds,
                 connections=connections,
+                hidden_views=hidden_views,
             )
         else:
             logger.info("Publishing {0} to server".format(filename))
@@ -410,6 +411,7 @@ class Workbooks(QuerysetEndpoint):
                 file_contents,
                 connection_credentials=conn_creds,
                 connections=connections,
+                hidden_views=hidden_views,
             )
         logger.debug("Request xml: {0} ".format(xml_request[:1000]))
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -836,6 +836,7 @@ class WorkbookRequest(object):
         workbook_item,
         connection_credentials=None,
         connections=None,
+        hidden_views=None,
     ):
         xml_request = ET.Element("tsRequest")
         workbook_element = ET.SubElement(xml_request, "workbook")
@@ -855,6 +856,16 @@ class WorkbookRequest(object):
             connections_element = ET.SubElement(workbook_element, "connections")
             for connection in connections:
                 _add_connections_element(connections_element, connection)
+
+        if hidden_views is not None:       
+            import warnings
+            warnings.simplefilter("always", DeprecationWarning)
+            warnings.warn(
+                "the hidden_views parameter should now be set on the workbook directly",
+                DeprecationWarning,
+            )
+            if workbook_item.hidden_views is None:
+                workbook_item.hidden_views = hidden_views
 
         if workbook_item.hidden_views is not None:
             views_element = ET.SubElement(workbook_element, "views")
@@ -896,11 +907,13 @@ class WorkbookRequest(object):
         file_contents,
         connection_credentials=None,
         connections=None,
+        hidden_views=None,
     ):
         xml_request = self._generate_xml(
             workbook_item,
             connection_credentials=connection_credentials,
             connections=connections,
+            hidden_views=hidden_views,
         )
 
         parts = {
@@ -914,11 +927,13 @@ class WorkbookRequest(object):
         workbook_item,
         connection_credentials=None,
         connections=None,
+        hidden_views=None,
     ):
         xml_request = self._generate_xml(
             workbook_item,
             connection_credentials=connection_credentials,
             connections=connections,
+            hidden_views=hidden_views,
         )
 
         parts = {"request_payload": ("", xml_request, "text/xml")}

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -857,8 +857,9 @@ class WorkbookRequest(object):
             for connection in connections:
                 _add_connections_element(connections_element, connection)
 
-        if hidden_views is not None:       
+        if hidden_views is not None:
             import warnings
+
             warnings.simplefilter("always", DeprecationWarning)
             warnings.warn(
                 "the hidden_views parameter should now be set on the workbook directly",

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -579,8 +579,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual("RESTAPISample_0/sheets/GDPpercapita", new_workbook.views[0].content_url)
 
     def test_publish_with_hidden_views_on_workbook(self) -> None:
-        with open(PUBLISH_XML, 'rb') as f:
-            response_xml = f.read().decode('utf-8')
+        with open(PUBLISH_XML, "rb") as f:
+            response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
 
@@ -602,28 +602,26 @@ class WorkbookTests(unittest.TestCase):
     # should be removed when that functionality is removed
     # see https://github.com/tableau/server-client-python/pull/617
     def test_publish_with_hidden_view(self) -> None:
-        with open(PUBLISH_XML, 'rb') as f:
-            response_xml = f.read().decode('utf-8')
+        with open(PUBLISH_XML, "rb") as f:
+            response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
 
-            new_workbook = TSC.WorkbookItem(name='Sample',
-                                            show_tabs=False,
-                                            project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+            new_workbook = TSC.WorkbookItem(
+                name="Sample", show_tabs=False, project_id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760"
+            )
 
-            sample_workbook = os.path.join(TEST_ASSET_DIR, 'SampleWB.twbx')
+            sample_workbook = os.path.join(TEST_ASSET_DIR, "SampleWB.twbx")
             publish_mode = self.server.PublishMode.CreateNew
 
-            new_workbook = self.server.workbooks.publish(new_workbook,
-                                                         sample_workbook,
-                                                         publish_mode,
-                                                         hidden_views=['GDP per capita'])
+            new_workbook = self.server.workbooks.publish(
+                new_workbook, sample_workbook, publish_mode, hidden_views=["GDP per capita"]
+            )
 
             request_body = m._adapter.request_history[0]._request.body
             # order of attributes in xml is unspecified
-            self.assertTrue(re.search(rb'<views><view.*?hidden=\"true\".*?\/><\/views>', request_body))
-            self.assertTrue(re.search(rb'<views><view.*?name=\"GDP per capita\".*?\/><\/views>', request_body))
-
+            self.assertTrue(re.search(rb"<views><view.*?hidden=\"true\".*?\/><\/views>", request_body))
+            self.assertTrue(re.search(rb"<views><view.*?name=\"GDP per capita\".*?\/><\/views>", request_body))
 
     def test_publish_with_query_params(self) -> None:
         with open(PUBLISH_ASYNC_XML, "rb") as f:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -578,9 +578,9 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual("GDP per capita", new_workbook.views[0].name)
         self.assertEqual("RESTAPISample_0/sheets/GDPpercapita", new_workbook.views[0].content_url)
 
-    def test_publish_with_hidden_view(self) -> None:
-        with open(PUBLISH_XML, "rb") as f:
-            response_xml = f.read().decode("utf-8")
+    def test_publish_with_hidden_views_on_workbook(self) -> None:
+        with open(PUBLISH_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
 
@@ -597,6 +597,33 @@ class WorkbookTests(unittest.TestCase):
             # order of attributes in xml is unspecified
             self.assertTrue(re.search(rb"<views><view.*?hidden=\"true\".*?\/><\/views>", request_body))
             self.assertTrue(re.search(rb"<views><view.*?name=\"GDP per capita\".*?\/><\/views>", request_body))
+
+    # this tests the old method of including workbook views as a parameter for publishing
+    # should be removed when that functionality is removed
+    # see https://github.com/tableau/server-client-python/pull/617
+    def test_publish_with_hidden_view(self) -> None:
+        with open(PUBLISH_XML, 'rb') as f:
+            response_xml = f.read().decode('utf-8')
+        with requests_mock.mock() as m:
+            m.post(self.baseurl, text=response_xml)
+
+            new_workbook = TSC.WorkbookItem(name='Sample',
+                                            show_tabs=False,
+                                            project_id='ee8c6e70-43b6-11e6-af4f-f7b0d8e20760')
+
+            sample_workbook = os.path.join(TEST_ASSET_DIR, 'SampleWB.twbx')
+            publish_mode = self.server.PublishMode.CreateNew
+
+            new_workbook = self.server.workbooks.publish(new_workbook,
+                                                         sample_workbook,
+                                                         publish_mode,
+                                                         hidden_views=['GDP per capita'])
+
+            request_body = m._adapter.request_history[0]._request.body
+            # order of attributes in xml is unspecified
+            self.assertTrue(re.search(rb'<views><view.*?hidden=\"true\".*?\/><\/views>', request_body))
+            self.assertTrue(re.search(rb'<views><view.*?name=\"GDP per capita\".*?\/><\/views>', request_body))
+
 
     def test_publish_with_query_params(self) -> None:
         with open(PUBLISH_ASYNC_XML, "rb") as f:


### PR DESCRIPTION
This is to create a temporary back compatible functionality for https://github.com/tableau/server-client-python/pull/617