### PR TITLE
⬆️ Allow more recent version of packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 dependencies = [
     'defusedxml>=0.7.1',
-    'packaging~=21.3',
+    'packaging>=22.0',  # bumping to minimum version required by black
     'requests>=2.28',
     'urllib3~=1.26.8',
 ]

--- a/samples/add_default_permission.py
+++ b/samples/add_default_permission.py
@@ -46,7 +46,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Create a sample project
         project = TSC.ProjectItem("sample_project")
         project = server.projects.create(project)

--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -18,7 +18,6 @@ from tableauserverclient import ServerResponseError
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Creates a sample user group.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/create_schedules.py
+++ b/samples/create_schedules.py
@@ -15,7 +15,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Creates sample schedules for each type of frequency.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/explore_datasource.py
+++ b/samples/explore_datasource.py
@@ -16,7 +16,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Explore datasource functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/explore_site.py
+++ b/samples/explore_site.py
@@ -12,7 +12,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Explore site updates by the Server API.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/explore_webhooks.py
+++ b/samples/explore_webhooks.py
@@ -17,7 +17,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Explore webhook functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")
@@ -49,10 +48,8 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Create webhook if create flag is set (-create, -c)
         if args.create:
-
             new_webhook = TSC.WebhookItem()
             new_webhook.name = args.create
             new_webhook.url = "https://ifttt.com/maker-url"

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -17,7 +17,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Explore workbook functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")
@@ -52,7 +51,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Publish workbook if publish flag is set (-publish, -p)
         overwrite_true = TSC.Server.PublishMode.Overwrite
         if args.publish:

--- a/samples/extracts.py
+++ b/samples/extracts.py
@@ -17,7 +17,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Explore extract functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")
@@ -50,7 +49,6 @@ def main():
     server.add_http_options({"verify": False})
     server.use_server_version()
     with server.auth.sign_in(tableau_auth):
-
         # Gets all workbook items
         all_workbooks, pagination_item = server.workbooks.get()
         print("\nThere are {} workbooks on site: ".format(pagination_item.total_available))

--- a/samples/filter_sort_groups.py
+++ b/samples/filter_sort_groups.py
@@ -53,7 +53,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         group_name = "SALES NORTHWEST"
         # Try to create a group named "SALES NORTHWEST"
         create_example_group(group_name, server)

--- a/samples/filter_sort_projects.py
+++ b/samples/filter_sort_projects.py
@@ -18,7 +18,6 @@ def create_example_project(
     description="Project created for testing",
     server=None,
 ):
-
     new_project = TSC.ProjectItem(name=name, content_permissions=content_permissions, description=description)
     try:
         server.projects.create(new_project)

--- a/samples/initialize_server.py
+++ b/samples/initialize_server.py
@@ -45,7 +45,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         ################################################################################
         # Step 2: Create the site we need only if it doesn't exist
         ################################################################################
@@ -75,7 +74,6 @@ def main():
     tableau_auth.site_id = args.site_id
 
     with server_upload.auth.sign_in(tableau_auth):
-
         ################################################################################
         # Step 4: Create the project we need only if it doesn't exist
         ################################################################################

--- a/samples/login.py
+++ b/samples/login.py
@@ -48,7 +48,6 @@ def sample_define_common_options(parser):
 
 
 def sample_connect_to_server(args):
