### PR TITLE
Fix QuerySet slicing logic

### DIFF
--- a/test/assets/queryset_slicing_page_1.xml
+++ b/test/assets/queryset_slicing_page_1.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="1" pageSize="10" totalAvailable="20" />
+    <views>
+        <view id="d79634e1-6063-4ec9-95ff-50acbf609ff5" name="ENDANGERED SAFARI" contentUrl="SafariSample/sheets/ENDANGEREDSAFARI">
+            <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" contentUrl="Superstore/sheets/Overview">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="7ddf1576-4b15-4df5-98cb-03066f279059" name="Product" contentUrl="Superstore/sheets/Product">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="c75f90a9-f10e-46be-8f01-07403780386a" name="Customers" contentUrl="Superstore/sheets/Customers">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="880cd185-3f15-4063-816c-4a600883f4ed" name="Shipping" contentUrl="Superstore/sheets/Shipping">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="29c73e36-94ed-474a-9533-e310d1e6a787" name="Performance" contentUrl="Superstore/sheets/Performance">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="48ff745e-aeda-4d76-a162-2bc740b4f478" name="Commission Model" contentUrl="Superstore/sheets/CommissionModel">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="2df55de2-3a2d-4e34-b515-6d4e70b830e9" name="Order Details" contentUrl="Superstore/sheets/OrderDetails">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="c1513b2f-cb6f-4ae8-841f-4128fdd2a7dd" name="Forecast" contentUrl="Superstore/sheets/Forecast">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+        <view id="2e6d6c81-da71-4b41-892c-ba80d4e7a6d0" name="What If Forecast" contentUrl="Superstore/sheets/WhatIfForecast">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        </view>
+    </views>
+</tsResponse>

--- a/test/assets/queryset_slicing_page_2.xml
+++ b/test/assets/queryset_slicing_page_2.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="2" pageSize="10" totalAvailable="20" />
+    <views>
+        <view id="47ffcb8e-3f7a-4ecf-8ab3-605da9febe20" name="Population" contentUrl="WorldIndicators/sheets/Population">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="6757fea8-0aa9-4160-a87c-9be27b1d1c8c" name="HealthIndicators" contentUrl="WorldIndicators/sheets/HealthIndicators">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="6c90df57-8852-4470-b237-836354fe4f6a" name="Care Spend" contentUrl="WorldIndicators/sheets/CareSpend">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="d8405103-be40-48f1-a522-cc2c7c26d952" name="Technology" contentUrl="WorldIndicators/sheets/Technology">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="b5ab383e-26d3-4a63-b89d-c69bf5a3f9e8" name="Economy" contentUrl="WorldIndicators/sheets/Economy">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="8d600fae-371f-4a80-a41c-c9b7d5c8effd" name="Tourism" contentUrl="WorldIndicators/sheets/Tourism">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="9570a9e9-e7f8-421d-a49e-401df4231336" name="Business" contentUrl="WorldIndicators/sheets/Business">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="b037d23f-2242-4483-be2d-e61b39747fd0" name="Tourism Over Time" contentUrl="WorldIndicators/sheets/TourismOverTime">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="a5633b2b-91a7-4fb7-8f44-083c504d15ff" name="Tourism by Country" contentUrl="WorldIndicators/sheets/TourismByCountry">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+        <view id="06e51d57-fc33-412e-a4bd-8bab12d2adff" name="Biz Tax Rate" contentUrl="WorldIndicators/sheets/BizTaxRate">
+            <workbook id="307d59be-f0c3-4b78-bd30-d62e1185e756" />
+            <owner id="4235b5a6-3594-4f20-aa93-91faa4899046" />
+        </view>
+    </views>
+</tsResponse>

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import unittest
 
@@ -6,7 +7,7 @@ import requests_mock
 
 import tableauserverclient as TSC
 
-TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
+TEST_ASSET_DIR = Path(__file__).parent / "assets"
 
 PAGINATION_XML = os.path.join(TEST_ASSET_DIR, "request_option_pagination.xml")
 PAGE_NUMBER_XML = os.path.join(TEST_ASSET_DIR, "request_option_page_number.xml")
