### PR TITLE
Fix typings for clean run in mypy

### DIFF
--- a/tableauserverclient/models/pagination_item.py
+++ b/tableauserverclient/models/pagination_item.py
@@ -8,19 +8,19 @@ class PaginationItem(object):
         self._total_available = None
 
     @property
-    def page_number(self):
+    def page_number(self) -> int:
         return self._page_number
 
     @property
-    def page_size(self):
+    def page_size(self) -> int:
         return self._page_size
 
     @property
-    def total_available(self):
+    def total_available(self) -> int:
         return self._total_available
 
     @classmethod
-    def from_response(cls, resp, ns):
+    def from_response(cls, resp, ns) -> "PaginationItem":
         parsed_response = ET.fromstring(resp)
         pagination_xml = parsed_response.find("t:pagination", namespaces=ns)
         pagination_item = cls()
@@ -31,7 +31,7 @@ class PaginationItem(object):
         return pagination_item
 
     @classmethod
-    def from_single_page_list(cls, single_page_list):
+    def from_single_page_list(cls, single_page_list) -> "PaginationItem":
         item = cls()
         item._page_number = 1
         item._page_size = len(single_page_list)

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -76,7 +76,6 @@ class PermissionsRule(object):
             rule = PermissionsRule(grantee, capability_dict)
             rules.append(rule)
 
-
         return rules
 
     @staticmethod

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,7 +1,7 @@
 import xml.etree.ElementTree as ET
 import logging
 
-from .exceptions import UnknownGranteeTypeError
+from .exceptions import UnknownGranteeTypeError, UnpopulatedPropertyError
 from .user_item import UserItem
 from .group_item import GroupItem
 
@@ -47,7 +47,7 @@ class Permission:
 
 
 class PermissionsRule(object):
-    def __init__(self, grantee: "ResourceReference", capabilities: Dict[Optional[str], Optional[str]]) -> None:
+    def __init__(self, grantee: "ResourceReference", capabilities: Dict[str, str]) -> None:
         self.grantee = grantee
         self.capabilities = capabilities
 
@@ -59,7 +59,7 @@ class PermissionsRule(object):
         permissions_rules_list_xml = parsed_response.findall(".//t:granteeCapabilities", namespaces=ns)
 
         for grantee_capability_xml in permissions_rules_list_xml:
-            capability_dict: Dict[Optional[str], Optional[str]] = {}
+            capability_dict: Dict[str, str] = {}
 
             grantee = PermissionsRule._parse_grantee_element(grantee_capability_xml, ns)
 
@@ -67,10 +67,15 @@ class PermissionsRule(object):
                 name = capability_xml.get("name")
                 mode = capability_xml.get("mode")
 
-                capability_dict[name] = mode
+                if name is None or mode is None:
+                    logger.error("Capability was not valid: ", capability_xml)
+                    raise UnpopulatedPropertyError()
+                else:
+                    capability_dict[name] = mode
 
             rule = PermissionsRule(grantee, capability_dict)
             rules.append(rule)
+
 
         return rules
 

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -47,7 +47,7 @@ class Groups(Endpoint):
 
     def _get_users_for_group(
         self, group_item, req_options: Optional["RequestOptions"] = None
-    ) -> Tuple[List[GroupItem], PaginationItem]:
+    ) -> Tuple[List[UserItem], PaginationItem]:
         url = "{0}/{1}/users".format(self.baseurl, group_item.id)
         server_response = self.get_request(url, req_options)
         user_item = UserItem.from_response(server_response.content, self.parent_srv.namespace)

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -148,7 +148,6 @@ class GroupTests(unittest.TestCase):
 
     def test_add_user_missing_group_id(self) -> None:
         single_group = TSC.GroupItem("test")
-        single_group._users = []
         self.assertRaises(
             TSC.MissingRequiredFieldError,
             self.server.groups.add_user,
@@ -183,7 +182,6 @@ class GroupTests(unittest.TestCase):
 
     def test_remove_user_missing_group_id(self) -> None:
         single_group = TSC.GroupItem("test")
-        single_group._users = []
         self.assertRaises(
             TSC.MissingRequiredFieldError,
             self.server.groups.remove_user,

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -119,7 +119,7 @@ class ProjectTests(unittest.TestCase):
 
             capabilities = {TSC.Permission.Capability.ExportXml: TSC.Permission.Mode.Deny}
 
-            rules = [TSC.PermissionsRule(grantee=group, capabilities=capabilities)]
+            rules = [TSC.PermissionsRule(grantee=group.to_reference(), capabilities=capabilities)]
 
             new_rules = self.server.projects.update_datasource_default_permissions(project, rules)
 
@@ -236,7 +236,7 @@ class ProjectTests(unittest.TestCase):
                     if permission.grantee.id == single_group._id:
                         capabilities = permission.capabilities
 
-            rules = TSC.PermissionsRule(grantee=single_group, capabilities=capabilities)
+            rules = TSC.PermissionsRule(grantee=single_group.to_reference(), capabilities=capabilities)
 
             endpoint = "{}/permissions/groups/{}".format(single_project._id, single_group._id)
             m.delete("{}/{}/Read/Allow".format(self.baseurl, endpoint), status_code=204)
@@ -282,7 +282,7 @@ class ProjectTests(unittest.TestCase):
                 TSC.Permission.Capability.ChangePermissions: TSC.Permission.Mode.Allow,
             }
 
-            rules = TSC.PermissionsRule(grantee=single_group, capabilities=capabilities)
+            rules = TSC.PermissionsRule(grantee=single_group.to_reference(), capabilities=capabilities)
 
             endpoint = "{}/default-permissions/workbooks/groups/{}".format(single_project._id, single_group._id)
             m.delete("{}/{}/Read/Allow".format(self.baseurl, endpoint), status_code=204)


### PR DESCRIPTION
probably introduced these failures in merge mistakes when I merged all those type-hints at once.