### PR TITLE
Fix bug in update-datasources before 3.15

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -140,11 +140,20 @@ class Datasources(QuerysetEndpoint):
         if not datasource_item.id:
             error = "Datasource item missing ID. Datasource must be retrieved from server first."
             raise MissingRequiredFieldError(error)
+        # bug - before v3.15 you must always include the project id
+        if datasource_item.owner_id and not datasource_item.project_id:
+            if not self.parent_srv.check_at_least_version(self, "3.15"):
+                error = (
+                    "Attempting to set new owner but datasource is missing Project ID."
+                    "In versions before 3.15 the project id must be included to update the owner."
+                )
+                raise MissingRequiredFieldError(error)
 
         self._resource_tagger.update_tags(self.baseurl, datasource_item)
 
         # Update the datasource itself
         url = "{0}/{1}".format(self.baseurl, datasource_item.id)
+
         update_req = RequestFactory.Datasource.update_req(datasource_item)
         server_response = self.put_request(url, update_req)
         logger.info("Updated datasource item (ID: {0})".format(datasource_item.id))

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -142,7 +142,7 @@ class Datasources(QuerysetEndpoint):
             raise MissingRequiredFieldError(error)
         # bug - before v3.15 you must always include the project id
         if datasource_item.owner_id and not datasource_item.project_id:
-            if not self.parent_srv.check_at_least_version(self, "3.15"):
+            if not self.parent_srv.check_at_least_version("3.15"):
                 error = (
                     "Attempting to set new owner but datasource is missing Project ID."
                     "In versions before 3.15 the project id must be included to update the owner."


### PR DESCRIPTION
require project id for updating datasource before 3.15. Fix for https://github.com/tableau/server-client-python/issues/1072