### PR TITLE
Include 'parquet' as a publishing file type

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -23,7 +23,7 @@ import json
 # The maximum size of a file that can be published in a single request is 64MB
 FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB
 
-ALLOWED_FILE_EXTENSIONS = ["tds", "tdsx", "tde", "hyper"]
+ALLOWED_FILE_EXTENSIONS = ["tds", "tdsx", "tde", "hyper", "parquet"]
 
 logger = logging.getLogger("tableau.endpoint.datasources")
 


### PR DESCRIPTION
Add "parquet" to the list of publishable file types. It will become a Hyper data source during publish 22.1+.