### PR TITLE
catch exceptions from ServerInfo

### DIFF
--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -40,6 +40,10 @@ class ServerInfoItem(object):
         except xml.etree.ElementTree.ParseError as error:
             print("Unexpected response for ServerInfo: {}".format(resp))
             return cls("Unknown", "Unknown", "Unknown")
+        except Exception as e:
+            warnings.warn("Unexpected response for ServerInfo: {}".format(resp))
+            return cls("Unknown", "Unknown", "Unknown")
+
         product_version_tag = parsed_response.find(".//t:productVersion", namespaces=ns)
         rest_api_version_tag = parsed_response.find(".//t:restApiVersion", namespaces=ns)
 

--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 import xml
 
@@ -35,13 +36,16 @@ class ServerInfoItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
+        logger = logging.getLogger("TSC.ServerInfo")
         try:
             parsed_response = fromstring(resp)
         except xml.etree.ElementTree.ParseError as error:
-            print("Unexpected response for ServerInfo: {}".format(resp))
+            logger.info("Unexpected response for ServerInfo: {}".format(resp))
+            logger.info(error)
             return cls("Unknown", "Unknown", "Unknown")
-        except Exception as e:
-            warnings.warn("Unexpected response for ServerInfo: {}".format(resp))
+        except Exception as error:
+            logger.info("Unexpected response for ServerInfo: {}".format(resp))
+            logger.info(error)
             return cls("Unknown", "Unknown", "Unknown")
 
         product_version_tag = parsed_response.find(".//t:productVersion", namespaces=ns)

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -41,5 +41,8 @@ class ServerInfo(Endpoint):
                 raise EndpointUnavailableError(e)
             raise e
 
-        self._info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
+        try:
+            self._info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
+        except Exception as e:
+            logging.getLogger(self.__class__.__name__).debug(server_response.content)
         return self._info

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -44,5 +44,6 @@ class ServerInfo(Endpoint):
         try:
             self._info = ServerInfoItem.from_response(server_response.content, self.parent_srv.namespace)
         except Exception as e:
+            logging.getLogger(self.__class__.__name__).debug(e)
             logging.getLogger(self.__class__.__name__).debug(server_response.content)
         return self._info

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -172,7 +172,7 @@ class Server(object):
         except Exception as e:
             self.logger.info("Could not get version info from server: {}{}".format(e.__class__, e))
             version = None
-        self.logger.info(version, old_version)
+        self.logger.info("versions: {}, {}".format(version, old_version))
         return version or old_version
 
     def use_server_version(self):

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -97,6 +97,8 @@ class Server(object):
 
         self.logger = logging.getLogger("TSC.server")
 
+        self.logger = logging.getLogger("TSC.server")
+
         self._session = self._session_factory()
         self._http_options = dict()  # must set this before making a server call
         if http_options:

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -158,7 +158,7 @@ class Server(object):
             self.logger.info("Could not read server version info. The server may not be running or configured.")
             return self.version
         prod_version = info_xml.find(".//product_version").text
-        version = _PRODUCT_TO_REST_VERSION.get(prod_version, default_server_version)  # 2.4
+        version = _PRODUCT_TO_REST_VERSION.get(prod_version, minimum_supported_server_version)
         return version
 
     def _determine_highest_version(self):

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -97,8 +97,6 @@ class Server(object):
 
         self.logger = logging.getLogger("TSC.server")
 
-        self.logger = logging.getLogger("TSC.server")
-
         self._session = self._session_factory()
         self._http_options = dict()  # must set this before making a server call
         if http_options:

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -42,7 +42,8 @@ class ServerInfoTests(unittest.TestCase):
             m.get(self.server.server_address + "/api/2.4/serverInfo", text=si_response_xml, status_code=404)
             m.get(self.server.server_address + "/auth?format=xml", text=auth_response_xml)
             self.server.use_server_version()
-            self.assertEqual(self.server.version, "2.4")
+            # does server-version[9.2] lookup in PRODUCT_TO_REST_VERSION
+            self.assertEqual(self.server.version, "2.2")
 
     def test_server_info_use_highest_version_upgrades(self):
         with open(SERVER_INFO_GET_XML, "rb") as f:


### PR DESCRIPTION
Catch and log all exceptions so we can give more info on why the initial connection failed.