### PR TITLE
Bump default Server version

### DIFF
--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -40,7 +40,7 @@ class WorkbookItem(object):
         self.owner_id: Optional[str] = None
         self.project_id = project_id
         self.show_tabs = show_tabs
-        self.hidden_views = None
+        self.hidden_views: Optional[List[str]] = None
         self.tags: Set[str] = set()
         self.data_acceleration_config = {
             "acceleration_enabled": None,

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -59,7 +59,7 @@ class Server(object):
         self._session = requests.Session()
         self._http_options = dict()
 
-        self.version = "2.3"
+        self.version = "3.10"
         self.auth = Auth(self)
         self.views = Views(self)
         self.users = Users(self)

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -124,8 +124,7 @@ class GroupTests(unittest.TestCase):
             add_user_response = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=get_xml_response)
-            m.post('http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/groups/ef8b19c0-43b6-11e6-af50'
-                   '-63f5805dbe3c/users', text=add_user_response)
+            m.post('{0}/ef8b19c0-43b6-11e6-af50-63f5805dbe3c/users'.format(self.baseurl), text=add_user_response)
             all_groups, pagination_item = self.server.groups.get()
             single_group = all_groups[0]
             self.server.groups.add_user(single_group, '5de011f8-5aa9-4d5b-b991-f462c8dd6bb7')
@@ -152,8 +151,7 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode('utf-8')
         with requests_mock.mock() as m:
             m.get(self.baseurl, text=response_xml)
-            m.delete('http://test/api/2.3/sites/dad65087-b08b-4603-af4e-2887b8aafc67/groups/ef8b19c0-43b6-11e6-af50'
-                     '-63f5805dbe3c/users/5de011f8-5aa9-4d5b-b991-f462c8dd6bb7',
+            m.delete(self.baseurl + '/ef8b19c0-43b6-11e6-af50-63f5805dbe3c/users/5de011f8-5aa9-4d5b-b991-f462c8dd6bb7',
                      text='ok')
             all_groups, pagination_item = self.server.groups.get()
             single_group = all_groups[0]


### PR DESCRIPTION
As of 2021-11-11, Tableau Server versions below 2020.4.x are out of support. Bumping the default server version in accordance with that.