### PR TITLE
Add updated_at to JobItem class

### DIFF
--- a/tableauserverclient/models/job_item.py
+++ b/tableauserverclient/models/job_item.py
@@ -34,6 +34,7 @@ class JobItem(object):
         workbook_id: Optional[str] = None,
         datasource_id: Optional[str] = None,
         flow_run: Optional[FlowRunItem] = None,
+        updated_at: Optional["datetime.datetime"] = None,
     ):
         self._id = id_
         self._type = job_type
@@ -47,6 +48,7 @@ class JobItem(object):
         self._workbook_id = workbook_id
         self._datasource_id = datasource_id
         self._flow_run = flow_run
+        self._updated_at = updated_at
 
     @property
     def id(self) -> str:
@@ -113,9 +115,13 @@ class JobItem(object):
     def flow_run(self, value):
         self._flow_run = value
 
+    @property
+    def updated_at(self) -> Optional["datetime.datetime"]:
+        return self._updated_at
+
     def __repr__(self):
         return (
-            "<Job#{_id} {_type} created_at({_created_at}) started_at({_started_at}) completed_at({_completed_at})"
+            "<Job#{_id} {_type} created_at({_created_at}) started_at({_started_at}) updated_at({_updated_at}) completed_at({_completed_at})"
             " progress ({_progress}) finish_code({_finish_code})>".format(**self.__dict__)
         )
 
@@ -144,6 +150,7 @@ class JobItem(object):
         datasource = element.find(".//t:datasource[@id]", namespaces=ns)
         datasource_id = datasource.get("id") if datasource is not None else None
         flow_run = None
+        updated_at = parse_datetime(element.get("updatedAt", None))
         for flow_job in element.findall(".//t:runFlowJobType", namespaces=ns):
             flow_run = FlowRunItem()
             flow_run._id = flow_job.get("flowRunId", None)
@@ -163,6 +170,7 @@ class JobItem(object):
             workbook_id,
             datasource_id,
             flow_run,
+            updated_at,
         )
 
 

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -53,8 +53,10 @@ class JobTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get("{0}/{1}".format(self.baseurl, job_id), text=response_xml)
             job = self.server.jobs.get_by_id(job_id)
+            updated_at = datetime(2020, 5, 13, 20, 25, 18, tzinfo=utc)
 
             self.assertEqual(job_id, job.id)
+            self.assertEqual(updated_at, job.updated_at)
             self.assertListEqual(job.notes, ["Job detail notes"])
 
     def test_get_before_signin(self) -> None:


### PR DESCRIPTION
The [Query Job](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_jobs_tasks_and_schedules.htm#query_job) REST API returns `createdAt`, `updatedAt` and `completedAt` date/times. This is implemented in `JobItem` class, but `updatedAt` was not being parsed (`startedAt` is looked for, but is not documented and I have not seen it included in any response, I would propose removal but there's a lot of positional arguments that would break!). 

For reference, the [Query Jobs](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_jobs_tasks_and_schedules.htm#query_jobs) REST API returns `createdAt`, `startedAt` and `endedAt`, just to be confusing. These jobs are implemented using `BackgroundJobItem` class and those fields are correctly parsed.