### PR TITLE
Use defusedxml library to reduce xml attack surface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     test_suite='test',
     setup_requires=pytest_runner,
     install_requires=[
+        'defusedxml>=0.7.1',
         'requests>=2.11,<3.0',
     ],
     tests_require=test_requirements,

--- a/tableauserverclient/__init__.py
+++ b/tableauserverclient/__init__.py
@@ -1,4 +1,4 @@
-from .namespace import NEW_NAMESPACE as DEFAULT_NAMESPACE
+from ._version import get_versions
 from .models import (
     ConnectionCredentials,
     ConnectionItem,
@@ -37,6 +37,7 @@ from .models import (
     FlowRunItem,
     RevisionItem,
 )
+from .namespace import NEW_NAMESPACE as DEFAULT_NAMESPACE
 from .server import (
     RequestOptions,
     CSVRequestOptions,
@@ -50,7 +51,6 @@ from .server import (
     NotSignedInError,
     Pager,
 )
-from ._version import get_versions
 
 __version__ = get_versions()["version"]
 __VERSION__ = __version__

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -1,16 +1,16 @@
+from .column_item import ColumnItem
 from .connection_credentials import ConnectionCredentials
 from .connection_item import ConnectionItem
-from .column_item import ColumnItem
 from .data_acceleration_report_item import DataAccelerationReportItem
 from .data_alert_item import DataAlertItem
-from .datasource_item import DatasourceItem
 from .database_item import DatabaseItem
+from .datasource_item import DatasourceItem
 from .dqw_item import DQWItem
 from .exceptions import UnpopulatedPropertyError
 from .favorites_item import FavoriteItem
-from .group_item import GroupItem
 from .flow_item import FlowItem
 from .flow_run_item import FlowRunItem
+from .group_item import GroupItem
 from .interval_item import (
     IntervalItem,
     DailyInterval,
@@ -20,20 +20,20 @@ from .interval_item import (
 )
 from .job_item import JobItem, BackgroundJobItem
 from .pagination_item import PaginationItem
+from .permissions_item import PermissionsRule, Permission
+from .personal_access_token_auth import PersonalAccessTokenAuth
+from .personal_access_token_auth import PersonalAccessTokenAuth
 from .project_item import ProjectItem
+from .revision_item import RevisionItem
 from .schedule_item import ScheduleItem
 from .server_info_item import ServerInfoItem
 from .site_item import SiteItem
-from .tableau_auth import TableauAuth
-from .personal_access_token_auth import PersonalAccessTokenAuth
-from .target import Target
+from .subscription_item import SubscriptionItem
 from .table_item import TableItem
+from .tableau_auth import TableauAuth
+from .target import Target
 from .task_item import TaskItem
 from .user_item import UserItem
 from .view_item import ViewItem
-from .workbook_item import WorkbookItem
-from .subscription_item import SubscriptionItem
-from .permissions_item import PermissionsRule, Permission
 from .webhook_item import WebhookItem
-from .personal_access_token_auth import PersonalAccessTokenAuth
-from .revision_item import RevisionItem
+from .workbook_item import WorkbookItem

--- a/tableauserverclient/models/column_item.py
+++ b/tableauserverclient/models/column_item.py
@@ -1,4 +1,5 @@
 from defusedxml.ElementTree import fromstring
+
 from .property_decorators import property_not_empty
 
 

--- a/tableauserverclient/models/column_item.py
+++ b/tableauserverclient/models/column_item.py
@@ -1,5 +1,4 @@
-import xml.etree.ElementTree as ET
-
+from defusedxml.ElementTree import fromstring
 from .property_decorators import property_not_empty
 
 
@@ -47,7 +46,7 @@ class ColumnItem(object):
     @classmethod
     def from_response(cls, resp, ns):
         all_column_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_column_xml = parsed_response.findall(".//t:column", namespaces=ns)
 
         for column_xml in all_column_xml:

--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
+
 from .connection_credentials import ConnectionCredentials
 
 
@@ -39,7 +40,7 @@ class ConnectionItem(object):
     @classmethod
     def from_response(cls, resp, ns):
         all_connection_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_connection_xml = parsed_response.findall(".//t:connection", namespaces=ns)
         for connection_xml in all_connection_xml:
             connection_item = cls()

--- a/tableauserverclient/models/data_acceleration_report_item.py
+++ b/tableauserverclient/models/data_acceleration_report_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 
 
 class DataAccelerationReportItem(object):
@@ -70,7 +70,7 @@ class DataAccelerationReportItem(object):
     @classmethod
     def from_response(cls, resp, ns):
         comparison_records = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_comparison_records_xml = parsed_response.findall(".//t:comparisonRecord", namespaces=ns)
         for comparison_record_xml in all_comparison_records_xml:
             (

--- a/tableauserverclient/models/data_alert_item.py
+++ b/tableauserverclient/models/data_alert_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree
+from typing import List, Optional, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
 
 from .property_decorators import (
@@ -6,11 +7,6 @@ from .property_decorators import (
     property_is_enum,
     property_is_boolean,
 )
-from .user_item import UserItem
-from .view_item import ViewItem
-
-
-from typing import List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/tableauserverclient/models/data_alert_item.py
+++ b/tableauserverclient/models/data_alert_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 
 from .property_decorators import (
     property_not_empty,
@@ -181,7 +182,7 @@ class DataAlertItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["DataAlertItem"]:
         all_alert_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_alert_xml = parsed_response.findall(".//t:dataAlert", namespaces=ns)
 
         for alert_xml in all_alert_xml:

--- a/tableauserverclient/models/database_item.py
+++ b/tableauserverclient/models/database_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 
 from .property_decorators import (
     property_is_enum,
@@ -254,7 +255,7 @@ class DatabaseItem(object):
     @classmethod
     def from_response(cls, resp, ns):
         all_database_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_database_xml = parsed_response.findall(".//t:database", namespaces=ns)
 
         for database_xml in all_database_xml:

--- a/tableauserverclient/models/database_item.py
+++ b/tableauserverclient/models/database_item.py
@@ -1,12 +1,11 @@
-import xml.etree.ElementTree
 from defusedxml.ElementTree import fromstring
 
+from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_is_enum,
     property_not_empty,
     property_is_boolean,
 )
-from .exceptions import UnpopulatedPropertyError
 
 
 class DatabaseItem(object):

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_not_nullable,
@@ -189,7 +190,7 @@ class DatasourceItem(object):
 
     def _parse_common_elements(self, datasource_xml, ns):
         if not isinstance(datasource_xml, ET.Element):
-            datasource_xml = ET.fromstring(datasource_xml).find(".//t:datasource", namespaces=ns)
+            datasource_xml = fromstring(datasource_xml).find(".//t:datasource", namespaces=ns)
         if datasource_xml is not None:
             (
                 ask_data_enablement,
@@ -294,7 +295,7 @@ class DatasourceItem(object):
     @classmethod
     def from_response(cls, resp: str, ns: Dict) -> List["DatasourceItem"]:
         all_datasource_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_datasource_xml = parsed_response.findall(".//t:datasource", namespaces=ns)
 
         for datasource_xml in all_datasource_xml:

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,5 +1,9 @@
+import copy
 import xml.etree.ElementTree as ET
+from typing import Dict, List, Optional, Set, Tuple, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_not_nullable,
@@ -8,9 +12,6 @@ from .property_decorators import (
 )
 from .tag_item import TagItem
 from ..datetime_helpers import parse_datetime
-import copy
-
-from typing import Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from .permissions_item import PermissionsRule

--- a/tableauserverclient/models/dqw_item.py
+++ b/tableauserverclient/models/dqw_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from ..datetime_helpers import parse_datetime
 
 
@@ -98,7 +98,7 @@ class DQWItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
-        return cls.from_xml_element(ET.fromstring(resp), ns)
+        return cls.from_xml_element(fromstring(resp), ns)
 
     @classmethod
     def from_xml_element(cls, parsed_response, ns):

--- a/tableauserverclient/models/dqw_item.py
+++ b/tableauserverclient/models/dqw_item.py
@@ -1,4 +1,5 @@
 from defusedxml.ElementTree import fromstring
+
 from ..datetime_helpers import parse_datetime
 
 

--- a/tableauserverclient/models/favorites_item.py
+++ b/tableauserverclient/models/favorites_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 import logging
 from .workbook_item import WorkbookItem
 from .view_item import ViewItem
@@ -42,7 +42,7 @@ class FavoriteItem:
             "workbooks": [],
         }
 
-        parsed_response = ET.fromstring(xml)
+        parsed_response = fromstring(xml)
         for workbook in parsed_response.findall(".//t:favorite/t:workbook", namespace):
             fav_workbook = WorkbookItem("")
             fav_workbook._set_values(*fav_workbook._parse_element(workbook, namespace))

--- a/tableauserverclient/models/favorites_item.py
+++ b/tableauserverclient/models/favorites_item.py
@@ -1,10 +1,12 @@
-from defusedxml.ElementTree import fromstring
 import logging
-from .workbook_item import WorkbookItem
-from .view_item import ViewItem
-from .project_item import ProjectItem
+
+from defusedxml.ElementTree import fromstring
+
 from .datasource_item import DatasourceItem
 from .flow_item import FlowItem
+from .project_item import ProjectItem
+from .view_item import ViewItem
+from .workbook_item import WorkbookItem
 
 logger = logging.getLogger("tableau.models.favorites_item")
 

--- a/tableauserverclient/models/fileupload_item.py
+++ b/tableauserverclient/models/fileupload_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 
 
 class FileuploadItem(object):
@@ -16,7 +16,7 @@ class FileuploadItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         fileupload_elem = parsed_response.find(".//t:fileUpload", namespaces=ns)
         fileupload_item = cls()
         fileupload_item._upload_session_id = fileupload_elem.get("uploadSessionId", None)

--- a/tableauserverclient/models/flow_item.py
+++ b/tableauserverclient/models/flow_item.py
@@ -1,3 +1,4 @@
+from defusedxml.ElementTree import fromstring
 import xml.etree.ElementTree as ET
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_nullable
@@ -105,7 +106,7 @@ class FlowItem(object):
 
     def _parse_common_elements(self, flow_xml, ns):
         if not isinstance(flow_xml, ET.Element):
-            flow_xml = ET.fromstring(flow_xml).find(".//t:flow", namespaces=ns)
+            flow_xml = fromstring(flow_xml).find(".//t:flow", namespaces=ns)
         if flow_xml is not None:
             (
                 _,
@@ -171,7 +172,7 @@ class FlowItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["FlowItem"]:
         all_flow_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_flow_xml = parsed_response.findall(".//t:flow", namespaces=ns)
 
         for flow_xml in all_flow_xml:

--- a/tableauserverclient/models/flow_item.py
+++ b/tableauserverclient/models/flow_item.py
@@ -1,18 +1,16 @@
-from defusedxml.ElementTree import fromstring
+import copy
 import xml.etree.ElementTree as ET
+from typing import List, Optional, TYPE_CHECKING, Set
+
+from defusedxml.ElementTree import fromstring
+
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_nullable
 from .tag_item import TagItem
 from ..datetime_helpers import parse_datetime
-import copy
-
-from typing import List, Optional, TYPE_CHECKING, Set
 
 if TYPE_CHECKING:
     import datetime
-    from .connection_item import ConnectionItem
-    from .permissions_item import Permission
-    from .dqw_item import DQWItem
 
 
 class FlowItem(object):

--- a/tableauserverclient/models/flow_run_item.py
+++ b/tableauserverclient/models/flow_run_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 from ..datetime_helpers import parse_datetime
 import itertools
 
@@ -74,7 +75,7 @@ class FlowRunItem(object):
     @classmethod
     def from_response(cls: Type["FlowRunItem"], resp: bytes, ns: Optional[Dict]) -> List["FlowRunItem"]:
         all_flowrun_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_flowrun_xml = itertools.chain(
             parsed_response.findall(".//t:flowRun[@id]", namespaces=ns),
             parsed_response.findall(".//t:flowRuns[@id]", namespaces=ns),

--- a/tableauserverclient/models/flow_run_item.py
+++ b/tableauserverclient/models/flow_run_item.py
@@ -1,9 +1,9 @@
-import xml.etree.ElementTree
-from defusedxml.ElementTree import fromstring
-from ..datetime_helpers import parse_datetime
 import itertools
-
 from typing import Dict, List, Optional, Type, TYPE_CHECKING
+
+from defusedxml.ElementTree import fromstring
+
+from ..datetime_helpers import parse_datetime
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -1,11 +1,11 @@
-import xml.etree.ElementTree
+from typing import Callable, List, Optional, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_empty, property_is_enum
 from .reference_item import ResourceReference
 from .user_item import UserItem
-
-from typing import Callable, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..server import Pager

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import property_not_empty, property_is_enum
 from .reference_item import ResourceReference
@@ -82,7 +83,7 @@ class GroupItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["GroupItem"]:
         all_group_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_group_xml = parsed_response.findall(".//t:group", namespaces=ns)
         for group_xml in all_group_xml:
             name = group_xml.get("name", None)

--- a/tableauserverclient/models/job_item.py
+++ b/tableauserverclient/models/job_item.py
@@ -1,10 +1,9 @@
-import xml.etree.ElementTree
+from typing import List, Optional, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from .flow_run_item import FlowRunItem
 from ..datetime_helpers import parse_datetime
-
-
-from typing import List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import datetime

--- a/tableauserverclient/models/job_item.py
+++ b/tableauserverclient/models/job_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 from .flow_run_item import FlowRunItem
 from ..datetime_helpers import parse_datetime
 
@@ -101,7 +102,7 @@ class JobItem(object):
 
     @classmethod
     def from_response(cls, xml, ns) -> List["JobItem"]:
-        parsed_response = ET.fromstring(xml)
+        parsed_response = fromstring(xml)
         all_tasks_xml = parsed_response.findall(".//t:job", namespaces=ns)
 
         all_tasks = [JobItem._parse_element(x, ns) for x in all_tasks_xml]
@@ -214,7 +215,7 @@ class BackgroundJobItem(object):
 
     @classmethod
     def from_response(cls, xml, ns) -> List["BackgroundJobItem"]:
-        parsed_response = ET.fromstring(xml)
+        parsed_response = fromstring(xml)
         all_tasks_xml = parsed_response.findall(".//t:backgroundJob", namespaces=ns)
         return [cls._parse_element(x, ns) for x in all_tasks_xml]
 

--- a/tableauserverclient/models/pagination_item.py
+++ b/tableauserverclient/models/pagination_item.py
@@ -1,4 +1,3 @@
-import xml.etree.ElementTree
 from defusedxml.ElementTree import fromstring
 
 

--- a/tableauserverclient/models/pagination_item.py
+++ b/tableauserverclient/models/pagination_item.py
@@ -1,4 +1,5 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
+from defusedxml.ElementTree import fromstring
 
 
 class PaginationItem(object):
@@ -21,7 +22,7 @@ class PaginationItem(object):
 
     @classmethod
     def from_response(cls, resp, ns) -> "PaginationItem":
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         pagination_xml = parsed_response.find("t:pagination", namespaces=ns)
         pagination_item = cls()
         if pagination_xml is not None:

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,9 +1,11 @@
-import xml.etree.ElementTree as ET
 import logging
+import xml.etree.ElementTree as ET
+
+from defusedxml.ElementTree import fromstring
 
 from .exceptions import UnknownGranteeTypeError, UnpopulatedPropertyError
-from .user_item import UserItem
 from .group_item import GroupItem
+from .user_item import UserItem
 
 logger = logging.getLogger("tableau.models.permissions_item")
 
@@ -53,7 +55,7 @@ class PermissionsRule(object):
 
     @classmethod
     def from_response(cls, resp, ns=None) -> List["PermissionsRule"]:
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
 
         rules = []
         permissions_rules_list_xml = parsed_response.findall(".//t:granteeCapabilities", namespaces=ns)

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,6 +1,5 @@
 import xml.etree.ElementTree as ET
-
-from .permissions_item import Permission
+from defusedxml.ElementTree import fromstring
 
 from .property_decorators import property_is_enum, property_not_empty
 from .exceptions import UnpopulatedPropertyError
@@ -97,7 +96,7 @@ class ProjectItem(object):
 
     def _parse_common_tags(self, project_xml, ns):
         if not isinstance(project_xml, ET.Element):
-            project_xml = ET.fromstring(project_xml).find(".//t:project", namespaces=ns)
+            project_xml = fromstring(project_xml).find(".//t:project", namespaces=ns)
 
         if project_xml is not None:
             (
@@ -137,7 +136,7 @@ class ProjectItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["ProjectItem"]:
         all_project_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_project_xml = parsed_response.findall(".//t:project", namespaces=ns)
 
         for project_xml in all_project_xml:

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,11 +1,10 @@
 import xml.etree.ElementTree as ET
+from typing import List, Optional
+
 from defusedxml.ElementTree import fromstring
 
-from .property_decorators import property_is_enum, property_not_empty
 from .exceptions import UnpopulatedPropertyError
-
-
-from typing import List, Optional, TYPE_CHECKING
+from .property_decorators import property_is_enum, property_not_empty
 
 
 class ProjectItem(object):

--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 from functools import wraps
+
 from ..datetime_helpers import parse_datetime
 
 

--- a/tableauserverclient/models/revision_item.py
+++ b/tableauserverclient/models/revision_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from ..datetime_helpers import parse_datetime
 from typing import List, Optional, TYPE_CHECKING, Type
 
@@ -58,7 +58,7 @@ class RevisionItem(object):
     @classmethod
     def from_response(cls, resp: bytes, ns, resource_item) -> List["RevisionItem"]:
         all_revision_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_revision_xml = parsed_response.findall(".//t:revision", namespaces=ns)
         for revision_xml in all_revision_xml:
             revision_item = cls()

--- a/tableauserverclient/models/revision_item.py
+++ b/tableauserverclient/models/revision_item.py
@@ -1,6 +1,8 @@
+from typing import List, Optional, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from ..datetime_helpers import parse_datetime
-from typing import List, Optional, TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -1,7 +1,8 @@
 import xml.etree.ElementTree as ET
-from defusedxml.ElementTree import fromstring
 from datetime import datetime
 from typing import Optional, Union
+
+from defusedxml.ElementTree import fromstring
 
 from .interval_item import (
     IntervalItem,

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from datetime import datetime
 from typing import Optional, Union
 
@@ -122,7 +123,7 @@ class ScheduleItem(object):
 
     def _parse_common_tags(self, schedule_xml, ns):
         if not isinstance(schedule_xml, ET.Element):
-            schedule_xml = ET.fromstring(schedule_xml).find(".//t:schedule", namespaces=ns)
+            schedule_xml = fromstring(schedule_xml).find(".//t:schedule", namespaces=ns)
         if schedule_xml is not None:
             (
                 _,
@@ -196,7 +197,7 @@ class ScheduleItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         return cls.from_element(parsed_response, ns)
 
     @classmethod
@@ -311,7 +312,7 @@ class ScheduleItem(object):
 
     @staticmethod
     def parse_add_to_schedule_response(response, ns):
-        parsed_response = ET.fromstring(response.content)
+        parsed_response = fromstring(response.content)
         warnings = ScheduleItem._read_warnings(parsed_response, ns)
         all_task_xml = parsed_response.findall(".//t:task", namespaces=ns)
 

--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 
 
 class ServerInfoItem(object):
@@ -21,7 +21,7 @@ class ServerInfoItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         product_version_tag = parsed_response.find(".//t:productVersion", namespaces=ns)
         rest_api_version_tag = parsed_response.find(".//t:restApiVersion", namespaces=ns)
 

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,5 +1,7 @@
 import xml.etree.ElementTree as ET
+
 from defusedxml.ElementTree import fromstring
+
 from .property_decorators import (
     property_is_enum,
     property_is_boolean,
@@ -8,7 +10,6 @@ from .property_decorators import (
     property_not_nullable,
     property_is_int,
 )
-
 
 VALID_CONTENT_URL_RE = r"^[a-zA-Z0-9_\-]*$"
 

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .property_decorators import (
     property_is_enum,
     property_is_boolean,
@@ -541,7 +542,7 @@ class SiteItem(object):
 
     def _parse_common_tags(self, site_xml, ns):
         if not isinstance(site_xml, ET.Element):
-            site_xml = ET.fromstring(site_xml).find(".//t:site", namespaces=ns)
+            site_xml = fromstring(site_xml).find(".//t:site", namespaces=ns)
         if site_xml is not None:
             (
                 _,
@@ -812,7 +813,7 @@ class SiteItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["SiteItem"]:
         all_site_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_site_xml = parsed_response.findall(".//t:site", namespaces=ns)
         for site_xml in all_site_xml:
             (

--- a/tableauserverclient/models/subscription_item.py
+++ b/tableauserverclient/models/subscription_item.py
@@ -1,8 +1,9 @@
-from defusedxml.ElementTree import fromstring
-from .target import Target
-from .property_decorators import property_is_boolean
-
 from typing import List, Type, TYPE_CHECKING
+
+from defusedxml.ElementTree import fromstring
+
+from .property_decorators import property_is_boolean
+from .target import Target
 
 if TYPE_CHECKING:
     from .target import Target

--- a/tableauserverclient/models/subscription_item.py
+++ b/tableauserverclient/models/subscription_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .target import Target
 from .property_decorators import property_is_boolean
 
@@ -77,7 +77,7 @@ class SubscriptionItem(object):
 
     @classmethod
     def from_response(cls: Type, xml: bytes, ns) -> List["SubscriptionItem"]:
-        parsed_response = ET.fromstring(xml)
+        parsed_response = fromstring(xml)
         all_subscriptions_xml = parsed_response.findall(".//t:subscription", namespaces=ns)
 
         all_subscriptions = [SubscriptionItem._parse_element(x, ns) for x in all_subscriptions_xml]

--- a/tableauserverclient/models/table_item.py
+++ b/tableauserverclient/models/table_item.py
@@ -1,5 +1,4 @@
-import xml.etree.ElementTree as ET
-
+from defusedxml.ElementTree import fromstring
 from .property_decorators import property_not_empty, property_is_boolean
 from .exceptions import UnpopulatedPropertyError
 
@@ -128,7 +127,7 @@ class TableItem(object):
     @classmethod
     def from_response(cls, resp, ns):
         all_table_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_table_xml = parsed_response.findall(".//t:table", namespaces=ns)
 
         for table_xml in all_table_xml:

--- a/tableauserverclient/models/table_item.py
+++ b/tableauserverclient/models/table_item.py
@@ -1,6 +1,7 @@
 from defusedxml.ElementTree import fromstring
-from .property_decorators import property_not_empty, property_is_boolean
+
 from .exceptions import UnpopulatedPropertyError
+from .property_decorators import property_not_empty, property_is_boolean
 
 
 class TableItem(object):

--- a/tableauserverclient/models/tag_item.py
+++ b/tableauserverclient/models/tag_item.py
@@ -1,10 +1,10 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 
 
 class TagItem(object):
     @classmethod
     def from_response(cls, resp, ns):
-        return cls.from_xml_element(ET.fromstring(resp), ns)
+        return cls.from_xml_element(fromstring(resp), ns)
 
     @classmethod
     def from_xml_element(cls, parsed_response, ns):

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .target import Target
 from .schedule_item import ScheduleItem
 from ..datetime_helpers import parse_datetime
@@ -43,7 +43,7 @@ class TaskItem(object):
 
     @classmethod
     def from_response(cls, xml, ns, task_type=Type.ExtractRefresh):
-        parsed_response = ET.fromstring(xml)
+        parsed_response = fromstring(xml)
         all_tasks_xml = parsed_response.findall(".//t:task/t:{}".format(task_type), namespaces=ns)
 
         all_tasks = (TaskItem._parse_element(x, ns) for x in all_tasks_xml)

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -1,6 +1,7 @@
 from defusedxml.ElementTree import fromstring
-from .target import Target
+
 from .schedule_item import ScheduleItem
+from .target import Target
 from ..datetime_helpers import parse_datetime
 
 

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -1,16 +1,17 @@
-from datetime import datetime
 import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Dict, List, Optional, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_is_enum,
     property_not_empty,
     property_not_nullable,
 )
-from ..datetime_helpers import parse_datetime
 from .reference_item import ResourceReference
-
-from typing import Dict, List, Optional, TYPE_CHECKING
+from ..datetime_helpers import parse_datetime
 
 if TYPE_CHECKING:
     from ..server.pager import Pager

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_is_enum,
@@ -140,7 +141,7 @@ class UserItem(object):
 
     def _parse_common_tags(self, user_xml, ns) -> "UserItem":
         if not isinstance(user_xml, ET.Element):
-            user_xml = ET.fromstring(user_xml).find(".//t:user", namespaces=ns)
+            user_xml = fromstring(user_xml).find(".//t:user", namespaces=ns)
         if user_xml is not None:
             (
                 _,
@@ -190,7 +191,7 @@ class UserItem(object):
     @classmethod
     def from_response(cls, resp, ns) -> List["UserItem"]:
         all_user_items = []
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_user_xml = parsed_response.findall(".//t:user", namespaces=ns)
         for user_xml in all_user_xml:
             (

--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from ..datetime_helpers import parse_datetime
 from .exceptions import UnpopulatedPropertyError
 from .tag_item import TagItem
@@ -126,7 +126,7 @@ class ViewItem(object):
 
     @classmethod
     def from_response(cls, resp, ns, workbook_id="") -> List["ViewItem"]:
-        return cls.from_xml_element(ET.fromstring(resp), ns, workbook_id)
+        return cls.from_xml_element(fromstring(resp), ns, workbook_id)
 
     @classmethod
     def from_xml_element(cls, parsed_response, ns, workbook_id="") -> List["ViewItem"]:

--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -1,10 +1,11 @@
+import copy
+from typing import Callable, Iterable, List, Optional, Set, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
-from ..datetime_helpers import parse_datetime
+
 from .exceptions import UnpopulatedPropertyError
 from .tag_item import TagItem
-import copy
-
-from typing import ByteString, Callable, Iterable, List, Optional, Set, TYPE_CHECKING
+from ..datetime_helpers import parse_datetime
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/tableauserverclient/models/webhook_item.py
+++ b/tableauserverclient/models/webhook_item.py
@@ -1,8 +1,8 @@
-import xml.etree.ElementTree as ET
-
 import re
+import xml.etree.ElementTree as ET
+from typing import List, Optional, Tuple, Type
 
-from typing import List, Optional, TYPE_CHECKING, Tuple, Type
+from defusedxml.ElementTree import fromstring
 
 NAMESPACE_RE = re.compile(r"^{.*}")
 
@@ -50,7 +50,7 @@ class WebhookItem(object):
     @classmethod
     def from_response(cls: Type["WebhookItem"], resp: bytes, ns) -> List["WebhookItem"]:
         all_webhooks_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_webhooks_xml = parsed_response.findall(".//t:webhook", namespaces=ns)
         for webhook_xml in all_webhooks_xml:
             values = cls._parse_element(webhook_xml, ns)

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from .exceptions import UnpopulatedPropertyError
 from .property_decorators import (
     property_not_nullable,
@@ -184,7 +185,7 @@ class WorkbookItem(object):
 
     def _parse_common_tags(self, workbook_xml, ns):
         if not isinstance(workbook_xml, ET.Element):
-            workbook_xml = ET.fromstring(workbook_xml).find(".//t:workbook", namespaces=ns)
+            workbook_xml = fromstring(workbook_xml).find(".//t:workbook", namespaces=ns)
         if workbook_xml is not None:
             (
                 _,
@@ -277,7 +278,7 @@ class WorkbookItem(object):
     @classmethod
     def from_response(cls, resp: str, ns: Dict[str, str]) -> List["WorkbookItem"]:
         all_workbook_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_workbook_xml = parsed_response.findall(".//t:workbook", namespaces=ns)
         for workbook_xml in all_workbook_xml:
             (

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,6 +1,12 @@
+import copy
+import uuid
 import xml.etree.ElementTree as ET
+from typing import Dict, List, Optional, Set, TYPE_CHECKING
+
 from defusedxml.ElementTree import fromstring
+
 from .exceptions import UnpopulatedPropertyError
+from .permissions_item import PermissionsRule
 from .property_decorators import (
     property_not_nullable,
     property_is_boolean,
@@ -8,12 +14,7 @@ from .property_decorators import (
 )
 from .tag_item import TagItem
 from .view_item import ViewItem
-from .permissions_item import PermissionsRule
 from ..datetime_helpers import parse_datetime
-import copy
-import uuid
-
-from typing import Dict, List, Optional, Set, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from .connection_item import ConnectionItem

--- a/tableauserverclient/namespace.py
+++ b/tableauserverclient/namespace.py
@@ -1,5 +1,5 @@
-from xml.etree import ElementTree as ET
 import re
+from defusedxml.ElementTree import fromstring
 
 OLD_NAMESPACE = "http://tableausoftware.com/api"
 NEW_NAMESPACE = "http://tableau.com/api"
@@ -25,7 +25,7 @@ class Namespace(object):
         if not xml.startswith(b"<?xml"):
             return  # Not an xml file, don't detect anything
 
-        root = ET.fromstring(xml)
+        root = fromstring(xml)
         matches = NAMESPACE_RE.match(root.tag)
         if matches:
             detected_ns = matches.group(1)

--- a/tableauserverclient/namespace.py
+++ b/tableauserverclient/namespace.py
@@ -1,4 +1,5 @@
 import re
+
 from defusedxml.ElementTree import fromstring
 
 OLD_NAMESPACE = "http://tableausoftware.com/api"

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -1,39 +1,30 @@
-from .request_factory import RequestFactory
-from .request_options import (
-    CSVRequestOptions,
-    ImageRequestOptions,
-    PDFRequestOptions,
-    RequestOptions,
-)
-from .filter import Filter
-from .sort import Sort
 from .. import (
-    ConnectionItem,
-    DataAlertItem,
-    DatasourceItem,
-    DatabaseItem,
-    DQWItem,
-    JobItem,
     BackgroundJobItem,
+    ColumnItem,
+    ConnectionItem,
+    DQWItem,
+    DataAlertItem,
+    DatabaseItem,
+    DatasourceItem,
+    FlowItem,
+    FlowRunItem,
     GroupItem,
+    JobItem,
     PaginationItem,
+    Permission,
+    PermissionsRule,
     ProjectItem,
+    RevisionItem,
     ScheduleItem,
     SiteItem,
+    SubscriptionItem,
+    TableItem,
     TableauAuth,
+    TaskItem,
     UserItem,
     ViewItem,
-    WorkbookItem,
-    TableItem,
-    TaskItem,
-    SubscriptionItem,
-    PermissionsRule,
-    Permission,
-    ColumnItem,
-    FlowItem,
     WebhookItem,
-    FlowRunItem,
-    RevisionItem,
+    WorkbookItem,
 )
 from .endpoint import (
     Auth,
@@ -54,6 +45,15 @@ from .endpoint import (
     Flows,
     Favorites,
 )
-from .server import Server
-from .pager import Pager
 from .exceptions import NotSignedInError
+from .filter import Filter
+from .pager import Pager
+from .request_factory import RequestFactory
+from .request_options import (
+    CSVRequestOptions,
+    ImageRequestOptions,
+    PDFRequestOptions,
+    RequestOptions,
+)
+from .server import Server
+from .sort import Sort

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -1,3 +1,14 @@
+# These two imports must come first
+from .request_factory import RequestFactory
+from .request_options import (
+    CSVRequestOptions,
+    ImageRequestOptions,
+    PDFRequestOptions,
+    RequestOptions,
+)
+
+from .filter import Filter
+from .sort import Sort
 from .. import (
     BackgroundJobItem,
     ColumnItem,
@@ -45,15 +56,6 @@ from .endpoint import (
     Flows,
     Favorites,
 )
-from .exceptions import NotSignedInError
-from .filter import Filter
-from .pager import Pager
-from .request_factory import RequestFactory
-from .request_options import (
-    CSVRequestOptions,
-    ImageRequestOptions,
-    PDFRequestOptions,
-    RequestOptions,
-)
 from .server import Server
-from .sort import Sort
+from .pager import Pager
+from .exceptions import NotSignedInError

--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -1,18 +1,18 @@
 from .auth_endpoint import Auth
 from .data_acceleration_report_endpoint import DataAccelerationReport
 from .data_alert_endpoint import DataAlerts
-from .datasources_endpoint import Datasources
 from .databases_endpoint import Databases
+from .datasources_endpoint import Datasources
 from .endpoint import Endpoint
-from .favorites_endpoint import Favorites
-from .fileuploads_endpoint import Fileuploads
-from .flows_endpoint import Flows
-from .flow_runs_endpoint import FlowRuns
 from .exceptions import (
     ServerResponseError,
     MissingRequiredFieldError,
     ServerInfoEndpointNotFoundError,
 )
+from .favorites_endpoint import Favorites
+from .fileuploads_endpoint import Fileuploads
+from .flow_runs_endpoint import FlowRuns
+from .flows_endpoint import Flows
 from .groups_endpoint import Groups
 from .jobs_endpoint import Jobs
 from .metadata_endpoint import Metadata

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -1,7 +1,7 @@
 from ..request_factory import RequestFactory
 from .exceptions import ServerResponseError
 from .endpoint import Endpoint, api
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 import logging
 
 logger = logging.getLogger("tableau.endpoint.auth")
@@ -29,7 +29,7 @@ class Auth(Endpoint):
         server_response = self.parent_srv.session.post(url, data=signin_req, **self.parent_srv.http_options)
         self.parent_srv._namespace.detect(server_response.content)
         self._check_status(server_response)
-        parsed_response = ET.fromstring(server_response.content)
+        parsed_response = fromstring(server_response.content)
         site_id = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("id", None)
         user_id = parsed_response.find(".//t:user", namespaces=self.parent_srv.namespace).get("id", None)
         auth_token = parsed_response.find("t:credentials", namespaces=self.parent_srv.namespace).get("token", None)
@@ -65,7 +65,7 @@ class Auth(Endpoint):
                 raise e
         self.parent_srv._namespace.detect(server_response.content)
         self._check_status(server_response)
-        parsed_response = ET.fromstring(server_response.content)
+        parsed_response = fromstring(server_response.content)
         site_id = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("id", None)
         user_id = parsed_response.find(".//t:user", namespaces=self.parent_srv.namespace).get("id", None)
         auth_token = parsed_response.find("t:credentials", namespaces=self.parent_srv.namespace).get("token", None)

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -1,8 +1,10 @@
-from ..request_factory import RequestFactory
-from .exceptions import ServerResponseError
-from .endpoint import Endpoint, api
-from defusedxml.ElementTree import fromstring
 import logging
+
+from defusedxml.ElementTree import fromstring
+
+from .endpoint import Endpoint, api
+from .exceptions import ServerResponseError
+from ..request_factory import RequestFactory
 
 logger = logging.getLogger("tableau.endpoint.auth")
 

--- a/tableauserverclient/server/endpoint/data_acceleration_report_endpoint.py
+++ b/tableauserverclient/server/endpoint/data_acceleration_report_endpoint.py
@@ -1,10 +1,9 @@
+import logging
+
+from .default_permissions_endpoint import _DefaultPermissionsEndpoint
 from .endpoint import api, Endpoint
 from .permissions_endpoint import _PermissionsEndpoint
-from .default_permissions_endpoint import _DefaultPermissionsEndpoint
-
 from ...models.data_acceleration_report_item import DataAccelerationReportItem
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.data_acceleration_report")
 

--- a/tableauserverclient/server/endpoint/data_alert_endpoint.py
+++ b/tableauserverclient/server/endpoint/data_alert_endpoint.py
@@ -1,9 +1,8 @@
+import logging
+
 from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
-
 from .. import RequestFactory, DataAlertItem, PaginationItem, UserItem
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.dataAlerts")
 

--- a/tableauserverclient/server/endpoint/databases_endpoint.py
+++ b/tableauserverclient/server/endpoint/databases_endpoint.py
@@ -1,12 +1,11 @@
+import logging
+
+from .default_permissions_endpoint import _DefaultPermissionsEndpoint
+from .dqw_endpoint import _DataQualityWarningEndpoint
 from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
-from .default_permissions_endpoint import _DefaultPermissionsEndpoint
-from .dqw_endpoint import _DataQualityWarningEndpoint
-
 from .. import RequestFactory, DatabaseItem, TableItem, PaginationItem, Permission
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.databases")
 

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -1,27 +1,10 @@
-from .endpoint import QuerysetEndpoint, api, parameter_added_in
-from .exceptions import InternalServerError, MissingRequiredFieldError
-from .permissions_endpoint import _PermissionsEndpoint
-from .dqw_endpoint import _DataQualityWarningEndpoint
-from .resource_tagger import _ResourceTagger
-from .. import RequestFactory, DatasourceItem, PaginationItem, ConnectionItem, RequestOptions
-from ..query import QuerySet
-from ...filesys_helpers import (
-    to_filename,
-    make_download_path,
-    get_file_type,
-    get_file_object_size,
-)
-from ...models.job_item import JobItem
-from ...models import ConnectionCredentials, RevisionItem
-
-import io
-import os
-import logging
-import copy
 import cgi
-from contextlib import closing
+import copy
+import io
 import json
-
+import logging
+import os
+from contextlib import closing
 from pathlib import Path
 from typing import (
     List,
@@ -32,6 +15,21 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+
+from .dqw_endpoint import _DataQualityWarningEndpoint
+from .endpoint import QuerysetEndpoint, api, parameter_added_in
+from .exceptions import InternalServerError, MissingRequiredFieldError
+from .permissions_endpoint import _PermissionsEndpoint
+from .resource_tagger import _ResourceTagger
+from .. import RequestFactory, DatasourceItem, PaginationItem, ConnectionItem, RequestOptions
+from ...filesys_helpers import (
+    to_filename,
+    make_download_path,
+    get_file_type,
+    get_file_object_size,
+)
+from ...models import ConnectionCredentials, RevisionItem
+from ...models.job_item import JobItem
 
 io_types = (io.BytesIO, io.BufferedReader)
 

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -1,11 +1,9 @@
 import logging
 
-from .. import RequestFactory
-from ...models import PermissionsRule
-
 from .endpoint import Endpoint
 from .exceptions import MissingRequiredFieldError
-
+from .. import RequestFactory
+from ...models import PermissionsRule
 
 logger = logging.getLogger(__name__)
 

--- a/tableauserverclient/server/endpoint/dqw_endpoint.py
+++ b/tableauserverclient/server/endpoint/dqw_endpoint.py
@@ -1,10 +1,8 @@
 import logging
 
-from .. import RequestFactory, DQWItem
-
 from .endpoint import Endpoint
 from .exceptions import MissingRequiredFieldError
-
+from .. import RequestFactory, DQWItem
 
 logger = logging.getLogger(__name__)
 

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,15 +1,15 @@
+import logging
+from distutils.version import LooseVersion as Version
+from functools import wraps
+from xml.etree.ElementTree import ParseError
+
 from .exceptions import (
     ServerResponseError,
     InternalServerError,
     NonXMLResponseError,
     EndpointUnavailableError,
 )
-from functools import wraps
-from xml.etree.ElementTree import ParseError
 from ..query import QuerySet
-import logging
-
-from distutils.version import LooseVersion as Version
 
 logger = logging.getLogger("tableau.endpoint")
 

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 
 
 class ServerResponseError(Exception):
@@ -14,7 +14,7 @@ class ServerResponseError(Exception):
     @classmethod
     def from_response(cls, resp, ns):
         # Check elements exist before .text
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         error_response = cls(
             parsed_response.find("t:error", namespaces=ns).get("code", ""),
             parsed_response.find(".//t:summary", namespaces=ns).text,

--- a/tableauserverclient/server/endpoint/favorites_endpoint.py
+++ b/tableauserverclient/server/endpoint/favorites_endpoint.py
@@ -1,7 +1,8 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .. import RequestFactory
 from ...models import FavoriteItem
-import logging
 
 logger = logging.getLogger("tableau.endpoint.favorites")
 

--- a/tableauserverclient/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverclient/server/endpoint/fileuploads_endpoint.py
@@ -1,9 +1,8 @@
-from .exceptions import MissingRequiredFieldError
+import logging
+
 from .endpoint import Endpoint, api
 from .. import RequestFactory
 from ...models.fileupload_item import FileuploadItem
-import os.path
-import logging
 
 # For when a datasource is over 64MB, break it into 5MB(standard chunk size) chunks
 CHUNK_SIZE = 1024 * 1024 * 5  # 5MB

--- a/tableauserverclient/server/endpoint/flow_runs_endpoint.py
+++ b/tableauserverclient/server/endpoint/flow_runs_endpoint.py
@@ -1,11 +1,10 @@
-from .endpoint import Endpoint, QuerysetEndpoint, api
+import logging
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from .endpoint import QuerysetEndpoint, api
 from .exceptions import FlowRunFailedException, FlowRunCancelledException
 from .. import FlowRunItem, PaginationItem
 from ...exponential_backoff import ExponentialBackoffTimer
-
-import logging
-
-from typing import List, Optional, Tuple, TYPE_CHECKING, Union
 
 logger = logging.getLogger("tableau.endpoint.flowruns")
 

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -1,19 +1,18 @@
+import cgi
+import copy
+import logging
+import os
+from contextlib import closing
+from typing import Iterable, List, Optional, TYPE_CHECKING, Tuple, Union
+
+from .dqw_endpoint import _DataQualityWarningEndpoint
 from .endpoint import Endpoint, api
 from .exceptions import InternalServerError, MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
-from .dqw_endpoint import _DataQualityWarningEndpoint
 from .resource_tagger import _ResourceTagger
 from .. import RequestFactory, FlowItem, PaginationItem, ConnectionItem
 from ...filesys_helpers import to_filename, make_download_path
 from ...models.job_item import JobItem
-
-import os
-import logging
-import copy
-import cgi
-from contextlib import closing
-
-from typing import Iterable, List, Optional, TYPE_CHECKING, Tuple, Union
 
 # The maximum size of a file that can be published in a single request is 64MB
 FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB
@@ -25,7 +24,7 @@ logger = logging.getLogger("tableau.endpoint.flows")
 if TYPE_CHECKING:
     from .. import DQWItem
     from ..request_options import RequestOptions
-    from ...models.permissions_item import Permission, PermissionsRule
+    from ...models.permissions_item import PermissionsRule
 
 
 FilePath = Union[str, os.PathLike]

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -1,9 +1,9 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, GroupItem, UserItem, PaginationItem, JobItem
 from ..pager import Pager
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.groups")
 

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -1,14 +1,14 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import JobCancelledException, JobFailedException
 from .. import JobItem, BackgroundJobItem, PaginationItem
 from ..request_options import RequestOptionsBase
 from ...exponential_backoff import ExponentialBackoffTimer
 
-import logging
-
 logger = logging.getLogger("tableau.endpoint.jobs")
 
-from typing import List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import List, Optional, Tuple, Union
 
 
 class Jobs(Endpoint):

--- a/tableauserverclient/server/endpoint/metadata_endpoint.py
+++ b/tableauserverclient/server/endpoint/metadata_endpoint.py
@@ -1,8 +1,8 @@
+import json
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import GraphQLError, InvalidGraphQLQuery
-import logging
-import json
-
 
 logger = logging.getLogger("tableau.endpoint.metadata")
 

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -5,10 +5,9 @@ from .. import RequestFactory, PermissionsRule
 from .endpoint import Endpoint
 from .exceptions import MissingRequiredFieldError
 
+from typing import Callable, TYPE_CHECKING, List, Union
 
 logger = logging.getLogger(__name__)
-
-from typing import Callable, TYPE_CHECKING, List, Union
 
 if TYPE_CHECKING:
     from ...models import DatasourceItem, ProjectItem, WorkbookItem, ViewItem
@@ -21,9 +20,9 @@ TableauItem = Union["DatasourceItem", "ProjectItem", "WorkbookItem", "ViewItem"]
 class _PermissionsEndpoint(Endpoint):
     """Adds permission model to another endpoint
 
-    Tableau permissions model is identical between objects but they are nested under
+    Tableau permissions model is identical between objects, but they are nested under
     the parent object endpoint (i.e. permissions for workbooks are under
-    /workbooks/:id/permission).  This class is meant to be instantated inside a
+    /workbooks/:id/permission).  This class is meant to be instantiated inside a
     parent endpoint which has these supported endpoints
     """
 

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -1,12 +1,10 @@
-from tableauserverclient.server.request_factory import ProjectRequest
+import logging
+
+from .default_permissions_endpoint import _DefaultPermissionsEndpoint
 from .endpoint import api, Endpoint, XML_CONTENT_TYPE
 from .exceptions import MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
-from .default_permissions_endpoint import _DefaultPermissionsEndpoint
-
 from .. import RequestFactory, RequestOptions, ProjectItem, PaginationItem, Permission
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.projects")
 

--- a/tableauserverclient/server/endpoint/resource_tagger.py
+++ b/tableauserverclient/server/endpoint/resource_tagger.py
@@ -1,10 +1,11 @@
+import copy
+import logging
+import urllib.parse
+
 from .endpoint import Endpoint
 from .exceptions import EndpointUnavailableError, ServerResponseError
 from .. import RequestFactory
 from ...models.tag_item import TagItem
-import logging
-import copy
-import urllib.parse
 
 logger = logging.getLogger("tableau.endpoint.resource_tagger")
 

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -1,10 +1,11 @@
+import copy
+import logging
+from collections import namedtuple
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, PaginationItem, ScheduleItem, TaskItem
-import logging
-import copy
-from collections import namedtuple
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 logger = logging.getLogger("tableau.endpoint.schedules")
 # Oh to have a first class Result concept in Python...

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -1,3 +1,5 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import (
     ServerResponseError,
@@ -5,7 +7,6 @@ from .exceptions import (
     EndpointUnavailableError,
 )
 from ...models import ServerInfoItem
-import logging
 
 logger = logging.getLogger("tableau.endpoint.server_info")
 

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -1,9 +1,9 @@
+import copy
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, SiteItem, PaginationItem
-
-import copy
-import logging
 
 logger = logging.getLogger("tableau.endpoint.sites")
 

--- a/tableauserverclient/server/endpoint/subscriptions_endpoint.py
+++ b/tableauserverclient/server/endpoint/subscriptions_endpoint.py
@@ -1,8 +1,8 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import RequestFactory, SubscriptionItem, PaginationItem
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.subscriptions")
 

--- a/tableauserverclient/server/endpoint/tables_endpoint.py
+++ b/tableauserverclient/server/endpoint/tables_endpoint.py
@@ -1,12 +1,11 @@
+import logging
+
+from .dqw_endpoint import _DataQualityWarningEndpoint
 from .endpoint import api, Endpoint
 from .exceptions import MissingRequiredFieldError
 from .permissions_endpoint import _PermissionsEndpoint
-from .dqw_endpoint import _DataQualityWarningEndpoint
-from ..pager import Pager
-
 from .. import RequestFactory, TableItem, ColumnItem, PaginationItem
-
-import logging
+from ..pager import Pager
 
 logger = logging.getLogger("tableau.endpoint.tables")
 

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -1,8 +1,8 @@
+import logging
+
 from .endpoint import Endpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import TaskItem, PaginationItem, RequestFactory
-
-import logging
 
 logger = logging.getLogger("tableau.endpoint.tasks")
 

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -1,4 +1,7 @@
+import copy
+import logging
 from typing import List, Tuple
+
 from .endpoint import QuerysetEndpoint, api
 from .exceptions import MissingRequiredFieldError
 from .. import (
@@ -10,9 +13,6 @@ from .. import (
     GroupItem,
 )
 from ..pager import Pager
-
-import copy
-import logging
 
 logger = logging.getLogger("tableau.endpoint.users")
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -1,11 +1,11 @@
+import logging
+from contextlib import closing
+
 from .endpoint import QuerysetEndpoint, api
 from .exceptions import MissingRequiredFieldError
-from .resource_tagger import _ResourceTagger
 from .permissions_endpoint import _PermissionsEndpoint
+from .resource_tagger import _ResourceTagger
 from .. import ViewItem, PaginationItem
-
-from contextlib import closing
-import logging
 
 logger = logging.getLogger("tableau.endpoint.views")
 

--- a/tableauserverclient/server/endpoint/webhooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/webhooks_endpoint.py
@@ -1,8 +1,8 @@
-from .endpoint import Endpoint, api
-from ...models import WebhookItem, PaginationItem
-from .. import RequestFactory
-
 import logging
+
+from .endpoint import Endpoint, api
+from .. import RequestFactory
+from ...models import WebhookItem, PaginationItem
 
 logger = logging.getLogger("tableau.endpoint.webhooks")
 

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,25 +1,10 @@
-from .endpoint import QuerysetEndpoint, api, parameter_added_in
-from .exceptions import InternalServerError, MissingRequiredFieldError
-from .permissions_endpoint import _PermissionsEndpoint
-from .resource_tagger import _ResourceTagger
-from .. import RequestFactory, WorkbookItem, ConnectionItem, ViewItem, PaginationItem
-from ...models.job_item import JobItem
-from ...models.revision_item import RevisionItem
-from ...filesys_helpers import (
-    to_filename,
-    make_download_path,
-    get_file_type,
-    get_file_object_size,
-)
-
-import os
-from pathlib import Path
+import cgi
+import copy
 import io
 import logging
-import copy
-import cgi
+import os
 from contextlib import closing
-
+from pathlib import Path
 from typing import (
     List,
     Optional,
@@ -28,6 +13,20 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+
+from .endpoint import QuerysetEndpoint, api, parameter_added_in
+from .exceptions import InternalServerError, MissingRequiredFieldError
+from .permissions_endpoint import _PermissionsEndpoint
+from .resource_tagger import _ResourceTagger
+from .. import RequestFactory, WorkbookItem, ConnectionItem, ViewItem, PaginationItem
+from ...filesys_helpers import (
+    to_filename,
+    make_download_path,
+    get_file_type,
+    get_file_object_size,
+)
+from ...models.job_item import JobItem
+from ...models.revision_item import RevisionItem
 
 if TYPE_CHECKING:
     from ..server import Server

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -1,5 +1,5 @@
-from .request_options import RequestOptions
 from .filter import Filter
+from .request_options import RequestOptions
 from .sort import Sort
 
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1,17 +1,16 @@
 import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional, Tuple, Iterable
 
 from requests.packages.urllib3.fields import RequestField
 from requests.packages.urllib3.filepost import encode_multipart_formdata
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Iterable
 
-from ..models import TaskItem, UserItem, GroupItem, PermissionsRule, FavoriteItem
-
-from ..models import SubscriptionItem
+from ..models import ConnectionItem
 from ..models import DataAlertItem
 from ..models import FlowItem
-from ..models import ConnectionItem
-from ..models import SiteItem
 from ..models import ProjectItem
+from ..models import SiteItem
+from ..models import SubscriptionItem
+from ..models import TaskItem, UserItem, GroupItem, PermissionsRule, FavoriteItem
 from ..models import WebhookItem
 
 

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -1,7 +1,8 @@
-import xml.etree.ElementTree as ET
+from distutils.version import LooseVersion as Version
 
-from .exceptions import NotSignedInError
-from ..namespace import Namespace
+import requests
+from defusedxml.ElementTree import fromstring
+
 from .endpoint import (
     Sites,
     Views,
@@ -31,10 +32,8 @@ from .endpoint.exceptions import (
     EndpointUnavailableError,
     ServerInfoEndpointNotFoundError,
 )
-
-import requests
-
-from distutils.version import LooseVersion as Version
+from .exceptions import NotSignedInError
+from ..namespace import Namespace
 
 _PRODUCT_TO_REST_VERSION = {
     "10.0": "2.3",
@@ -107,7 +106,7 @@ class Server(object):
 
     def _get_legacy_version(self):
         response = self._session.get(self.server_address + "/auth?format=xml")
-        info_xml = ET.fromstring(response.content)
+        info_xml = fromstring(response.content)
         prod_version = info_xml.find(".//product_version").text
         version = _PRODUCT_TO_REST_VERSION.get(prod_version, "2.1")  # 2.1
         return version

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -1,6 +1,6 @@
-from contextlib import contextmanager
-import unittest
 import os.path
+import unittest
+from contextlib import contextmanager
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,6 +1,8 @@
-import unittest
 import os.path
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_data_acceleration_report.py
+++ b/test/test_data_acceleration_report.py
@@ -1,9 +1,9 @@
 import unittest
-import os
+
 import requests_mock
-import xml.etree.ElementTree as ET
+
 import tableauserverclient as TSC
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset
 
 GET_XML = "data_acceleration_report.xml"
 

--- a/test/test_dataalert.py
+++ b/test/test_dataalert.py
@@ -1,12 +1,7 @@
 import unittest
-import os
 import requests_mock
-import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
-from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset
 
 GET_XML = "data_alerts_get.xml"
 GET_BY_ID_XML = "data_alerts_get_by_id.xml"

--- a/test/test_dataalert.py
+++ b/test/test_dataalert.py
@@ -1,5 +1,7 @@
 import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from ._utils import read_xml_asset
 

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,12 +1,7 @@
 import unittest
-import os
 import requests_mock
-import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
-from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset, asset
 
 GET_XML = "database_get.xml"
 POPULATE_PERMISSIONS_XML = "database_populate_permissions.xml"

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,5 +1,7 @@
 import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from ._utils import read_xml_asset, asset
 

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -3,7 +3,7 @@ import unittest
 from io import BytesIO
 import os
 import requests_mock
-import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from zipfile import ZipFile
 import tempfile
 
@@ -558,7 +558,7 @@ class DatasourceTests(unittest.TestCase):
 
         response = RequestFactory.Datasource._generate_xml(new_datasource, connections=[connection1, connection2])
         # Can't use ConnectionItem parser due to xml namespace problems
-        connection_results = ET.fromstring(response).findall(".//connection")
+        connection_results = fromstring(response).findall(".//connection")
 
         self.assertEqual(connection_results[0].get("serverAddress", None), "mysql.test.com")
         self.assertEqual(connection_results[0].find("connectionCredentials").get("name", None), "test")  # type: ignore[union-attr]
@@ -571,7 +571,7 @@ class DatasourceTests(unittest.TestCase):
 
         response = RequestFactory.Datasource._generate_xml(new_datasource, connection_credentials=connection_creds)
         #  Can't use ConnectionItem parser due to xml namespace problems
-        credentials = ET.fromstring(response).findall(".//connectionCredentials")
+        credentials = fromstring(response).findall(".//connectionCredentials")
 
         self.assertEqual(len(credentials), 1)
         self.assertEqual(credentials[0].get("name", None), "test")

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -1,15 +1,16 @@
-from tableauserverclient.server.endpoint.fileuploads_endpoint import Fileuploads
+import os
+import tempfile
 import unittest
 from io import BytesIO
-import os
+from zipfile import ZipFile
+
 import requests_mock
 from defusedxml.ElementTree import fromstring
-from zipfile import ZipFile
-import tempfile
 
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 from tableauserverclient.server.endpoint.exceptions import InternalServerError
+from tableauserverclient.server.endpoint.fileuploads_endpoint import Fileuploads
 from tableauserverclient.server.request_factory import RequestFactory
 from ._utils import read_xml_asset, read_xml_assets, asset
 

--- a/test/test_datasource_model.py
+++ b/test/test_datasource_model.py
@@ -1,5 +1,5 @@
-import datetime
 import unittest
+
 import tableauserverclient as TSC
 
 

--- a/test/test_exponential_backoff.py
+++ b/test/test_exponential_backoff.py
@@ -1,6 +1,7 @@
 import unittest
-from ._utils import mocked_time
+
 from tableauserverclient.exponential_backoff import ExponentialBackoffTimer
+from ._utils import mocked_time
 
 
 class ExponentialBackoffTests(unittest.TestCase):

--- a/test/test_favorites.py
+++ b/test/test_favorites.py
@@ -1,5 +1,7 @@
 import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from ._utils import read_xml_asset
 

--- a/test/test_favorites.py
+++ b/test/test_favorites.py
@@ -1,12 +1,7 @@
 import unittest
-import os
 import requests_mock
-import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
-from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset
 
 GET_FAVORITES_XML = "favorites_get.xml"
 ADD_FAVORITE_WORKBOOK_XML = "favorites_add_workbook.xml"

--- a/test/test_filesys_helpers.py
+++ b/test/test_filesys_helpers.py
@@ -1,6 +1,6 @@
+import os
 import unittest
 from io import BytesIO
-import os
 from xml.etree import ElementTree as ET
 from zipfile import ZipFile
 

--- a/test/test_fileuploads.py
+++ b/test/test_fileuploads.py
@@ -1,9 +1,10 @@
 import os
-import requests_mock
 import unittest
 
-from ._utils import asset
+import requests_mock
+
 from tableauserverclient.server import Server
+from ._utils import asset
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 FILEUPLOAD_INITIALIZE = os.path.join(TEST_ASSET_DIR, "fileupload_initialize.xml")

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -1,12 +1,8 @@
 import unittest
-import os
 import requests_mock
-import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset, asset
 
 GET_XML = "flow_get.xml"
 POPULATE_CONNECTIONS_XML = "flow_populate_connections.xml"

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -1,5 +1,7 @@
 import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 from ._utils import read_xml_asset, asset

--- a/test/test_flowruns.py
+++ b/test/test_flowruns.py
@@ -1,11 +1,10 @@
 import unittest
-import os
+
 import requests_mock
-import xml.etree.ElementTree as ET
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 from tableauserverclient.server.endpoint.exceptions import FlowRunFailedException
-from tableauserverclient.server.request_factory import RequestFactory
 from ._utils import read_xml_asset, mocked_time
 
 GET_XML = "flow_runs_get.xml"

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,7 +1,9 @@
 # encoding=utf-8
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 

--- a/test/test_group_model.py
+++ b/test/test_group_model.py
@@ -1,4 +1,5 @@
 import unittest
+
 import tableauserverclient as TSC
 
 

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -1,7 +1,9 @@
-import unittest
 import os
+import unittest
 from datetime import datetime
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import utc
 from tableauserverclient.server.endpoint.exceptions import JobFailedException

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,9 +1,10 @@
-import unittest
-import os.path
 import json
-import requests_mock
-import tableauserverclient as TSC
+import os.path
+import unittest
 
+import requests_mock
+
+import tableauserverclient as TSC
 from tableauserverclient.server.endpoint.exceptions import GraphQLError
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -1,6 +1,8 @@
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1,9 +1,10 @@
-import unittest
 import os
-import requests_mock
-import tableauserverclient as TSC
+import unittest
 
-from ._utils import read_xml_asset, read_xml_assets, asset
+import requests_mock
+
+import tableauserverclient as TSC
+from ._utils import read_xml_asset, asset
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_project_model.py
+++ b/test/test_project_model.py
@@ -1,4 +1,5 @@
 import unittest
+
 import tableauserverclient as TSC
 
 

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -1,8 +1,9 @@
-import unittest
 import os
 import re
-import requests
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -1,10 +1,10 @@
-import unittest
 import re
+import unittest
+
 import requests
 import requests_mock
 
 import tableauserverclient as TSC
-
 from tableauserverclient.server.endpoint.exceptions import InternalServerError, NonXMLResponseError
 
 

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1,7 +1,9 @@
-from datetime import time
-import unittest
 import os
+import unittest
+from datetime import time
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -1,6 +1,8 @@
-import unittest
 import os.path
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -1,6 +1,8 @@
-import unittest
 import os.path
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_site_model.py
+++ b/test/test_site_model.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import unittest
+
 import tableauserverclient as TSC
 
 

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -1,7 +1,8 @@
-import unittest
 import re
-import requests
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 

--- a/test/test_subscription.py
+++ b/test/test_subscription.py
@@ -1,6 +1,8 @@
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,5 +1,7 @@
 import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from ._utils import read_xml_asset
 

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,12 +1,7 @@
 import unittest
-import os
 import requests_mock
-import xml.etree.ElementTree as ET
 import tableauserverclient as TSC
-from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import read_xml_asset
 
 GET_XML = "table_get.xml"
 UPDATE_XML = "table_update.xml"

--- a/test/test_tableauauth_model.py
+++ b/test/test_tableauauth_model.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+
 import tableauserverclient as TSC
 
 

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -1,9 +1,11 @@
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
-from tableauserverclient.models.task_item import TaskItem
 from tableauserverclient.datetime_helpers import parse_datetime
+from tableauserverclient.models.task_item import TaskItem
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,6 +1,8 @@
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
 

--- a/test/test_user_model.py
+++ b/test/test_user_model.py
@@ -1,4 +1,5 @@
 import unittest
+
 import tableauserverclient as TSC
 
 

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -1,10 +1,11 @@
-import unittest
 import os
-import requests_mock
-import tableauserverclient as TSC
+import unittest
 
-from tableauserverclient.datetime_helpers import format_datetime
+import requests_mock
+
+import tableauserverclient as TSC
 from tableauserverclient import UserItem, GroupItem, PermissionsRule
+from tableauserverclient.datetime_helpers import format_datetime
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -1,10 +1,11 @@
-import unittest
 import os
+import unittest
+
 import requests_mock
+
 import tableauserverclient as TSC
 from tableauserverclient.server import RequestFactory, WebhookItem
-
-from ._utils import read_xml_asset, read_xml_assets, asset
+from ._utils import asset
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -1,23 +1,21 @@
-import unittest
-from io import BytesIO
 import os
 import re
-import requests_mock
-import tableauserverclient as TSC
-import xml.etree.ElementTree as ET
-from defusedxml.ElementTree import fromstring
-from pathlib import Path
 import tempfile
+import unittest
+from io import BytesIO
+from pathlib import Path
 
+import requests_mock
+from defusedxml.ElementTree import fromstring
+
+import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import format_datetime
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
-from tableauserverclient.server.request_factory import RequestFactory
+from tableauserverclient.models.group_item import GroupItem
 from tableauserverclient.models.permissions_item import PermissionsRule
 from tableauserverclient.models.user_item import UserItem
-from tableauserverclient.models.group_item import GroupItem
-
+from tableauserverclient.server.endpoint.exceptions import InternalServerError
+from tableauserverclient.server.request_factory import RequestFactory
 from ._utils import asset
-
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -5,6 +5,7 @@ import re
 import requests_mock
 import tableauserverclient as TSC
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring
 from pathlib import Path
 import tempfile
 
@@ -698,7 +699,7 @@ class WorkbookTests(unittest.TestCase):
 
         response = RequestFactory.Workbook._generate_xml(new_workbook, connections=[connection1, connection2])
         # Can't use ConnectionItem parser due to xml namespace problems
-        connection_results = ET.fromstring(response).findall(".//connection")
+        connection_results = fromstring(response).findall(".//connection")
 
         self.assertEqual(connection_results[0].get("serverAddress", None), "mysql.test.com")
         self.assertEqual(connection_results[0].find("connectionCredentials").get("name", None), "test")  # type: ignore[union-attr]
@@ -713,7 +714,7 @@ class WorkbookTests(unittest.TestCase):
 
         response = RequestFactory.Workbook._generate_xml(new_workbook, connection_credentials=connection_creds)
         # Can't use ConnectionItem parser due to xml namespace problems
-        credentials = ET.fromstring(response).findall(".//connectionCredentials")
+        credentials = fromstring(response).findall(".//connectionCredentials")
         self.assertEqual(len(credentials), 1)
         self.assertEqual(credentials[0].get("name", None), "test")
         self.assertEqual(credentials[0].get("password", None), "secret")

--- a/test/test_workbook_model.py
+++ b/test/test_workbook_model.py
@@ -1,4 +1,5 @@
 import unittest
+
 import tableauserverclient as TSC
 
 


### PR DESCRIPTION
https://github.com/tableau/server-client-python/issues/988

from https://pypi.org/project/defusedxml/, we need to make sure we call defusedxml.ElementTree instead of xml.etree.ElementTree for these methods: parse(), iterparse(), fromstring(), XMLParser
the only one of those we call is fromstring()