### PR TITLE
Do not eagerly fetch content in case a stream was requested

### DIFF
--- a/tableauserverclient/models/view_item.py
+++ b/tableauserverclient/models/view_item.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Iterable, List, Optional, Set, TYPE_CHECKING
+from typing import Callable, Generator, Iterator, List, Optional, Set, TYPE_CHECKING
 
 from defusedxml.ElementTree import fromstring
 
@@ -24,8 +24,8 @@ class ViewItem(object):
         self._preview_image: Optional[Callable[[], bytes]] = None
         self._project_id: Optional[str] = None
         self._pdf: Optional[Callable[[], bytes]] = None
-        self._csv: Optional[Callable[[], Iterable[bytes]]] = None
-        self._excel: Optional[Callable[[], Iterable[bytes]]] = None
+        self._csv: Optional[Callable[[], Iterator[bytes]]] = None
+        self._excel: Optional[Callable[[], Iterator[bytes]]] = None
         self._total_views: Optional[int] = None
         self._sheet_type: Optional[str] = None
         self._updated_at: Optional["datetime"] = None
@@ -94,14 +94,14 @@ class ViewItem(object):
         return self._pdf()
 
     @property
-    def csv(self) -> Iterable[bytes]:
+    def csv(self) -> Iterator[bytes]:
         if self._csv is None:
             error = "View item must be populated with its csv first."
             raise UnpopulatedPropertyError(error)
         return self._csv()
 
     @property
-    def excel(self) -> Iterable[bytes]:
+    def excel(self) -> Iterator[bytes]:
         if self._excel is None:
             error = "View item must be populated with its excel first."
             raise UnpopulatedPropertyError(error)

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -339,7 +339,7 @@ class Datasources(QuerysetEndpoint):
         *,
         request_id: str,
         actions: Sequence[Mapping],
-        payload: Optional[FilePath] = None
+        payload: Optional[FilePath] = None,
     ) -> JobItem:
         if isinstance(datasource_or_connection_item, DatasourceItem):
             datasource_id = datasource_or_connection_item.id

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -73,15 +73,18 @@ class Endpoint(object):
 
         server_response = method(url, **parameters)
 
+        # Check if response is xml, and if so, validate namespace. Checking the
+        # content type header prevents eager evaluation of streaming requests.
+        if server_response.headers.get("Content-Type") == "application/xml":
+            self.parent_srv._namespace.detect(server_response.content)
+        self._check_status(server_response)
+
         # Response.content is a property. Calling it will load the entire response into memory. Checking if the
         # content-type is an octet-stream accomplishes the same goal without eagerly loading content.
         stream = parameters.get("stream", False)
         stream = stream or (server_response.headers.get("Content-Type") == "application/octet-stream")
         if stream:
             return server_response
-
-        self.parent_srv._namespace.detect(server_response.content)
-        self._check_status(server_response)
 
         # This check is to determine if the response is a text response (xml or otherwise)
         # so that we do not attempt to log bytes and other binary data.

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -75,12 +75,13 @@ class Endpoint(object):
 
         # Response.content is a property. Calling it will load the entire response into memory. Checking if the
         # content-type is an octet-stream accomplishes the same goal without eagerly loading content.
-        if server_response.headers.get("Content-Type") != "application/octet-stream":
-            self.parent_srv._namespace.detect(server_response.content)
-        self._check_status(server_response)
-
-        if server_response.headers.get("Content-Type") == "application/octet-stream":
+        stream = parameters.get('stream', False)
+        stream = stream or (server_response.headers.get("Content-Type") == "application/octet-stream")
+        if stream:
             return server_response
+
+        self.parent_srv._namespace.detect(server_response.content)
+        self._check_status(server_response)
 
         # This check is to determine if the response is a text response (xml or otherwise)
         # so that we do not attempt to log bytes and other binary data.

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -75,7 +75,7 @@ class Endpoint(object):
 
         # Response.content is a property. Calling it will load the entire response into memory. Checking if the
         # content-type is an octet-stream accomplishes the same goal without eagerly loading content.
