### PR TITLE
Add build package to pip install

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build dist files
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          pip install -e .[test] build
           python -m build
           git describe --tag --dirty --always
       - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,9 +23,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[test]
+        pip install -e .[test] build
 
     - name: Test with pytest
       if: always()
       run: |
         pytest test
+
+    - name: Test build
+      if: always()
+      run: |
+        python -m build


### PR DESCRIPTION
Development branch missing, so targeting master.

This PR adds the build package to the pip install step explicitly so that build can run and create the artifacts to publish to PyPI.