### PR TITLE
PEP 561 compliance for types

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,5 @@ recursive-include test *.tdsx
 recursive-include test *.twb
 recursive-include test *.twbx
 recursive-include test *.xml
+global-include *.pyi
+global-include *.typed

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     author='Tableau',
     author_email='github@tableau.com',
     url='https://github.com/tableau/server-client-python',
+    package_data={'tableauserverclient':['py.typed']},
     packages=['tableauserverclient', 'tableauserverclient.models', 'tableauserverclient.server',
               'tableauserverclient.server.endpoint'],
     license='MIT',
@@ -38,5 +39,6 @@ setup(
     tests_require=test_requirements,
     extras_require={
         'test': test_requirements
-    }
+    },
+    zip_safe=False
 )

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -62,9 +62,9 @@ class Endpoint(object):
         if content is not None:
             parameters["data"] = content
 
-        logger.debug(u"request {}, url: {}".format(method.__name__, url))
+        logger.debug("request {}, url: {}".format(method.__name__, url))
         if content:
-            logger.debug(u"request content: {}".format(content[:1000]))
+            logger.debug("request content: {}".format(content[:1000]))
 
         server_response = method(url, **parameters)
         self.parent_srv._namespace.detect(server_response.content)
@@ -74,9 +74,7 @@ class Endpoint(object):
         # so that we do not attempt to log bytes and other binary data.
         if len(server_response.content) > 0 and server_response.encoding:
             logger.debug(
-                u"Server response from {0}:\n\t{1}".format(
-                    url, server_response.content.decode(server_response.encoding)
-                )
+                "Server response from {0}:\n\t{1}".format(url, server_response.content.decode(server_response.encoding))
             )
         return server_response
 

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -194,9 +194,9 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
-            group_to_create = TSC.GroupItem(u"試供品")
+            group_to_create = TSC.GroupItem("試供品")
             group = self.server.groups.create(group_to_create)
-            self.assertEqual(group.name, u"試供品")
+            self.assertEqual(group.name, "試供品")
             self.assertEqual(group.id, "3e4a9ea0-a07a-4fe6-b50f-c345c8c81034")
 
     def test_create_ad_group(self) -> None:
@@ -204,10 +204,10 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
-            group_to_create = TSC.GroupItem(u"試供品")
+            group_to_create = TSC.GroupItem("試供品")
             group_to_create.domain_name = "just-has-to-exist"
             group = self.server.groups.create_AD_group(group_to_create, False)
-            self.assertEqual(group.name, u"試供品")
+            self.assertEqual(group.name, "試供品")
             self.assertEqual(group.license_mode, "onLogin")
             self.assertEqual(group.minimum_site_role, "Creator")
             self.assertEqual(group.domain_name, "active-directory-domain-name")
@@ -217,7 +217,7 @@ class GroupTests(unittest.TestCase):
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=response_xml)
-            group_to_create = TSC.GroupItem(u"試供品")
+            group_to_create = TSC.GroupItem("試供品")
             group_to_create.domain_name = "woohoo"
             job = self.server.groups.create_AD_group(group_to_create, True)
             self.assertEqual(job.mode, "Asynchronous")

--- a/test/test_regression_tests.py
+++ b/test/test_regression_tests.py
@@ -52,10 +52,10 @@ class FileSysHelpers(unittest.TestCase):
     def test_make_download_path(self):
         no_file_path = (None, "file.ext")
         has_file_path_folder = ("/root/folder/", "file.ext")
-        has_file_path_file = ("out", "file.ext")
+        has_file_path_file = ("outx", "file.ext")
 
         self.assertEqual("file.ext", make_download_path(*no_file_path))
-        self.assertEqual("out.ext", make_download_path(*has_file_path_file))
+        self.assertEqual("outx.ext", make_download_path(*has_file_path_file))
 
         with mock.patch("os.path.isdir") as mocked_isdir:
             mocked_isdir.return_value = True


### PR DESCRIPTION
Adds py.typed to package to inform mypy that the package is typed to be able to support type checking in client code.

Resolves #991 