### PR TITLE
fix behavior when url has no protocol

### DIFF
--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -65,6 +65,6 @@ class PersonalAccessTokenAuth(Credentials):
         }
 
     def __repr__(self):
-        return "<PersonalAccessToken name={} token={} site={}>".format(
+        return "<PersonalAccessToken name={} token={}>(site={})".format(
             self.token_name, self.personal_access_token[:2] + "...", self.site_id
         )

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -61,7 +61,7 @@ class Server(object):
         self._site_id = None
         self._user_id = None
 
-        self._server_address = server_address
+        self._server_address: str = server_address
         self._session_factory = session_factory or requests.session
 
         self.auth = Auth(self)
@@ -103,6 +103,8 @@ class Server(object):
 
     def validate_server_connection(self):
         try:
+            if not self._server_address.startswith("http"):
+                self._server_address = "http://" + self._server_address
             self._session.prepare_request(requests.Request("GET", url=self._server_address, params=self._http_options))
         except Exception as req_ex:
             warnings.warn("Invalid server initialization\n  {}".format(req_ex.__str__()), UserWarning)
@@ -152,7 +154,8 @@ class Server(object):
             version = self.server_info.get().rest_api_version
         except ServerInfoEndpointNotFoundError:
             version = self._get_legacy_version()
-        except BaseException:
+        except BaseException as e:
+            warnings.warn("Could not get version info from server, guessing {}".format(e.__class__))
             version = self._get_legacy_version()
 
         self.version = old_version

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -1,9 +1,10 @@
+import logging
 import warnings
 
 import requests
 import urllib3
 
-from defusedxml.ElementTree import fromstring
+from defusedxml.ElementTree import fromstring, ParseError
 from packaging.version import Version
 from .endpoint import (
     Sites,
@@ -103,12 +104,13 @@ class Server(object):
 
     def validate_server_connection(self):
         try:
-            if not self._server_address.startswith("http"):
+            if not self._server_address.startswith("http://") and not self._server_address.startswith("https://"):
                 self._server_address = "http://" + self._server_address
-            self._session.prepare_request(requests.Request("GET", url=self._server_address, params=self._http_options))
+                self._session.prepare_request(
+                    requests.Request("GET", url=self._server_address, params=self._http_options)
+                )
         except Exception as req_ex:
-            warnings.warn("Invalid server initialization\n  {}".format(req_ex.__str__()), UserWarning)
-        print("==================")
+            raise ValueError("Invalid server initialization", req_ex)
 
     def __repr__(self):
         return "<TableauServerClient> [Connection: {}, {}]".format(self.baseurl, self.server_info.serverInfo)
@@ -142,7 +144,13 @@ class Server(object):
 
     def _get_legacy_version(self):
         response = self._session.get(self.server_address + "/auth?format=xml")
-        info_xml = fromstring(response.content)
+        try:
+            info_xml = fromstring(response.content)
+        except ParseError as parseError:
+            logging.getLogger("TSC.server").info(
+                "Could not read server version info. The server may not be running or configured."
+            )
+            return self.version
         prod_version = info_xml.find(".//product_version").text
         version = _PRODUCT_TO_REST_VERSION.get(prod_version, "2.1")  # 2.1
         return version
@@ -154,9 +162,6 @@ class Server(object):
             version = self.server_info.get().rest_api_version
         except ServerInfoEndpointNotFoundError:
             version = self._get_legacy_version()
-        except BaseException as e:
-            warnings.warn("Could not get version info from server, guessing {}".format(e.__class__))
-            version = self._get_legacy_version()
 
         self.version = old_version
 
@@ -167,8 +172,6 @@ class Server(object):
 
     def use_highest_version(self):
         self.use_server_version()
-        import warnings
-
         warnings.warn("use use_server_version instead", DeprecationWarning)
 
     def check_at_least_version(self, target: str):

--- a/test/http/test_http_requests.py
+++ b/test/http/test_http_requests.py
@@ -30,12 +30,10 @@ class ServerTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             server = TSC.Server()
 
-    def test_init_server_model_bad_server_name_complains(self):
-        # by default, it will just set the version to 2.3
+    def test_init_server_model_no_protocol_defaults_htt(self):
         server = TSC.Server("fake-url")
 
     def test_init_server_model_valid_server_name_works(self):
-        # by default, it will just set the version to 2.3
         server = TSC.Server("http://fake-url")
 
     def test_init_server_model_valid_https_server_name_works(self):
@@ -43,18 +41,18 @@ class ServerTests(unittest.TestCase):
         server = TSC.Server("https://fake-url")
 
     def test_init_server_model_bad_server_name_not_version_check(self):
-        # by default, it will just set the version to 2.3
         server = TSC.Server("fake-url", use_server_version=False)
 
-    @mock.patch("requests.sessions.Session.get", side_effect=mocked_requests_get)
-    def test_init_server_model_bad_server_name_do_version_check(self, mock_get):
-        server = TSC.Server("fake-url", use_server_version=True)
+    def test_init_server_model_bad_server_name_do_version_check(self):
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            server = TSC.Server("fake-url", use_server_version=True)
 
     def test_init_server_model_bad_server_name_not_version_check_random_options(self):
-        # by default, it will just set the version to 2.3
+        # with self.assertRaises(MissingSchema):
         server = TSC.Server("fake-url", use_server_version=False, http_options={"foo": 1})
 
     def test_init_server_model_bad_server_name_not_version_check_real_options(self):
+        # with self.assertRaises(ValueError):
         server = TSC.Server("fake-url", use_server_version=False, http_options={"verify": False})
 
     def test_http_options_skip_ssl_works(self):


### PR DESCRIPTION
Defaulting to http if no protocol is entered, since that is the behavior we expect in tabcmd currently.
Manually handle a redirect on login, so we don't send a GET request that fails.