@@ -15,10 +16,12 @@ FILTER_EQUALS = os.path.join(TEST_ASSET_DIR, "request_option_filter_equals.xml")
 FILTER_TAGS_IN = os.path.join(TEST_ASSET_DIR, "request_option_filter_tags_in.xml")
 FILTER_MULTIPLE = os.path.join(TEST_ASSET_DIR, "request_option_filter_tags_in.xml")
 SLICING_QUERYSET = os.path.join(TEST_ASSET_DIR, "request_option_slicing_queryset.xml")
+SLICING_QUERYSET_PAGE_1 = TEST_ASSET_DIR / "queryset_slicing_page_1.xml"
+SLICING_QUERYSET_PAGE_2 = TEST_ASSET_DIR / "queryset_slicing_page_2.xml"
 
 
 class RequestOptionTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.server = TSC.Server("http://test", False)
 
         # Fake signin
@@ -28,7 +31,7 @@ class RequestOptionTests(unittest.TestCase):
 
         self.baseurl = "{0}/{1}".format(self.server.sites.baseurl, self.server._site_id)
 
-    def test_pagination(self):
+    def test_pagination(self) -> None:
         with open(PAGINATION_XML, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -41,7 +44,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(33, pagination_item.total_available)
         self.assertEqual(10, len(all_views))
 
-    def test_page_number(self):
+    def test_page_number(self) -> None:
         with open(PAGE_NUMBER_XML, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -54,7 +57,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(210, pagination_item.total_available)
         self.assertEqual(10, len(all_views))
 
-    def test_page_size(self):
+    def test_page_size(self) -> None:
         with open(PAGE_SIZE_XML, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -67,7 +70,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(33, pagination_item.total_available)
         self.assertEqual(5, len(all_views))
 
-    def test_filter_equals(self):
+    def test_filter_equals(self) -> None:
         with open(FILTER_EQUALS, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -82,7 +85,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual("RESTAPISample", matching_workbooks[0].name)
         self.assertEqual("RESTAPISample", matching_workbooks[1].name)
 
-    def test_filter_equals_shorthand(self):
+    def test_filter_equals_shorthand(self) -> None:
         with open(FILTER_EQUALS, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -93,7 +96,7 @@ class RequestOptionTests(unittest.TestCase):
             self.assertEqual("RESTAPISample", matching_workbooks[0].name)
             self.assertEqual("RESTAPISample", matching_workbooks[1].name)
 
-    def test_filter_tags_in(self):
+    def test_filter_tags_in(self) -> None:
         with open(FILTER_TAGS_IN, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -111,7 +114,7 @@ class RequestOptionTests(unittest.TestCase):
         self.assertEqual(set(["safari"]), matching_workbooks[1].tags)
         self.assertEqual(set(["sample"]), matching_workbooks[2].tags)
 
-    def test_filter_tags_in_shorthand(self):
+    def test_filter_tags_in_shorthand(self) -> None:
         with open(FILTER_TAGS_IN, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -123,11 +126,11 @@ class RequestOptionTests(unittest.TestCase):
             self.assertEqual(set(["safari"]), matching_workbooks[1].tags)
             self.assertEqual(set(["sample"]), matching_workbooks[2].tags)
 
-    def test_invalid_shorthand_option(self):
+    def test_invalid_shorthand_option(self) -> None:
         with self.assertRaises(ValueError):
             self.server.workbooks.filter(nonexistant__in=["sample", "safari"])
 
-    def test_multiple_filter_options(self):
+    def test_multiple_filter_options(self) -> None:
         with open(FILTER_MULTIPLE, "rb") as f:
             response_xml = f.read().decode("utf-8")
         # To ensure that this is deterministic, run this a few times
@@ -153,7 +156,7 @@ class RequestOptionTests(unittest.TestCase):
                 self.assertEqual(3, pagination_item.total_available)
 
     # Test req_options if url already has query params
-    def test_double_query_params(self):
+    def test_double_query_params(self) -> None:
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
             url = self.baseurl + "/views?queryParamExists=true"
@@ -170,7 +173,7 @@ class RequestOptionTests(unittest.TestCase):
             self.assertTrue(re.search("sort=name%3aasc", resp.request.query))
 
     # Test req_options for versions below 3.7
-    def test_filter_sort_legacy(self):
+    def test_filter_sort_legacy(self) -> None:
         self.server.version = "3.6"
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
@@ -187,7 +190,7 @@ class RequestOptionTests(unittest.TestCase):
             self.assertTrue(re.search("filter=tags:in:%5bstocks,market%5d", resp.request.query))
             self.assertTrue(re.search("sort=name:asc", resp.request.query))
 
-    def test_vf(self):
+    def test_vf(self) -> None:
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
             url = self.baseurl + "/views/456/data"
@@ -202,7 +205,7 @@ class RequestOptionTests(unittest.TestCase):
             self.assertTrue(re.search("type=tabloid", resp.request.query))
 
     # Test req_options for versions beloe 3.7
-    def test_vf_legacy(self):
+    def test_vf_legacy(self) -> None:
         self.server.version = "3.6"
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
@@ -217,7 +220,7 @@ class RequestOptionTests(unittest.TestCase):
             self.assertTrue(re.search("vf_name2\\$=value2", resp.request.query))
             self.assertTrue(re.search("type=tabloid", resp.request.query))
 
-    def test_all_fields(self):
+    def test_all_fields(self) -> None:
         with requests_mock.mock() as m:
             m.get(requests_mock.ANY)
             url = self.baseurl + "/views/456/data"
@@ -227,7 +230,7 @@ class RequestOptionTests(unittest.TestCase):
             resp = self.server.users.get_request(url, request_object=opts)
             self.assertTrue(re.search("fields=_all_", resp.request.query))
 
-    def test_multiple_filter_options_shorthand(self):
+    def test_multiple_filter_options_shorthand(self) -> None:
         with open(FILTER_MULTIPLE, "rb") as f:
             response_xml = f.read().decode("utf-8")
         # To ensure that this is deterministic, run this a few times
@@ -246,7 +249,7 @@ class RequestOptionTests(unittest.TestCase):
                 matching_workbooks = self.server.workbooks.filter(tags__in=["sample", "safari", "weather"], name="foo")
                 self.assertEqual(3, matching_workbooks.total_available)
 
-    def test_slicing_queryset(self):
+    def test_slicing_queryset(self) -> None:
         with open(SLICING_QUERYSET, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -270,6 +273,18 @@ class RequestOptionTests(unittest.TestCase):
         with self.assertRaises(IndexError):
             all_views[100]
 
-    def test_queryset_filter_args_error(self):
+    def test_slicing_queryset_multi_page(self) -> None:
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + "/views?pageNumber=1", text=SLICING_QUERYSET_PAGE_1.read_text())
+            m.get(self.baseurl + "/views?pageNumber=2", text=SLICING_QUERYSET_PAGE_2.read_text())
+            all_views_queryset = self.server.views.all()
+            all_views_queryset.request_options.page_size = 10
+            sliced_views = self.server.views.all()[9:12]
+
+        self.assertEqual(sliced_views[0].id, "2e6d6c81-da71-4b41-892c-ba80d4e7a6d0")
+        self.assertEqual(sliced_views[1].id, "47ffcb8e-3f7a-4ecf-8ab3-605da9febe20")
+        self.assertEqual(sliced_views[2].id, "6757fea8-0aa9-4160-a87c-9be27b1d1c8c")
+
+    def test_queryset_filter_args_error(self) -> None:
         with self.assertRaises(RuntimeError):
             workbooks = self.server.workbooks.filter("argument")

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -277,8 +277,6 @@ class RequestOptionTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(self.baseurl + "/views?pageNumber=1", text=SLICING_QUERYSET_PAGE_1.read_text())
             m.get(self.baseurl + "/views?pageNumber=2", text=SLICING_QUERYSET_PAGE_2.read_text())
-            all_views_queryset = self.server.views.all()
-            all_views_queryset.request_options.page_size = 10
             sliced_views = self.server.views.all()[9:12]
 
         self.assertEqual(sliced_views[0].id, "2e6d6c81-da71-4b41-892c-ba80d4e7a6d0")


### PR DESCRIPTION
The old logic for handling slices on QuerySet objects worked for toy examples when the result set was small, but would crash if having to work through too many items. This logic will work for  all sizes of results.