### PR TITLE
Fix github reference for publishing action

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,7 +34,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           
       - name: Publish distribution 📦 to PyPI
-        if: ${GITHUB_REF} == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: pypa/gh-action-pypi-publish@release/v1  # license BSD-2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Trying again using an example I see here:
https://docs.github.com/en/actions/learn-github-actions/contexts