### PR TITLE
Implement custom view objects

### DIFF
--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -74,6 +74,10 @@ def main():
         if all_workbooks:
             # Pick one workbook from the list
             sample_workbook = all_workbooks[0]
+            sample_workbook.name = "Name me something cooler"
+            sample_workbook.description = "That doesn't work"
+            updated: TSC.WorkbookItem = server.workbooks.update(sample_workbook)
+            print(updated.name, updated.description)
 
             # Populate views
             server.workbooks.populate_views(sample_workbook)
@@ -126,6 +130,32 @@ def main():
                 with open(args.preview_image, "wb") as f:
                     f.write(sample_workbook.preview_image)
                 print("\nDownloaded preview image of workbook to {}".format(os.path.abspath(args.preview_image)))
+
+
+            # get custom views
+            cvs, _ = server.custom_views.get()
+            for c in cvs:
+                print(c)
+
+            # for the last custom view in the list
+
+            # update the name
+            # note that this will fail if the name is already changed to this value
+            changed: TSC.CustomViewItem(id=c.id, name="I was updated by tsc")
+            verified_change = server.custom_views.update(changed)
+            print(verified_change)
+
+            # export as image. Filters etc could be added here as usual
+            server.custom_views.populate_image(c)
+            filename = c.id + "-image-export.png"
+            with open(filename, "wb") as f:
+                f.write(c.image)
+            print("saved to " + filename)
+
+            if args.delete:
+                print("deleting {}".format(c.id))
+                unlucky = TSC.CustomViewItem(c.id)
+                server.custom_views.delete(unlucky.id)
 
 
 if __name__ == "__main__":

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -131,7 +131,6 @@ def main():
                     f.write(sample_workbook.preview_image)
                 print("\nDownloaded preview image of workbook to {}".format(os.path.abspath(args.preview_image)))
 
-
             # get custom views
             cvs, _ = server.custom_views.get()
             for c in cvs:

--- a/tableauserverclient/models/__init__.py
+++ b/tableauserverclient/models/__init__.py
@@ -1,6 +1,7 @@
 from .column_item import ColumnItem
 from .connection_credentials import ConnectionCredentials
 from .connection_item import ConnectionItem
+from .custom_view_item import CustomViewItem
 from .data_acceleration_report_item import DataAccelerationReportItem
 from .data_alert_item import DataAlertItem
 from .database_item import DatabaseItem

--- a/tableauserverclient/models/custom_view_item.py
+++ b/tableauserverclient/models/custom_view_item.py
@@ -35,9 +35,7 @@ class CustomViewItem(object):
         owner_info = ""
         if self._owner:
             owner_info = " owner='{}'".format(self._owner.name or self._owner.id or "unknown")
-        return "<CustomViewItem id={} name=`{}`{}{}{}>".format(
-            self.id, self.name, view_info, wb_info, owner_info
-        )
+        return "<CustomViewItem id={} name=`{}`{}{}{}>".format(self.id, self.name, view_info, wb_info, owner_info)
 
     def _set_image(self, image):
         self._image = image
@@ -98,7 +96,7 @@ class CustomViewItem(object):
         return self._view
 
     @classmethod
-    def from_response(cls, resp, ns, workbook_id="") -> "CustomViewItem":
+    def from_response(cls, resp, ns, workbook_id="") -> Optional["CustomViewItem"]:
         item = cls.list_from_response(resp, ns, workbook_id)
         if not item or len(item) == 0:
             return None

--- a/tableauserverclient/models/custom_view_item.py
+++ b/tableauserverclient/models/custom_view_item.py
@@ -12,30 +12,30 @@ from ..datetime_helpers import parse_datetime
 
 
 class CustomViewItem(object):
-    def __init__(self) -> None:
+    def __init__(self, id: Optional[str] = None, name: Optional[str] = None) -> None:
         self._content_url: Optional[str] = None  # ?
         self._created_at: Optional["datetime"] = None
-        self._id: Optional[str] = None
+        self._id: Optional[str] = id
         self._image: Optional[Callable[[], bytes]] = None
-        self._name: Optional[str] = None
+        self._name: Optional[str] = name
         self._shared: Optional[bool] = False
         self._updated_at: Optional["datetime"] = None
 
-        self._owner: Optional[UserItem]
+        self._owner: Optional[UserItem] = None
         self._view: Optional[ViewItem] = None
         self._workbook: Optional[WorkbookItem] = None
 
     def __repr__(self: "CustomViewItem"):
-        view_info = "not listed"
+        view_info = ""
         if self._view:
-            view_info = self._view.name or self._view.id or "no data"
-        wb_info = "not listed"
+            view_info = " view='{}'".format(self._view.name or self._view.id or "unknown")
+        wb_info = ""
         if self._workbook:
