### PR TITLE
replace deprecated Version class from distutils with packaging.version

### DIFF
--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -1,7 +1,7 @@
-from distutils.version import LooseVersion as Version
 import urllib3
 import requests
 from defusedxml.ElementTree import fromstring
+from packaging.version import Version
 
 from .endpoint import (
     Sites,
@@ -38,7 +38,7 @@ from ..namespace import Namespace
 
 import requests
 
-from distutils.version import LooseVersion as Version
+from packaging.version import Version
 
 _PRODUCT_TO_REST_VERSION = {
     "10.0": "2.3",


### PR DESCRIPTION
I discovered the following warning while using the Python client:
```
/****/lib/python3.8/site-packages/tableauserverclient/server/server.py:149: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  minimum_supported = Version(version)
```

So I replaced the `distutils` class with the `version` class of `packing`, which seems legitimate from what I've seen so far.