### PR TITLE
Jac/show server info

### DIFF
--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -46,7 +46,7 @@ def main():
     logging.basicConfig(level=logging_level)
 
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
-    server = TSC.Server(args.server, use_server_version=True)
+    server = TSC.Server(args.server, use_server_version=True, http_options={"verify": False})
     with server.auth.sign_in(tableau_auth):
         # this code shows 3 different error codes that mean "resource is already in collection"
         # 409009: group already exists on server

--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -47,6 +47,7 @@ def main():
 
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True, http_options={"verify": False})
+    print(server)
     with server.auth.sign_in(tableau_auth):
         # this code shows 3 different error codes that mean "resource is already in collection"
         # 409009: group already exists on server

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,7 +1,6 @@
 import warnings
 import xml.etree.ElementTree as ET
 
-from distutils.version import Version
 from defusedxml.ElementTree import fromstring
 from .property_decorators import (
     property_is_enum,

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from distutils.version import LooseVersion as Version
+from packaging.version import Version
 from functools import wraps
 from xml.etree.ElementTree import ParseError
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
@@ -14,7 +14,6 @@ from .exceptions import (
 from ..query import QuerySet
 from ... import helpers
 from ..._version import get_versions
-
 __TSC_VERSION__ = get_versions()["version"]
 del get_versions
 

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -13,6 +13,15 @@ logger = logging.getLogger("tableau.endpoint.server_info")
 
 class ServerInfo(Endpoint):
     @property
+    def serverInfo(self):
+        if not self._info:
+            self.get()
+        return self._info
+
+    def __repr__(self):
+        return "<Endpoint {}>".format(self._info)
+
+    @property
     def baseurl(self):
         return "{0}/serverInfo".format(self.parent_srv.baseurl)
 
@@ -28,5 +37,5 @@ class ServerInfo(Endpoint):
                 raise EndpointUnavailableError
             raise e
 
-        server_info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
-        return server_info
+        self._info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
+        return self._info

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -96,6 +96,9 @@ class Server(object):
         if use_server_version:
             self.use_server_version()
 
+    def __repr__(self):
+        return "<TableauServerClient> [Connection: {}, {}]".format(self.baseurl, self.server_info.serverInfo)
+
     def add_http_options(self, option_pair: dict):
         if not option_pair:
             # log debug message

--- a/test/http/test_http_requests.py
+++ b/test/http/test_http_requests.py
@@ -1,0 +1,56 @@
+import tableauserverclient as TSC
+import unittest
+from requests.exceptions import MissingSchema
+
+
+class ServerTests(unittest.TestCase):
+    def test_init_server_model_empty_throws(self):
+        with self.assertRaises(TypeError):
+            server = TSC.Server()
+
+    def test_init_server_model_bad_server_name_complains(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url")
+
+    def test_init_server_model_valid_server_name_works(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("http://fake-url")
+
+    def test_init_server_model_valid_https_server_name_works(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("https://fake-url")
+
+    def test_init_server_model_bad_server_name_not_version_check(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url", use_server_version=False)
+
+    def test_init_server_model_bad_server_name_do_version_check(self):
+        with self.assertRaises(MissingSchema):
+            server = TSC.Server("fake-url", use_server_version=True)
+
+    def test_init_server_model_bad_server_name_not_version_check_random_options(self):
+        # by default, it will just set the version to 2.3
+        server = TSC.Server("fake-url", use_server_version=False, http_options={"foo": 1})
+
+    def test_init_server_model_bad_server_name_not_version_check_real_options(self):
+        # by default, it will attempt to contact the server to check it's version
+        server = TSC.Server("fake-url", use_server_version=False, http_options={"verify": False})
+
+    def test_http_options_skip_ssl_works(self):
+        http_options = {"verify": False}
+        server = TSC.Server("http://fake-url")
+        server.add_http_options(http_options)
+
+    # ValueError: dictionary update sequence element #0 has length 1; 2 is required
+    def test_http_options_multiple_options_fails(self):
+        http_options_1 = {"verify": False}
+        http_options_2 = {"birdname": "Parrot"}
+        server = TSC.Server("http://fake-url")
+        with self.assertRaises(ValueError):
+            server.add_http_options([http_options_1, http_options_2])
+
+    # TypeError: cannot convert dictionary update sequence element #0 to a sequence
+    def test_http_options_not_sequence_fails(self):
+        server = TSC.Server("http://fake-url")
+        with self.assertRaises(ValueError):
+            server.add_http_options({1, 2, 3})


### PR DESCRIPTION
- maybe some other attributes would be good?
- added caching for serverInfo call, that shouldn't change often
- added a print statement in create_group to show it off

looks like
<TableauServerClient> [Connection: https://10ax.online.tableau.com/api/3.17, ServerInfoItem: [product version: 2022.3.0, build no.:20223.22.0912.1638, REST API version:3.17]]