-            wb_info = self._workbook.name or self._workbook.id or "no data"
-        owner_info = "not listed"
+            wb_info = " workbook='{}'".format(self._workbook.name or self._workbook.id or "unknown")
+        owner_info = ""
         if self._owner:
-            owner_info = self._owner.name or self._owner.id or "no data"
-        return "<CustomViewItem id={} name=`{}` view=`{}` workbook=`{}` owner=`{}`>".format(
+            owner_info = " owner='{}'".format(self._owner.name or self._owner.id or "unknown")
+        return "<CustomViewItem id={} name=`{}`{}{}{}>".format(
             self.id, self.name, view_info, wb_info, owner_info
         )
 

--- a/tableauserverclient/models/custom_view_item.py
+++ b/tableauserverclient/models/custom_view_item.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+from defusedxml.ElementTree import fromstring
+from typing import Callable, List, Optional
+
+from .exceptions import UnpopulatedPropertyError
+from ..datetime_helpers import parse_datetime
+
+
+class CustomViewItem(object):
+    def __init__(self) -> None:
+        self._content_url: Optional[str] = None
+        self._created_at: Optional["datetime"] = None
+        self._id: Optional[str] = None
+        self._image: Optional[Callable[[], bytes]] = None
+        self._name: Optional[str] = None
+        self._owner_id: Optional[str] = None
+        self._updated_at: Optional["datetime"] = None
+        self._view_id: Optional[str] = None
+        self._workbook_id: Optional[str] = None
+
+    def _set_image(self, image):
+        self._image = image
+
+    @property
+    def content_url(self) -> Optional[str]:
+        return self._content_url
+
+    @property
+    def created_at(self) -> Optional["datetime"]:
+        return self._created_at
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._id
+
+    @property
+    def image(self) -> bytes:
+        if self._image is None:
+            error = "View item must be populated with its png image first."
+            raise UnpopulatedPropertyError(error)
+        return self._image()
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._name
+
+    @property
+    def owner_id(self) -> Optional[str]:
+        return self._owner_id
+
+    @property
+    def updated_at(self) -> Optional["datetime"]:
+        return self._updated_at
+
+    @property
+    def workbook_id(self) -> Optional[str]:
+        return self._workbook_id
+
+    @classmethod
+    def from_response(cls, resp, ns, workbook_id="") -> List["CustomViewItem"]:
+        return cls.from_xml_element(fromstring(resp), ns, workbook_id)
+
+    """
+    <customView
+    id="37d015c6-bc28-4c88-989c-72c0a171f7aa"
+    name="New name 2"
+    createdAt="2016-02-03T23:35:09Z"
+    updatedAt="2022-09-28T23:56:01Z"
+    shared="false">
+      <view id="8e33ff19-a7a4-4aa5-9dd8-a171e2b9c29f" name="circle"/>
+      <workbook id="2fbe87c9-a7d8-45bf-b2b3-877a26ec9af5" name="marks and viz types 2"/>
+      <owner id="cdfe8548-84c8-418e-9b33-2c0728b2398a" name="workgroupuser"/>
+    </customView>
+    """
+
+    @classmethod
+    def from_xml_element(cls, parsed_response, ns, workbook_id="") -> List["CustomViewItem"]:
+        all_view_items = list()
+        all_view_xml = parsed_response.findall(".//t:customView", namespaces=ns)
+        for custom_view_xml in all_view_xml:
+            cv_item = cls()
+            view_elem = custom_view_xml.find(".//t:view", namespaces=ns)
+            workbook_elem = custom_view_xml.find(".//t:workbook", namespaces=ns)
+            owner_elem = custom_view_xml.find(".//t:owner", namespaces=ns)
+            cv_item._created_at = parse_datetime(custom_view_xml.get("createdAt", None))
+            cv_item._updated_at = parse_datetime(custom_view_xml.get("updatedAt", None))
+            cv_item._id = custom_view_xml.get("id", None)
+            cv_item._name = custom_view_xml.get("name", None)
+
+            if owner_elem is not None:
+                cv_item._owner_id = owner_elem.get("id", None)
+
+            if view_elem is not None:
+                cv_item._view_id = view_elem.get("id", None)
+
+            if workbook_id:
+                cv_item._workbook_id = workbook_id
+            elif workbook_elem is not None:
+                cv_item._workbook_id = workbook_elem.get("id", None)
+
+            all_view_items.append(cv_item)
+        return all_view_items

--- a/tableauserverclient/models/custom_view_item.py
+++ b/tableauserverclient/models/custom_view_item.py
@@ -1,22 +1,43 @@
 from datetime import datetime
-from defusedxml.ElementTree import fromstring
+
+from defusedxml import ElementTree
+from defusedxml.ElementTree import fromstring, tostring
 from typing import Callable, List, Optional
 
 from .exceptions import UnpopulatedPropertyError
+from .user_item import UserItem
+from .view_item import ViewItem
+from .workbook_item import WorkbookItem
 from ..datetime_helpers import parse_datetime
 
 
 class CustomViewItem(object):
     def __init__(self) -> None:
-        self._content_url: Optional[str] = None
+        self._content_url: Optional[str] = None  # ?
         self._created_at: Optional["datetime"] = None
         self._id: Optional[str] = None
         self._image: Optional[Callable[[], bytes]] = None
         self._name: Optional[str] = None
-        self._owner_id: Optional[str] = None
+        self._shared: Optional[bool] = False
         self._updated_at: Optional["datetime"] = None
-        self._view_id: Optional[str] = None
-        self._workbook_id: Optional[str] = None
+
+        self._owner: Optional[UserItem]
+        self._view: Optional[ViewItem] = None
+        self._workbook: Optional[WorkbookItem] = None
+
+    def __repr__(self: "CustomViewItem"):
+        view_info = "not listed"
+        if self._view:
+            view_info = self._view.name or self._view.id or "no data"
+        wb_info = "not listed"
+        if self._workbook:
+            wb_info = self._workbook.name or self._workbook.id or "no data"
+        owner_info = "not listed"
+        if self._owner:
+            owner_info = self._owner.name or self._owner.id or "no data"
+        return "<CustomViewItem id={} name=`{}` view=`{}` workbook=`{}` owner=`{}`>".format(
+            self.id, self.name, view_info, wb_info, owner_info
+        )
 
     def _set_image(self, image):
         self._image = image
@@ -44,20 +65,48 @@ class CustomViewItem(object):
     def name(self) -> Optional[str]:
         return self._name
 
+    @name.setter
+    def name(self, value: str):
+        self._name = value
+
     @property
-    def owner_id(self) -> Optional[str]:
-        return self._owner_id
+    def shared(self) -> Optional[bool]:
+        return self._shared
+
+    @shared.setter
+    def shared(self, value: bool):
+        self._shared = value
 
     @property
     def updated_at(self) -> Optional["datetime"]:
         return self._updated_at
 
     @property
-    def workbook_id(self) -> Optional[str]:
-        return self._workbook_id
+    def owner(self) -> Optional[UserItem]:
+        return self._owner
+
+    @owner.setter
+    def owner(self, value: UserItem):
+        self._owner = value
+
+    @property
+    def workbook(self) -> Optional[WorkbookItem]:
+        return self._workbook
+
+    @property
+    def view(self) -> Optional[ViewItem]:
+        return self._view
 
     @classmethod
-    def from_response(cls, resp, ns, workbook_id="") -> List["CustomViewItem"]:
+    def from_response(cls, resp, ns, workbook_id="") -> "CustomViewItem":
+        item = cls.list_from_response(resp, ns, workbook_id)
+        if not item or len(item) == 0:
+            return None
+        else:
+            return item[0]
+
+    @classmethod
+    def list_from_response(cls, resp, ns, workbook_id="") -> List["CustomViewItem"]:
         return cls.from_xml_element(fromstring(resp), ns, workbook_id)
 
     """
@@ -79,24 +128,31 @@ class CustomViewItem(object):
         all_view_xml = parsed_response.findall(".//t:customView", namespaces=ns)
         for custom_view_xml in all_view_xml:
             cv_item = cls()
-            view_elem = custom_view_xml.find(".//t:view", namespaces=ns)
-            workbook_elem = custom_view_xml.find(".//t:workbook", namespaces=ns)
-            owner_elem = custom_view_xml.find(".//t:owner", namespaces=ns)
+            view_elem: ElementTree = custom_view_xml.find(".//t:view", namespaces=ns)
+            workbook_elem: str = custom_view_xml.find(".//t:workbook", namespaces=ns)
+            owner_elem: str = custom_view_xml.find(".//t:owner", namespaces=ns)
             cv_item._created_at = parse_datetime(custom_view_xml.get("createdAt", None))
             cv_item._updated_at = parse_datetime(custom_view_xml.get("updatedAt", None))
+            cv_item._content_url = custom_view_xml.get("contentUrl", None)
             cv_item._id = custom_view_xml.get("id", None)
             cv_item._name = custom_view_xml.get("name", None)
 
             if owner_elem is not None:
-                cv_item._owner_id = owner_elem.get("id", None)
+                parsed_owners = UserItem.from_response_as_owner(tostring(custom_view_xml), ns)
+                if parsed_owners and len(parsed_owners) > 0:
+                    cv_item._owner = parsed_owners[0]
 
             if view_elem is not None:
-                cv_item._view_id = view_elem.get("id", None)
+                parsed_views = ViewItem.from_response(tostring(custom_view_xml), ns)
+                if parsed_views and len(parsed_views) > 0:
+                    cv_item._view = parsed_views[0]
 
             if workbook_id:
-                cv_item._workbook_id = workbook_id
+                cv_item._workbook = WorkbookItem(workbook_id)
             elif workbook_elem is not None:
-                cv_item._workbook_id = workbook_elem.get("id", None)
+                parsed_workbooks = WorkbookItem.from_response(tostring(custom_view_xml), ns)
+                if parsed_workbooks and len(parsed_workbooks) > 0:
+                    cv_item._workbook = parsed_workbooks[0]
 
             all_view_items.append(cv_item)
         return all_view_items

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -93,7 +93,7 @@ class UserItem(object):
         return self._id
 
     @id.setter
-    def id(self, value:str) -> None:
+    def id(self, value: str) -> None:
         self._id = value
 
     @property

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -92,6 +92,10 @@ class UserItem(object):
     def id(self) -> Optional[str]:
         return self._id
 
+    @id.setter
+    def id(self, value:str) -> None:
+        self._id = value
+
     @property
     def last_login(self) -> Optional[datetime]:
         return self._last_login

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -101,7 +101,6 @@ class UserItem(object):
         return self._name
 
     @name.setter
-    @property_not_empty
     def name(self, value: str):
         self._name = value
 
@@ -205,9 +204,19 @@ class UserItem(object):
 
     @classmethod
     def from_response(cls, resp, ns) -> List["UserItem"]:
+        element_name = ".//t:user"
+        return cls._parse_xml(element_name, resp, ns)
+
+    @classmethod
+    def from_response_as_owner(cls, resp, ns) -> List["UserItem"]:
+        element_name = ".//t:owner"
+        return cls._parse_xml(element_name, resp, ns)
+
+    @classmethod
+    def _parse_xml(cls, element_name, resp, ns):
         all_user_items = []
         parsed_response = fromstring(resp)
-        all_user_xml = parsed_response.findall(".//t:user", namespaces=ns)
+        all_user_xml = parsed_response.findall(element_name, namespaces=ns)
         for user_xml in all_user_xml:
             (
                 id,

--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -1,4 +1,5 @@
 from .auth_endpoint import Auth
+from .custom_views_endpoint import CustomViews
 from .data_acceleration_report_endpoint import DataAccelerationReport
 from .data_alert_endpoint import DataAlerts
 from .databases_endpoint import Databases

--- a/tableauserverclient/server/endpoint/custom_views_endpoint.py
+++ b/tableauserverclient/server/endpoint/custom_views_endpoint.py
@@ -82,6 +82,9 @@ class CustomViews(QuerysetEndpoint):
         if not view_item.id:
             error = "Custom view item missing ID."
             raise MissingRequiredFieldError(error)
+        if not (view_item.owner or view_item.name or view_item.shared):
+            logger.debug("No changes to make")
+            return view_item
 
         # Update the custom view owner or name
         url = "{0}/{1}".format(self.baseurl, view_item.id)

--- a/tableauserverclient/server/endpoint/custom_views_endpoint.py
+++ b/tableauserverclient/server/endpoint/custom_views_endpoint.py
@@ -1,0 +1,91 @@
+import logging
+from typing import List, Optional, Tuple
+
+from .endpoint import QuerysetEndpoint, api
+from .exceptions import MissingRequiredFieldError
+from tableauserverclient.models import CustomViewItem, PaginationItem
+from tableauserverclient.server import RequestFactory, RequestOptions, ImageRequestOptions
+
+logger = logging.getLogger("tableau.endpoint.custom_views")
+
+"""
+Get a list of custom views on a site
+get the details of a custom view
+download an image of a custom view.
+Delete a custom view 
+update the name or owner of a custom view.
+"""
+
+
+class CustomViews(QuerysetEndpoint):
+    def __init__(self, parent_srv):
+        super(CustomViews, self).__init__(parent_srv)
+
+    @property
+    def baseurl(self) -> str:
+        return "{0}/sites/{1}/customviews".format(self.parent_srv.baseurl, self.parent_srv.site_id)
+
+    """
+    If the request has no filter parameters: Administrators will see all custom views. 
+        Other users will see only custom views that they own.
+    If the filter parameters include ownerId: Users will see only custom views that they own.
+    If the filter parameters include viewId and/or workbookId, and don't include ownerId:
+        Users will see those custom views that they have Write and WebAuthoring permissions for.
+    If site user visibility is not set to Limited, the Users will see those custom views that are "public",
+     meaning the value of their shared attribute is true.
+    If site user visibility is set to Limited, ????
+    """
+
+    @api(version="3.18")
+    def get(self, req_options: Optional["RequestOptions"] = None) -> Tuple[List[CustomViewItem], PaginationItem]:
+        logger.info("Querying all custom views on site")
+        url = self.baseurl
+        server_response = self.get_request(url, req_options)
+        pagination_item = PaginationItem.from_response(server_response.content, self.parent_srv.namespace)
+        all_view_items = CustomViewItem.from_response(server_response.content, self.parent_srv.namespace)
+        return all_view_items, pagination_item
+
+    @api(version="3.18")
+    def get_by_id(self, view_id: str) -> CustomViewItem:
+        if not view_id:
+            error = "Custom view item missing ID."
+            raise MissingRequiredFieldError(error)
+        logger.info("Querying custom view (ID: {0})".format(view_id))
+        url = "{0}/{1}".format(self.baseurl, view_id)
+        server_response = self.get_request(url)
+        return CustomViewItem.from_response(server_response.content, self.parent_srv.namespace)[0]
+
+    @api(version="3.18")
+    def populate_image(self, view_item: CustomViewItem, req_options: Optional["ImageRequestOptions"] = None) -> None:
+        if not view_item.id:
+            error = "Custom View item missing ID."
+            raise MissingRequiredFieldError(error)
+
+        def image_fetcher():
+            return self._get_view_image(view_item, req_options)
+
+        view_item._set_image(image_fetcher)
+        logger.info("Populated image for custom view (ID: {0})".format(view_item.id))
+
+    def _get_view_image(self, view_item: CustomViewItem, req_options: Optional["ImageRequestOptions"]) -> bytes:
+        url = "{0}/{1}/image".format(self.baseurl, view_item.id)
+        server_response = self.get_request(url, req_options)
+        image = server_response.content
+        return image
+
+    """
+    Not yet implemented: pdf or csv exports
+    """
+
+    @api(version="3.18")
+    def update(self, view_item: CustomViewItem) -> CustomViewItem:
+        if not view_item.id:
+            error = "Custom view item missing ID."
+            raise MissingRequiredFieldError(error)
+
+        # Update the custom view owner or name
+        url = "{0}/{1}".format(self.baseurl, view_item.id)
+        update_req = RequestFactory.Workbook.update_req(view_item)
+        server_response = self.put_request(url, update_req)
+        logger.info("Updated workbook item (ID: {0})".format(view_item.id))
+        return CustomViewItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/tableauserverclient/server/endpoint/custom_views_endpoint.py
+++ b/tableauserverclient/server/endpoint/custom_views_endpoint.py
@@ -55,7 +55,6 @@ class CustomViews(QuerysetEndpoint):
         server_response = self.get_request(url)
         return CustomViewItem.from_response(server_response.content, self.parent_srv.namespace)
 
-
     @api(version="3.18")
     def populate_image(self, view_item: CustomViewItem, req_options: Optional["ImageRequestOptions"] = None) -> None:
         if not view_item.id:
@@ -79,7 +78,7 @@ class CustomViews(QuerysetEndpoint):
     """
 
     @api(version="3.18")
-    def update(self, view_item: CustomViewItem) -> CustomViewItem:
+    def update(self, view_item: CustomViewItem) -> Optional[CustomViewItem]:
         if not view_item.id:
             error = "Custom view item missing ID."
             raise MissingRequiredFieldError(error)
@@ -100,4 +99,3 @@ class CustomViews(QuerysetEndpoint):
         url = "{0}/{1}".format(self.baseurl, view_id)
         self.delete_request(url)
         logger.info("Deleted single custom view (ID: {0})".format(view_id))
-

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1127,10 +1127,21 @@ class MetricRequest:
         return ET.tostring(xml_request)
 
 
+class CustomViewRequest(object):
+    @_tsrequest_wrapped
+    def update_req(self, xml_request:ET.Element, custom_view_item: CustomViewItem):
+        updating_element = ET.SubElement(xml_request, "customView")
+        if custom_view_item.owner is not None and custom_view_item.owner.id is not None:
+            ET.SubElement(updating_element, "owner", {"id": custom_view_item.owner.id})
+        if custom_view_item.name is not None:
+            updating_element.attrib["name"] = custom_view_item.name
+
+
 class RequestFactory(object):
     Auth = AuthRequest()
     Connection = Connection()
     Column = ColumnRequest()
+    CustomView = CustomViewRequest()
     DataAlert = DataAlertRequest()
     Datasource = DatasourceRequest()
     Database = DatabaseRequest()

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1129,7 +1129,7 @@ class MetricRequest:
 
 class CustomViewRequest(object):
     @_tsrequest_wrapped
-    def update_req(self, xml_request:ET.Element, custom_view_item: CustomViewItem):
+    def update_req(self, xml_request: ET.Element, custom_view_item: CustomViewItem):
         updating_element = ET.SubElement(xml_request, "customView")
         if custom_view_item.owner is not None and custom_view_item.owner.id is not None:
             ET.SubElement(updating_element, "owner", {"id": custom_view_item.owner.id})

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -51,7 +51,7 @@ _PRODUCT_TO_REST_VERSION = {
 }
 
 minimum_supported_server_version = "2.3"
-default_server_version = "3.0"  # at least use the current major version
+default_server_version = "2.4"  # first version that dropped the legacy auth endpoint
 
 
 class Server(object):

--- a/test/assets/custom_view_get.xml
+++ b/test/assets/custom_view_get.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="1" pageSize="100" totalAvailable="2" />
+    <customViews>
+        <customView id="d79634e1-6063-4ec9-95ff-50acbf609ff5" name="ENDANGERED SAFARI" contentUrl="SafariSample/sheets/ENDANGEREDSAFARI">
+            <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+            <view id="5241e88d-d384-4fd7-9c2f-648b5247efc5" />
+        </customView>
+        <customView id="fd252f73-593c-4c4e-8584-c032b8022adc" name="Overview" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" shared="True">
+            <workbook id="6d13b0ca-043d-4d42-8c9d-3f3313ea3a00" />
+            <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+            <view id="5b534f74-3226-11e8-b47a-cb2e00f738a3" />
+        </customView>
+    </customViews>
+</tsResponse>

--- a/test/assets/custom_view_get_id.xml
+++ b/test/assets/custom_view_get_id.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <customView id="d79634e1-6063-4ec9-95ff-50acbf609ff5" name="ENDANGERED SAFARI" contentUrl="SafariSample/sheets/ENDANGEREDSAFARI" createdAt="2002-05-30T09:00:00Z" updatedAt="2002-06-05T08:00:59Z" sheetType="story">
+        <workbook id="3cc6cd06-89ce-4fdc-b935-5294135d6d42" />
+        <owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
+        <view id="5241e88d-d384-4fd7-9c2f-648b5247efc5" />
+    </customView>
+</tsResponse>

--- a/test/assets/custom_view_update.xml
+++ b/test/assets/custom_view_update.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <customView id="1f951daf-4061-451a-9df1-69a8062664f2" name="Best test ever" contentUrl="RESTAPISample" shared="True" createdAt="2016-08-18T18:25:36Z" updatedAt="2016-08-18T18:29:36Z">
+        <workbook id="1d0304cd-3796-429f-b815-7258370b9b74" name="Tableau" />
+        <owner id="dd2239f6-ddf1-4107-981a-4cf94e415794" />
+        <view id="aa2239f6-ddf1-4107-981a-4cf94e415794" />
+    </customView>
+</tsResponse>

--- a/test/assets/server_info_get.xml
+++ b/test/assets/server_info_get.xml
@@ -1,6 +1,6 @@
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.4.xsd">
 <serverInfo>
 <productVersion build="10100.16.1024.2100">10.1.0</productVersion>
-<restApiVersion>2.4</restApiVersion>
+<restApiVersion>3.10</restApiVersion>
 </serverInfo>
 </tsResponse>

--- a/test/test_custom_view.py
+++ b/test/test_custom_view.py
@@ -60,9 +60,12 @@ class CustomViewTests(unittest.TestCase):
         self.assertEqual("d79634e1-6063-4ec9-95ff-50acbf609ff5", view.id)
         self.assertEqual("ENDANGERED SAFARI", view.name)
         self.assertEqual("SafariSample/sheets/ENDANGEREDSAFARI", view.content_url)
-        self.assertEqual("3cc6cd06-89ce-4fdc-b935-5294135d6d42", view.workbook.id)
-        self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", view.owner.id)
-        self.assertEqual("5241e88d-d384-4fd7-9c2f-648b5247efc5", view.view.id)
+        if view.workbook:
+            self.assertEqual("3cc6cd06-89ce-4fdc-b935-5294135d6d42", view.workbook.id)
+        if view.owner:
+            self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", view.owner.id)
+        if view.view:
+            self.assertEqual("5241e88d-d384-4fd7-9c2f-648b5247efc5", view.view.id)
         self.assertEqual("2002-05-30T09:00:00Z", format_datetime(view.created_at))
         self.assertEqual("2002-06-05T08:00:59Z", format_datetime(view.updated_at))
 
@@ -117,11 +120,12 @@ class CustomViewTests(unittest.TestCase):
             the_custom_view = TSC.CustomViewItem("1d0304cd-3796-429f-b815-7258370b9b74", name="Best test ever")
             the_custom_view._id = "1f951daf-4061-451a-9df1-69a8062664f2"
             the_custom_view.owner = TSC.UserItem()
-            the_custom_view.owner.id="dd2239f6-ddf1-4107-981a-4cf94e415794"
+            the_custom_view.owner.id = "dd2239f6-ddf1-4107-981a-4cf94e415794"
             the_custom_view = self.server.custom_views.update(the_custom_view)
 
         self.assertEqual("1f951daf-4061-451a-9df1-69a8062664f2", the_custom_view.id)
-        self.assertEqual("dd2239f6-ddf1-4107-981a-4cf94e415794", the_custom_view.owner.id)
+        if the_custom_view.owner:
+            self.assertEqual("dd2239f6-ddf1-4107-981a-4cf94e415794", the_custom_view.owner.id)
         self.assertEqual("Best test ever", the_custom_view.name)
 
     def test_update_missing_id(self) -> None:

--- a/test/test_custom_view.py
+++ b/test/test_custom_view.py
@@ -1,0 +1,101 @@
+import os
+import unittest
+
+import requests_mock
+
+import tableauserverclient as TSC
+from tableauserverclient.datetime_helpers import format_datetime
+
+TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
+
+GET_XML = os.path.join(TEST_ASSET_DIR, "custom_view_get.xml")
+GET_XML_ID = os.path.join(TEST_ASSET_DIR, "custom_view_get_id.xml")
+POPULATE_PREVIEW_IMAGE = os.path.join(TEST_ASSET_DIR, "Sample View Image.png")
+
+
+class CustomViewTests(unittest.TestCase):
+    def setUp(self):
+        self.server = TSC.Server("http://test", False)
+        self.server.version = "3.19"  # custom views only introduced in 3.19
+
+        # Fake sign in
+        self.server._site_id = "dad65087-b08b-4603-af4e-2887b8aafc67"
+        self.server._auth_token = "j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM"
+
+        self.baseurl = self.server.custom_views.baseurl
+
+    def test_get(self) -> None:
+        with open(GET_XML, "rb") as f:
+            response_xml = f.read().decode("utf-8")
+            print(response_xml)
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=response_xml)
+            all_views, pagination_item = self.server.custom_views.get()
+
+        self.assertEqual(2, pagination_item.total_available)
+        self.assertEqual("d79634e1-6063-4ec9-95ff-50acbf609ff5", all_views[0].id)
+        self.assertEqual("ENDANGERED SAFARI", all_views[0].name)
+        self.assertEqual("SafariSample/sheets/ENDANGEREDSAFARI", all_views[0].content_url)
+        self.assertEqual("3cc6cd06-89ce-4fdc-b935-5294135d6d42", all_views[0].workbook.id)
+        self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", all_views[0].owner.id)
+        self.assertIsNone(all_views[0].created_at)
+        self.assertIsNone(all_views[0].updated_at)
+
+        self.assertEqual("fd252f73-593c-4c4e-8584-c032b8022adc", all_views[1].id)
+        self.assertEqual("Overview", all_views[1].name)
+        self.assertEqual(False, all_views[1].shared)
+        self.assertEqual("6d13b0ca-043d-4d42-8c9d-3f3313ea3a00", all_views[1].workbook.id)
+        self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", all_views[1].owner.id)
+        self.assertEqual("2002-05-30T09:00:00Z", format_datetime(all_views[1].created_at))
+        self.assertEqual("2002-06-05T08:00:59Z", format_datetime(all_views[1].updated_at))
+
+    def test_get_by_id(self) -> None:
+        with open(GET_XML_ID, "rb") as f:
+            response_xml = f.read().decode("utf-8")
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + "/d79634e1-6063-4ec9-95ff-50acbf609ff5", text=response_xml)
+            view: TSC.CustomViewItem = self.server.custom_views.get_by_id("d79634e1-6063-4ec9-95ff-50acbf609ff5")
+
+        self.assertEqual("d79634e1-6063-4ec9-95ff-50acbf609ff5", view.id)
+        self.assertEqual("ENDANGERED SAFARI", view.name)
+        self.assertEqual("SafariSample/sheets/ENDANGEREDSAFARI", view.content_url)
+        self.assertEqual("3cc6cd06-89ce-4fdc-b935-5294135d6d42", view.workbook.id)
+        self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", view.owner.id)
+        self.assertEqual("5241e88d-d384-4fd7-9c2f-648b5247efc5", view.view.id)
+        self.assertEqual("2002-05-30T09:00:00Z", format_datetime(view.created_at))
+        self.assertEqual("2002-06-05T08:00:59Z", format_datetime(view.updated_at))
+
+    def test_get_by_id_missing_id(self) -> None:
+        self.assertRaises(TSC.MissingRequiredFieldError, self.server.custom_views.get_by_id, None)
+
+    def test_get_before_signin(self) -> None:
+        self.server._auth_token = None
+        self.assertRaises(TSC.NotSignedInError, self.server.custom_views.get)
+
+    def test_populate_image(self) -> None:
+        with open(POPULATE_PREVIEW_IMAGE, "rb") as f:
+            response = f.read()
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + "/d79634e1-6063-4ec9-95ff-50acbf609ff5/image", content=response)
+            single_view = TSC.CustomViewItem()
+            single_view._id = "d79634e1-6063-4ec9-95ff-50acbf609ff5"
+            self.server.custom_views.populate_image(single_view)
+            self.assertEqual(response, single_view.image)
+
+    def test_populate_image_with_options(self) -> None:
+        with open(POPULATE_PREVIEW_IMAGE, "rb") as f:
+            response = f.read()
+        with requests_mock.mock() as m:
+            m.get(
+                self.baseurl + "/d79634e1-6063-4ec9-95ff-50acbf609ff5/image?resolution=high&maxAge=10", content=response
+            )
+            single_view = TSC.CustomViewItem()
+            single_view._id = "d79634e1-6063-4ec9-95ff-50acbf609ff5"
+            req_option = TSC.ImageRequestOptions(imageresolution=TSC.ImageRequestOptions.Resolution.High, maxage=10)
+            self.server.custom_views.populate_image(single_view, req_option)
+            self.assertEqual(response, single_view.image)
+
+    def test_populate_image_missing_id(self) -> None:
+        single_view = TSC.CustomViewItem()
+        single_view._id = None
+        self.assertRaises(TSC.MissingRequiredFieldError, self.server.custom_views.populate_image, single_view)