-
     if args.username:
         # Trying to authenticate using username and password.
         password = args.password or getpass.getpass("Password: ")

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -15,7 +15,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Move one workbook from the default project to another.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -16,7 +16,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(
         description="Move one workbook from the"
         "default project of the default site to"
@@ -84,7 +83,6 @@ def main():
                 # Signing into another site requires another server object
                 # because of the different auth token and site ID.
                 with dest_server.auth.sign_in(tableau_auth):
-
                     # Step 5: Create a new workbook item and publish workbook. Note that
                     # an empty project_id will publish to the 'Default' project.
                     new_workbook = TSC.WorkbookItem(name=args.workbook_name, project_id="")

--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -18,7 +18,6 @@ import tableauserverclient as TSC
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Demonstrate pagination on the list of workbooks on the server.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -22,7 +22,6 @@ from tableauserverclient import ConnectionCredentials, ConnectionItem
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Publish a workbook to server.")
     # Common options; please keep those in sync across all samples
     parser.add_argument("--server", "-s", required=True, help="server address")
@@ -55,7 +54,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Step 2: Get all the projects on server, then look for the default one.
         all_projects, pagination_item = server.projects.get()
         default_project = next((project for project in all_projects if project.is_default()), None)

--- a/samples/query_permissions.py
+++ b/samples/query_permissions.py
@@ -44,7 +44,6 @@ def main():
     tableau_auth = TSC.PersonalAccessTokenAuth(args.token_name, args.token_value, site_id=args.site)
     server = TSC.Server(args.server, use_server_version=True)
     with server.auth.sign_in(tableau_auth):
-
         # Mapping to grab the handler for the user-inputted resource type
         endpoint = {
             "workbook": server.workbooks,

--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -85,7 +85,6 @@ class ConnectionItem(object):
             connection_credentials = connection_xml.find(".//t:connectionCredentials", namespaces=ns)
 
             if connection_credentials is not None:
-
                 connection_item.connection_credentials = ConnectionCredentials.from_xml_element(
                     connection_credentials, ns
                 )

--- a/tableauserverclient/models/group_item.py
+++ b/tableauserverclient/models/group_item.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
 
 class GroupItem(object):
-
     tag_name: str = "group"
 
     class LicenseMode:

--- a/tableauserverclient/models/interval_item.py
+++ b/tableauserverclient/models/interval_item.py
@@ -27,7 +27,6 @@ class IntervalItem(object):
 
 class HourlyInterval(object):
     def __init__(self, start_time, end_time, interval_value):
-
         self.start_time = start_time
         self.end_time = end_time
         self.interval = interval_value
@@ -70,7 +69,6 @@ class HourlyInterval(object):
         self._interval = interval
 
     def _interval_type_pairs(self):
-
         # We use fractional hours for the two minute-based intervals.
         # Need to convert to minutes from hours here
         if self.interval in {0.25, 0.5}:

--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -101,7 +101,6 @@ def property_is_int(range, allowed=None):
 
 
 def property_matches(regex_to_match, error):
-
     compiled_re = re.compile(regex_to_match)
 
     def wrapper(func):

--- a/tableauserverclient/models/table_item.py
+++ b/tableauserverclient/models/table_item.py
@@ -140,7 +140,6 @@ class TableItem(object):
 
     @staticmethod
     def _parse_element(table_xml, ns):
-
         table_values = table_xml.attrib.copy()
 
         contact = table_xml.find(".//t:contact", namespaces=ns)

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 
 class UserItem(object):
-
     tag_name: str = "user"
 
     class Roles:

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -199,7 +199,6 @@ class Datasources(QuerysetEndpoint):
         connections: Optional[Sequence[ConnectionItem]] = None,
         as_job: bool = False,
     ) -> Union[DatasourceItem, JobItem]:
-
         if isinstance(file, (os.PathLike, str)):
             if not os.path.isfile(file):
                 error = "File path does not lead to an existing file."

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -90,7 +90,6 @@ class Schedules(Endpoint):
         flow: Optional["FlowItem"] = None,
         task_type: Optional[str] = None,
     ) -> List[AddResponse]:
-
         # There doesn't seem to be a good reason to allow one item of each type?
         if workbook and datasource:
             warnings.warn("Passing in multiple items for add_to_schedule will be deprecated", PendingDeprecationWarning)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -319,7 +319,6 @@ class Workbooks(QuerysetEndpoint):
         hidden_views: Optional[Sequence[str]] = None,
         skip_connection_check: bool = False,
     ):
