### PR TITLE
Jorwoods/quota tiers allow null

### DIFF
--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import warnings
 import xml.etree.ElementTree as ET
 
@@ -749,7 +750,11 @@ class SiteItem(object):
         if revision_history_enabled is not None:
             self._revision_history_enabled = revision_history_enabled
         if user_quota:
-            self.user_quota = user_quota
+            try:
+                self.user_quota = user_quota
+            except ValueError:
+                warnings.warn("Tiered license level is set. Setting user_quota to None.")
+                self.user_quota = None
         if storage_quota:
             self.storage_quota = storage_quota
         if revision_limit:

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -230,7 +230,11 @@ class SiteItem(object):
         if value is not None and any(
             (self.tier_creator_capacity, self.tier_explorer_capacity, self.tier_viewer_capacity)
         ):
-            raise ValueError("User quota conflicts with setting tiered license levels. Set those to None first.")
+            raise ValueError(
+                "User quota conflicts with setting tiered license levels. "
+                "Use replace_license_tiers_with_user_quota to set those to None, "
+                "and set user_quota to the desired value."
+            )
         self._user_quota = value
 
     @property
@@ -563,6 +567,12 @@ class SiteItem(object):
     @auto_suspend_refresh_enabled.setter
     def auto_suspend_refresh_enabled(self, value: bool):
         self._auto_suspend_refresh_enabled = value
+
+    def replace_license_tiers_with_user_quota(self, value: int) -> None:
+        self.tier_creator_capacity = None
+        self.tier_explorer_capacity = None
+        self.tier_viewer_capacity = None
+        self.user_quota = value
 
     def _parse_common_tags(self, site_xml, ns):
         if not isinstance(site_xml, ET.Element):

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -226,7 +226,9 @@ class SiteItem(object):
 
     @user_quota.setter
     def user_quota(self, value: Optional[int]) -> None:
-        if any((self.tier_creator_capacity, self.tier_explorer_capacity, self.tier_viewer_capacity)):
+        if value is not None and any(
+            (self.tier_creator_capacity, self.tier_explorer_capacity, self.tier_viewer_capacity)
+        ):
             raise ValueError("User quota conflicts with setting tiered license levels. Set those to None first.")
         self._user_quota = value
 

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -186,7 +186,7 @@ class SiteTests(unittest.TestCase):
         self.assertRaises(TSC.MissingRequiredFieldError, self.server.sites.update, single_site)
 
     def test_null_site_quota(self) -> None:
-        test_site = TSC.SiteItem('testname', 'testcontenturl', tier_explorer_capacity=1, user_quota=None)
+        test_site = TSC.SiteItem("testname", "testcontenturl", tier_explorer_capacity=1, user_quota=None)
         assert test_site.tier_explorer_capacity == 1
         with self.assertRaises(ValueError):
             test_site.user_quota = 1
@@ -194,14 +194,13 @@ class SiteTests(unittest.TestCase):
         test_site.user_quota = 1
 
     def test_replace_license_tiers_with_user_quota(self) -> None:
-        test_site = TSC.SiteItem('testname', 'testcontenturl', tier_explorer_capacity=1, user_quota=None)
+        test_site = TSC.SiteItem("testname", "testcontenturl", tier_explorer_capacity=1, user_quota=None)
         assert test_site.tier_explorer_capacity == 1
         with self.assertRaises(ValueError):
             test_site.user_quota = 1
         test_site.replace_license_tiers_with_user_quota(1)
         self.assertEqual(1, test_site.user_quota)
         self.assertIsNone(test_site.tier_explorer_capacity)
-
 
     def test_create(self) -> None:
         with open(CREATE_XML, "rb") as f:


### PR DESCRIPTION
Allow setting `site.user_quota` equal to None if license levels are set.