--- a/test/test_custom_view.py
+++ b/test/test_custom_view.py
@@ -129,5 +129,5 @@ class CustomViewTests(unittest.TestCase):
         self.assertEqual("Best test ever", the_custom_view.name)
 
     def test_update_missing_id(self) -> None:
-        single_workbook = TSC.CustomViewItem("test")
-        self.assertRaises(TSC.MissingRequiredFieldError, self.server.workbooks.update, single_workbook)
+        cv = TSC.CustomViewItem(name="test")
+        self.assertRaises(TSC.MissingRequiredFieldError, self.server.custom_views.update, cv)

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -28,7 +28,7 @@ class ServerInfoTests(unittest.TestCase):
 
             self.assertEqual("10.1.0", actual.product_version)
             self.assertEqual("10100.16.1024.2100", actual.build_number)
-            self.assertEqual("2.4", actual.rest_api_version)
+            self.assertEqual("3.10", actual.rest_api_version)
 
     def test_server_info_use_highest_version_downgrades(self):
         with open(SERVER_INFO_AUTH_INFO_XML, "rb") as f:
@@ -42,18 +42,18 @@ class ServerInfoTests(unittest.TestCase):
             m.get(self.server.server_address + "/api/2.4/serverInfo", text=si_response_xml, status_code=404)
             m.get(self.server.server_address + "/auth?format=xml", text=auth_response_xml)
             self.server.use_server_version()
