### PR TITLE
Jac/headers

### DIFF
--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -46,7 +46,7 @@ def main():
     logging.basicConfig(level=logging_level)
 
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
-    server = TSC.Server(args.server, use_server_version=True)
+    server = TSC.Server(args.server, use_server_version=True, http_options={"verify": False})
     with server.auth.sign_in(tableau_auth):
         # this code shows 3 different error codes that mean "resource is already in collection"
         # 409009: group already exists on server

--- a/test/http/test_http_requests.py
+++ b/test/http/test_http_requests.py
@@ -1,0 +1,56 @@
+import tableauserverclient as TSC
+import unittest
+from requests.exceptions import MissingSchema
+
+
+class ServerTests(unittest.TestCase):
+    def test_init_server_model_empty_throws(self):
+        with self.assertRaises(TypeError):
+            server = TSC.Server()
+
+    def test_init_server_model_bad_server_name_complains(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url")
+
+    def test_init_server_model_valid_server_name_works(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("http://fake-url")
+
+    def test_init_server_model_valid_https_server_name_works(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("https://fake-url")
+
+    def test_init_server_model_bad_server_name_not_version_check(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url", use_server_version=False)
+
+    def test_init_server_model_bad_server_name_do_version_check(self):
+        with self.assertRaises(MissingSchema):
+            server = TSC.Server("fake-url", use_server_version=True)
+
+    def test_init_server_model_bad_server_name_not_version_check_random_options(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url", use_server_version=False, http_options={"foo": 1})
+
+    def test_init_server_model_bad_server_name_not_version_check_real_options(self):
+        # by default, it will attempt to contact the server to check it's version
+        server = TSC.Server("fake-url", use_server_version=False, http_options={"verify": False})
+
+    def test_http_options_skip_ssl_works(self):
+        http_options = {"verify": False}
+        server = TSC.Server("http://fake-url")
+        server.add_http_options(http_options)
+
+    # ValueError: dictionary update sequence element #0 has length 1; 2 is required
+    def test_http_options_multiple_options_fails(self):
+        http_options_1 = {"verify": False}
+        http_options_2 = {"birdname": "Parrot"}
+        server = TSC.Server("http://fake-url")
+        with self.assertRaises(ValueError):
+            server.add_http_options([http_options_1, http_options_2])
+
+    # TypeError: cannot convert dictionary update sequence element #0 to a sequence
+    def test_http_options_not_sequence_fails(self):
+        server = TSC.Server("http://fake-url")
+        with self.assertRaises(ValueError):
+            server.add_http_options({1, 2, 3})


### PR DESCRIPTION
Fixes #1116 - requests options were being passed in as headers.  Removed all the client versioning mentions from server.py and put them in endpoint. 
Also added a bunch of type checking in add_http_options which is probably overkill but will help people who try and pass in tuples, how silly.