-        stream = parameters.get('stream', False)
+        stream = parameters.get("stream", False)
         stream = stream or (server_response.headers.get("Content-Type") == "application/octet-stream")
         if stream:
             return server_response

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -1,4 +1,3 @@
-from email.generator import Generator
 import logging
 from contextlib import closing
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -1,3 +1,4 @@
+from email.generator import Generator
 import logging
 from contextlib import closing
 
@@ -9,7 +10,7 @@ from .. import ViewItem, PaginationItem
 
 logger = logging.getLogger("tableau.endpoint.views")
 
-from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..request_options import RequestOptions, CSVRequestOptions, PDFRequestOptions, ImageRequestOptions
@@ -119,12 +120,11 @@ class Views(QuerysetEndpoint):
         view_item._set_csv(csv_fetcher)
         logger.info("Populated csv for view (ID: {0})".format(view_item.id))
 
-    def _get_view_csv(self, view_item: ViewItem, req_options: Optional["CSVRequestOptions"]) -> Iterable[bytes]:
+    def _get_view_csv(self, view_item: ViewItem, req_options: Optional["CSVRequestOptions"]) -> Iterator[bytes]:
         url = "{0}/{1}/data".format(self.baseurl, view_item.id)
 
         with closing(self.get_request(url, request_object=req_options, parameters={"stream": True})) as server_response:
-            csv = server_response.iter_content(1024)
-        return csv
+            yield from server_response.iter_content(1024)
 
     @api(version="3.8")
     def populate_excel(self, view_item: ViewItem, req_options: Optional["CSVRequestOptions"] = None) -> None:
@@ -138,12 +138,11 @@ class Views(QuerysetEndpoint):
         view_item._set_excel(excel_fetcher)
         logger.info("Populated excel for view (ID: {0})".format(view_item.id))
 
-    def _get_view_excel(self, view_item: ViewItem, req_options: Optional["CSVRequestOptions"]) -> Iterable[bytes]:
+    def _get_view_excel(self, view_item: ViewItem, req_options: Optional["CSVRequestOptions"]) -> Iterator[bytes]:
         url = "{0}/{1}/crosstab/excel".format(self.baseurl, view_item.id)
 
         with closing(self.get_request(url, request_object=req_options, parameters={"stream": True})) as server_response:
-            excel = server_response.iter_content(1024)
-        return excel
+            yield from server_response.iter_content(1024)
 
     @api(version="3.2")
     def populate_permissions(self, item: ViewItem) -> None:

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import unittest
+
+import tableauserverclient as TSC
+
+import requests_mock
+
+ASSETS = Path(__file__).parent / "assets"
+
+class TestEndpoint(unittest.TestCase):
+    def setUp(self) -> None:
+        self.server = TSC.Server("http://test/", use_server_version=False)
+
+        # Fake signin
+        self.server._site_id = "dad65087-b08b-4603-af4e-2887b8aafc67"
+        self.server._auth_token = "j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM"
+
+        return super().setUp()
+
+
+    def test_get_request_stream(self) -> None:
+        url = "http://test/"
+        endpoint = TSC.server.Endpoint(self.server)
+        with requests_mock.mock() as m:
+            m.get(url, headers={"Content-Type": "application/octet-stream"})
+            response = endpoint.get_request(url, parameters={"stream": True})
+
+            self.assertFalse(response._content_consumed)

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -7,6 +7,7 @@ import requests_mock
 
 ASSETS = Path(__file__).parent / "assets"
 
+
 class TestEndpoint(unittest.TestCase):
     def setUp(self) -> None:
         self.server = TSC.Server("http://test/", use_server_version=False)
@@ -16,7 +17,6 @@ class TestEndpoint(unittest.TestCase):
         self.server._auth_token = "j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM"
 
         return super().setUp()
-
 
     def test_get_request_stream(self) -> None:
         url = "http://test/"


### PR DESCRIPTION
This should fix #1037. It appears to me that `Endpoint._make_request` was eagerly fetching content to be able to evaluate and log it, when it needs to allow the content to be iterated over if it is an octet-stream.