-
         if connection_credentials is not None:
             import warnings
 

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -13,7 +13,6 @@ class Pager(object):
     """
 
     def __init__(self, endpoint, request_opts=None, **kwargs):
-
         if hasattr(endpoint, "get"):
             # The simpliest case is to take an Endpoint and call its get
             endpoint = partial(endpoint.get, **kwargs)

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -542,7 +542,6 @@ class DatasourceTests(unittest.TestCase):
             )
 
     def test_publish_tde_file_object_raises_exception(self) -> None:
-
         new_datasource = TSC.DatasourceItem("ee8c6e70-43b6-11e6-af4f-f7b0d8e20760", "test")
         tds_asset = asset(os.path.join("Data", "Tableau Samples", "World Indicators.tde"))
         with open(tds_asset, "rb") as file_object:

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -29,7 +29,6 @@ class TestEndpoint(unittest.TestCase):
 
     def test_binary_log_truncated(self):
         class FakeResponse(object):
-
             headers = {"Content-Type": "application/octet-stream"}
             content = b"\x1337" * 1000
             status_code = 200

--- a/test/test_filesys_helpers.py
+++ b/test/test_filesys_helpers.py
@@ -10,7 +10,6 @@ from ._utils import asset, TEST_ASSET_DIR
 
 class FilesysTests(unittest.TestCase):
     def test_get_file_size_returns_correct_size(self):
-
         target_size = 1000  # bytes
 
         with BytesIO() as f:
@@ -21,14 +20,12 @@ class FilesysTests(unittest.TestCase):
         self.assertEqual(file_size, target_size)
 
     def test_get_file_size_returns_zero_for_empty_file(self):
-
         with BytesIO() as f:
             file_size = get_file_object_size(f)
 
         self.assertEqual(file_size, 0)
 
     def test_get_file_size_coincides_with_built_in_method(self):
-
         asset_path = asset("SampleWB.twbx")
         target_size = os.path.getsize(asset_path)
         with open(asset_path, "rb") as f:
@@ -37,7 +34,6 @@ class FilesysTests(unittest.TestCase):
         self.assertEqual(file_size, target_size)
 
     def test_get_file_type_identifies_a_zip_file(self):
-
         with BytesIO() as file_object:
             with ZipFile(file_object, "w") as zf:
                 with BytesIO() as stream:
@@ -59,7 +55,6 @@ class FilesysTests(unittest.TestCase):
         self.assertEqual(file_type, "zip")
 
     def test_get_file_type_identifies_xml_file(self):
-
         root = ET.Element("root")
         child = ET.SubElement(root, "child")
         child.text = "This is a child element"
@@ -95,7 +90,6 @@ class FilesysTests(unittest.TestCase):
         self.assertEqual(file_type, "tde")
 
     def test_get_file_type_handles_unknown_file_type(self):
-
         # Create a dummy png file
         with BytesIO() as file_object:
             png_signature = bytes.fromhex("89504E470D0A1A0A")

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -174,7 +174,6 @@ class FlowTests(unittest.TestCase):
             publish_mode = self.server.PublishMode.CreateNew
 
             with open(sample_flow, "rb") as fp:
-
                 publish_mode = self.server.PublishMode.CreateNew
 
                 new_flow = self.server.flows.publish(new_flow, fp, publish_mode)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -139,7 +139,6 @@ class ProjectTests(unittest.TestCase):
         self.assertRaises(TSC.MissingRequiredFieldError, self.server.projects.update, single_project)
 
     def test_create(self) -> None:
-
         with open(CREATE_XML, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:

--- a/test/test_site_model.py
+++ b/test/test_site_model.py
@@ -22,7 +22,6 @@ class SiteModelTests(unittest.TestCase):
             site.admin_mode = "Hello"
 
     def test_invalid_content_url(self):
-
         with self.assertRaises(ValueError):
             site = TSC.SiteItem(name="蚵仔煎", content_url="蚵仔煎")
 

--- a/test/test_user_model.py
+++ b/test/test_user_model.py
@@ -32,7 +32,6 @@ class UserModelTests(unittest.TestCase):
 
 
 class UserDataTest(unittest.TestCase):
-
     logger = logging.getLogger("UserDataTest")
 
     role_inputs = [

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -525,7 +525,6 @@ class WorkbookTests(unittest.TestCase):
             sample_workbook = os.path.join(TEST_ASSET_DIR, "SampleWB.twbx")
 
             with open(sample_workbook, "rb") as fp:
-
                 publish_mode = self.server.PublishMode.CreateNew
 
                 new_workbook = self.server.workbooks.publish(new_workbook, fp, publish_mode)
@@ -545,7 +544,6 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual("RESTAPISample_0/sheets/GDPpercapita", new_workbook.views[0].content_url)
 
     def test_publish_non_packeged_file_object(self) -> None:
-
         with open(PUBLISH_XML, "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -558,7 +556,6 @@ class WorkbookTests(unittest.TestCase):
             sample_workbook = os.path.join(TEST_ASSET_DIR, "RESTAPISample.twb")
 
             with open(sample_workbook, "rb") as fp:
-
                 publish_mode = self.server.PublishMode.CreateNew
 
                 new_workbook = self.server.workbooks.publish(new_workbook, fp, publish_mode)
@@ -715,7 +712,6 @@ class WorkbookTests(unittest.TestCase):
         new_workbook = TSC.WorkbookItem("test")
 
         with open(os.path.join(TEST_ASSET_DIR, "SampleWB.twbx"), "rb") as f:
-
             self.assertRaises(
                 ValueError, self.server.workbooks.publish, new_workbook, f, self.server.PublishMode.CreateNew
             )
@@ -724,7 +720,6 @@ class WorkbookTests(unittest.TestCase):
         new_workbook = TSC.WorkbookItem("test")
 
         with open(os.path.join(TEST_ASSET_DIR, "SampleWB.twbx")) as f:
-
             self.assertRaises(
                 TypeError, self.server.workbooks.publish, new_workbook, f, self.server.PublishMode.CreateNew
             )


### PR DESCRIPTION
## Why make change
The current specification conflicts with new versions of black
https://github.com/psf/black/blob/d9b8a6407e2f46304a8d36b18e4a73d8e0613519/pyproject.toml#L68

## What do the new versions of packaging do
https://github.com/pypa/packaging/releases/tag/22.0
of note
1. Removes support for python 3.6 (which this package doesn't support already)
1. Adds support for python 3.11 (Which this isn't marked as supporting yet but probably should at some point)