### PR TITLE
Solution for issue number #1033

### DIFF
--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -48,7 +48,7 @@ class Permission:
         Table = "table"
         Database = "database"
         View = "view"
-        Lense = 'lense'
+        Lens = 'lense'
 
 
 class PermissionsRule(object):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -37,6 +37,9 @@ class Permission:
         ViewUnderlyingData = "ViewUnderlyingData"
         WebAuthoring = "WebAuthoring"
         Write = "Write"
+        RunExplainData='RunExplainData'
+        CreateRefreshMetrics='CreateRefreshMetrics'
+        SaveAs='SaveAs'
 
     class Resource:
         Workbook = "workbook"
@@ -45,6 +48,7 @@ class Permission:
         Table = "table"
         Database = "database"
         View = "view"
+        Lense = 'lense'
 
 
 class PermissionsRule(object):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -37,9 +37,9 @@ class Permission:
         ViewUnderlyingData = "ViewUnderlyingData"
         WebAuthoring = "WebAuthoring"
         Write = "Write"
-        RunExplainData='RunExplainData'
-        CreateRefreshMetrics='CreateRefreshMetrics'
-        SaveAs='SaveAs'
+        RunExplainData = "RunExplainData"
+        CreateRefreshMetrics = "CreateRefreshMetrics"
+        SaveAs = "SaveAs"
 
     class Resource:
         Workbook = "workbook"
@@ -48,7 +48,7 @@ class Permission:
         Table = "table"
         Database = "database"
         View = "view"
-        Lens = 'lense'
+        Lens = "lense"
 
 
 class PermissionsRule(object):

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -31,6 +31,7 @@ class ProjectItem(object):
         self._default_workbook_permissions = None
         self._default_datasource_permissions = None
         self._default_flow_permissions = None
+        self._default_lense_permissions = None
 
     @property
     def content_permissions(self):
@@ -68,6 +69,13 @@ class ProjectItem(object):
             error = "Project item must be populated with permissions first."
             raise UnpopulatedPropertyError(error)
         return self._default_flow_permissions()
+
+    @property
+    def default_lense_permissions(self):
+        if self._default_lense_permissions is None:
+            error = "Project item must be populated with permissions first."
+            raise UnpopulatedPropertyError(error)
+        return self._default_lense_permissions()
 
     @property
     def id(self) -> Optional[str]:

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -31,7 +31,7 @@ class ProjectItem(object):
         self._default_workbook_permissions = None
         self._default_datasource_permissions = None
         self._default_flow_permissions = None
-        self._default_lense_permissions = None
+        self._default_lens_permissions = None
 
     @property
     def content_permissions(self):
@@ -71,11 +71,11 @@ class ProjectItem(object):
         return self._default_flow_permissions()
 
     @property
-    def default_lense_permissions(self):
-        if self._default_lense_permissions is None:
+    def default_lens_permissions(self):
+        if self._default_lens_permissions is None:
             error = "Project item must be populated with permissions first."
             raise UnpopulatedPropertyError(error)
-        return self._default_lense_permissions()
+        return self._default_lens_permissions()
 
     @property
     def id(self) -> Optional[str]:

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -103,7 +103,7 @@ class Projects(QuerysetEndpoint):
     def populate_flow_default_permissions(self, item):
         self._default_permissions.populate_default_permissions(item, Permission.Resource.Flow)
 
-    @api(version='3.4')
+    @api(version="3.4")
     def populate_lens_default_permissions(self, item):
         self._default_permissions.populate_default_permissions(item, Permission.Resource.Lens)
 
@@ -119,7 +119,7 @@ class Projects(QuerysetEndpoint):
     def update_flow_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Flow)
 
-    @api(version='3.4')
+    @api(version="3.4")
     def update_lens_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Lens)
 
@@ -135,6 +135,6 @@ class Projects(QuerysetEndpoint):
     def delete_flow_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Flow)
 
-    @api(version='3.4')
+    @api(version="3.4")
     def delete_lens_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Lens)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -103,6 +103,10 @@ class Projects(QuerysetEndpoint):
     def populate_flow_default_permissions(self, item):
         self._default_permissions.populate_default_permissions(item, Permission.Resource.Flow)
 
+    @api(version='3.4')
+    def populate_lense_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Lense)
+
     @api(version="2.1")
     def update_workbook_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Workbook)
@@ -115,6 +119,10 @@ class Projects(QuerysetEndpoint):
     def update_flow_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Flow)
 
+    @api(version='3.4')
+    def update_lense_default_permissions(self, item, rules):
+        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Lense)
+
     @api(version="2.1")
     def delete_workbook_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Workbook)
@@ -126,3 +134,7 @@ class Projects(QuerysetEndpoint):
     @api(version="3.4")
     def delete_flow_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Flow)
+
+    @api(version='3.4')
+    def delete_lense_default_permissions(self, item, rule):
+        self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Lense)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -104,8 +104,8 @@ class Projects(QuerysetEndpoint):
         self._default_permissions.populate_default_permissions(item, Permission.Resource.Flow)
 
     @api(version='3.4')
-    def populate_lense_default_permissions(self, item):
-        self._default_permissions.populate_default_permissions(item, Permission.Resource.Lense)
+    def populate_lens_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, Permission.Resource.Lens)
 
     @api(version="2.1")
     def update_workbook_default_permissions(self, item, rules):
@@ -120,8 +120,8 @@ class Projects(QuerysetEndpoint):
         return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Flow)
 
     @api(version='3.4')
-    def update_lense_default_permissions(self, item, rules):
-        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Lense)
+    def update_lens_default_permissions(self, item, rules):
+        return self._default_permissions.update_default_permissions(item, rules, Permission.Resource.Lens)
 
     @api(version="2.1")
     def delete_workbook_default_permissions(self, item, rule):
@@ -136,5 +136,5 @@ class Projects(QuerysetEndpoint):
         self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Flow)
 
     @api(version='3.4')
-    def delete_lense_default_permissions(self, item, rule):
-        self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Lense)
+    def delete_lens_default_permissions(self, item, rule):
+        self._default_permissions.delete_default_permission(item, rule, Permission.Resource.Lens)


### PR DESCRIPTION
Tableau 2021.4 has introduced new set of permissions which are as follows:
Workbooks
  • Run Explain Data
  • Create/Refresh Metrics
Data Sources
  • Save As
  • Move
Ask Data Lenses (all new)
  • View
  • Overwrite
  • Move
  • Delete
  • Set Permissions

These permissions are missing in the current wrapper class.
I have added these permissions in the Model and also created a new populate permission method for Lense permissions.