-            self.assertEqual(self.server.version, "2.2")
+            self.assertEqual(self.server.version, "2.4")
 
     def test_server_info_use_highest_version_upgrades(self):
         with open(SERVER_INFO_GET_XML, "rb") as f:
             si_response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
-            m.get(self.server.server_address + "/api/2.4/serverInfo", text=si_response_xml)
+            m.get(self.server.server_address + "/api/2.8/serverInfo", text=si_response_xml)
             # Pretend we're old
-            self.server.version = "2.0"
+            self.server.version = "2.8"
             self.server.use_server_version()
-            # Did we upgrade to 2.4?
-            self.assertEqual(self.server.version, "2.4")
+            # Did we upgrade to 3.10?
+            self.assertEqual(self.server.version, "3.10")
 
     def test_server_use_server_version_flag(self):
         with open(SERVER_INFO_25_XML, "rb") as f:

--- a/test/test_user_model.py
+++ b/test/test_user_model.py
@@ -10,16 +10,6 @@ import tableauserverclient as TSC
 
 
 class UserModelTests(unittest.TestCase):
-    def test_invalid_name(self):
-        self.assertRaises(ValueError, TSC.UserItem, None, TSC.UserItem.Roles.Publisher)
-        self.assertRaises(ValueError, TSC.UserItem, "", TSC.UserItem.Roles.Publisher)
-        user = TSC.UserItem("me", TSC.UserItem.Roles.Publisher)
-        with self.assertRaises(ValueError):
-            user.name = None
-
-        with self.assertRaises(ValueError):
-            user.name = ""
-
     def test_invalid_auth_setting(self):
         user = TSC.UserItem("me", TSC.UserItem.Roles.Publisher)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
They are not quite the same as normal views so they got their own class. 

You can
- Get a list of custom views on a site
- Get the details of a custom view
- Export an image of a custom view.
- Delete a custom view 
- Update the name or owner of a custom view.

Note that you can **only** export as image(png) - no csv or pdf export is available. 
This will enable the feature to be added to tabcmd - yay!
