### PR TITLE
gh-pages-update-doc workbooks attribute mention about read workbooks …

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -4108,7 +4108,7 @@ Name | Description
 `external_auth_user_id` |   Represents ID stored in Tableau's single sign-on (SSO) system. The `externalAuthUserId` value is returned for Tableau Cloud. For other server configurations, this field contains null.
 `id` |   The id of the user on the site.
 `last_login` | The date and time the user last logged in.
-`workbooks` |  The workbooks the user owns. You must run the populate_workbooks method to add the workbooks to the `UserItem`.
+`workbooks` |  The workbooks the user owns or has Read (view) permissions. You must run the populate_workbooks method to add the workbooks to the `UserItem`.
 `email` |  The email address of the user.
 `fullname` | The full name of the user.
 `name` |   The name of the user. This attribute is required when you are creating a `UserItem` instance.


### PR DESCRIPTION
I was confused by the docs  https://tableau.github.io/server-client-python/docs/api-ref#workbooks

> workbooks - The workbooks the user owns. You must run the populate_workbooks method to add the workbooks to the UserItem.


but according  to populate_workbooks it adds not only the ones user owns but also the ones user has read permissions to. 

> This method retrieves the workbook information for the specified user. The REST API is designed to return only the information you ask for explicitly. When you query for all the users, the workbook information for each user is not included. Use this method to retrieve information about the workbooks that the user owns or has Read (view) permissions.
