### PR TITLE
Workbook item nullable project

### DIFF
--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -124,7 +124,6 @@ class WorkbookItem(object):
         return self._project_id
 
     @project_id.setter
-    @property_not_nullable
     def project_id(self, value: str):
         self._project_id = value
 

--- a/test/test_workbook_model.py
+++ b/test/test_workbook_model.py
@@ -4,12 +4,6 @@ import tableauserverclient as TSC
 
 
 class WorkbookModelTests(unittest.TestCase):
-    def test_invalid_project_id(self):
-        self.assertRaises(ValueError, TSC.WorkbookItem, None)
-        workbook = TSC.WorkbookItem("10")
-        with self.assertRaises(ValueError):
-            workbook.project_id = None
-
     def test_invalid_show_tabs(self):
         workbook = TSC.WorkbookItem("10")
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Remove check for null project_id which is now possible as a result of the introduction of Personal Space in new tableau versions. Related issue found here: https://github.com/tableau/server-client-python/issues/974