### PR TITLE
0.26 logging updates, long running uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+env.py
 
 # virtualenv
 venv/

--- a/samples/add_default_permission.py
+++ b/samples/add_default_permission.py
@@ -18,14 +18,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Add workbook default permissions for a given project.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/create_group.py
+++ b/samples/create_group.py
@@ -20,14 +20,10 @@ from tableauserverclient import ServerResponseError
 def main():
     parser = argparse.ArgumentParser(description="Creates a sample user group.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/create_project.py
+++ b/samples/create_project.py
@@ -28,14 +28,10 @@ def create_project(server, project_item, samples=False):
 def main():
     parser = argparse.ArgumentParser(description="Create new projects.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/create_schedules.py
+++ b/samples/create_schedules.py
@@ -17,14 +17,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Creates sample schedules for each type of frequency.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/explore_datasource.py
+++ b/samples/explore_datasource.py
@@ -18,14 +18,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Explore datasource functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/explore_site.py
+++ b/samples/explore_site.py
@@ -14,14 +14,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Explore site updates by the Server API.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/explore_webhooks.py
+++ b/samples/explore_webhooks.py
@@ -19,14 +19,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Explore webhook functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/explore_workbook.py
+++ b/samples/explore_workbook.py
@@ -19,14 +19,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Explore workbook functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/export.py
+++ b/samples/export.py
@@ -14,14 +14,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Export a view as an image, PDF, or CSV")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/extracts.py
+++ b/samples/extracts.py
@@ -19,14 +19,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Explore extract functions supported by the Server API.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", help="site name")
-    parser.add_argument(
-        "--token-name", "-tn", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-tv", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-tn", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-tv", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/filter_sort_groups.py
+++ b/samples/filter_sort_groups.py
@@ -26,14 +26,10 @@ def create_example_group(group_name="Example Group", server=None):
 def main():
     parser = argparse.ArgumentParser(description="Filter and sort groups.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/filter_sort_projects.py
+++ b/samples/filter_sort_projects.py
@@ -29,14 +29,10 @@ def create_example_project(
 def main():
     parser = argparse.ArgumentParser(description="Filter and sort projects.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/initialize_server.py
+++ b/samples/initialize_server.py
@@ -13,14 +13,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Initialize a server with content.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",
@@ -29,8 +25,8 @@ def main():
         help="desired logging level (set to error by default)",
     )
     # Options specific to this sample
-    parser.add_argument("--datasources-folder", "-df", required=True, help="folder containing datasources")
-    parser.add_argument("--workbooks-folder", "-wf", required=True, help="folder containing workbooks")
+    parser.add_argument("--datasources-folder", "-df", help="folder containing datasources")
+    parser.add_argument("--workbooks-folder", "-wf", help="folder containing workbooks")
     parser.add_argument("--project", required=False, default="Default", help="project to use")
 
     args = parser.parse_args()

--- a/samples/kill_all_jobs.py
+++ b/samples/kill_all_jobs.py
@@ -13,14 +13,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Cancel all of the running background jobs.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/list.py
+++ b/samples/list.py
@@ -15,14 +15,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="List out the names and LUIDs for different resource types.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-n", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-n", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/login.py
+++ b/samples/login.py
@@ -9,6 +9,7 @@ import getpass
 import logging
 
 import tableauserverclient as TSC
+import env
 
 
 # If a sample has additional arguments, then it should copy this code and insert them after the call to
@@ -18,10 +19,15 @@ def set_up_and_log_in():
     parser = argparse.ArgumentParser(description="Logs in to the server.")
     sample_define_common_options(parser)
     args = parser.parse_args()
-
-    # Set logging level based on user input, or error by default.
-    logging_level = getattr(logging, args.logging_level.upper())
-    logging.basicConfig(level=logging_level)
+    if not args.server:
+        args.server = env.server
+    if not args.site:
+        args.site = env.site
+    if not args.token_name:
+        args.token_name = env.token_name
+    if not args.token_value:
+        args.token_value = env.token_value
+    args.logging_level = "debug"
 
     server = sample_connect_to_server(args)
     print(server.server_info.get())
@@ -30,9 +36,9 @@ def set_up_and_log_in():
 
 def sample_define_common_options(parser):
     # Common options; please keep these in sync across all samples by copying or calling this method directly
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-t", help="site name")
-    auth = parser.add_mutually_exclusive_group(required=True)
+    auth = parser.add_mutually_exclusive_group(required=False)
     auth.add_argument("--token-name", "-tn", help="name of the personal access token used to sign into the server")
     auth.add_argument("--username", "-u", help="username to sign into the server")
 
@@ -73,6 +79,9 @@ def sample_connect_to_server(args):
     # Make sure we use an updated version of the rest apis, and pass in our cert handling choice
     server = TSC.Server(args.server, use_server_version=True, http_options={"verify": check_ssl_certificate})
     server.auth.sign_in(tableau_auth)
+    server.version = "2.6"
+    new_site: TSC.SiteItem = TSC.SiteItem("cdnear", content_url=env.site)
+    server.auth.switch_site(new_site)
     print("Logged in successfully")
 
     return server

--- a/samples/metadata_query.py
+++ b/samples/metadata_query.py
@@ -14,14 +14,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Use the metadata API to get information on a published data source.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-n", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-n", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/move_workbook_projects.py
+++ b/samples/move_workbook_projects.py
@@ -17,14 +17,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Move one workbook from the default project to another.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",
@@ -33,8 +29,8 @@ def main():
         help="desired logging level (set to error by default)",
     )
     # Options specific to this sample
-    parser.add_argument("--workbook-name", "-w", required=True, help="name of workbook to move")
-    parser.add_argument("--destination-project", "-d", required=True, help="name of project to move workbook into")
+    parser.add_argument("--workbook-name", "-w", help="name of workbook to move")
+    parser.add_argument("--destination-project", "-d", help="name of project to move workbook into")
 
     args = parser.parse_args()
 

--- a/samples/move_workbook_sites.py
+++ b/samples/move_workbook_sites.py
@@ -22,14 +22,10 @@ def main():
         "the default project of another site."
     )
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",
@@ -38,8 +34,8 @@ def main():
         help="desired logging level (set to error by default)",
     )
     # Options specific to this sample
-    parser.add_argument("--workbook-name", "-w", required=True, help="name of workbook to move")
-    parser.add_argument("--destination-site", "-d", required=True, help="name of site to move workbook into")
+    parser.add_argument("--workbook-name", "-w", help="name of workbook to move")
+    parser.add_argument("--destination-site", "-d", help="name of site to move workbook into")
 
     args = parser.parse_args()
 

--- a/samples/pagination_sample.py
+++ b/samples/pagination_sample.py
@@ -20,14 +20,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Demonstrate pagination on the list of workbooks on the server.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-n", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-n", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/publish_workbook.py
+++ b/samples/publish_workbook.py
@@ -24,14 +24,10 @@ from tableauserverclient import ConnectionCredentials, ConnectionItem
 def main():
     parser = argparse.ArgumentParser(description="Publish a workbook to server.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",
@@ -40,7 +36,7 @@ def main():
         help="desired logging level (set to error by default)",
     )
     # Options specific to this sample
-    parser.add_argument("--file", "-f", required=True, help="local filepath of the workbook to publish")
+    parser.add_argument("--file", "-f", help="local filepath of the workbook to publish")
     parser.add_argument("--as-job", "-a", help="Publishing asynchronously", action="store_true")
     parser.add_argument("--skip-connection-check", "-c", help="Skip live connection check", action="store_true")
 

--- a/samples/query_permissions.py
+++ b/samples/query_permissions.py
@@ -15,14 +15,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Query permissions of a given resource.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/refresh.py
+++ b/samples/refresh.py
@@ -13,14 +13,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Trigger a refresh task on a workbook or datasource.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/refresh_tasks.py
+++ b/samples/refresh_tasks.py
@@ -30,14 +30,10 @@ def handle_info(server, args):
 def main():
     parser = argparse.ArgumentParser(description="Get all of the refresh tasks available on a server")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/set_refresh_schedule.py
+++ b/samples/set_refresh_schedule.py
@@ -15,14 +15,10 @@ import tableauserverclient as TSC
 def usage(args):
     parser = argparse.ArgumentParser(description="Set refresh schedule for a workbook or datasource.")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/smoke_test.py
+++ b/samples/smoke_test.py
@@ -1,8 +1,16 @@
 # This sample verifies that tableau server client is installed
 # and you can run it. It also shows the version of the client.
 
+import logging
 import tableauserverclient as TSC
+
+
+logger = logging.getLogger("Sample")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler())
+
 
 server = TSC.Server("Fake-Server-Url", use_server_version=False)
 print("Client details:")
-print(TSC.server.endpoint.Endpoint._make_common_headers("fake-token", "any-content"))
+logger.info(server.server_address)
+logger.debug(TSC.server.endpoint.Endpoint.set_user_agent({}))

--- a/samples/update_connection.py
+++ b/samples/update_connection.py
@@ -13,14 +13,10 @@ import tableauserverclient as TSC
 def main():
     parser = argparse.ArgumentParser(description="Update a connection on a datasource or workbook to embed credentials")
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/samples/update_datasource_data.py
+++ b/samples/update_datasource_data.py
@@ -25,14 +25,10 @@ def main():
         description="Delete the `Europe` region from a published `World Indicators` datasource."
     )
     # Common options; please keep those in sync across all samples
-    parser.add_argument("--server", "-s", required=True, help="server address")
+    parser.add_argument("--server", "-s", help="server address")
     parser.add_argument("--site", "-S", help="site name")
-    parser.add_argument(
-        "--token-name", "-p", required=True, help="name of the personal access token used to sign into the server"
-    )
-    parser.add_argument(
-        "--token-value", "-v", required=True, help="value of the personal access token used to sign into the server"
-    )
+    parser.add_argument("--token-name", "-p", help="name of the personal access token used to sign into the server")
+    parser.add_argument("--token-value", "-v", help="value of the personal access token used to sign into the server")
     parser.add_argument(
         "--logging-level",
         "-l",

--- a/tableauserverclient/config.py
+++ b/tableauserverclient/config.py
@@ -1,0 +1,13 @@
+# TODO: check for env variables, else set default values
+
+ALLOWED_FILE_EXTENSIONS = ["tds", "tdsx", "tde", "hyper", "parquet"]
+
+BYTES_PER_MB = 1024 * 1024
+
+# For when a datasource is over 64MB, break it into 5MB(standard chunk size) chunks
+CHUNK_SIZE_MB = 5 * 10  # 5MB felt too slow, upped it to 50
+
+DELAY_SLEEP_SECONDS = 10
+
+# The maximum size of a file that can be published in a single request is 64MB
+FILESIZE_LIMIT_MB = 64

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -5,6 +5,10 @@ ZERO = datetime.timedelta(0)
 HOUR = datetime.timedelta(hours=1)
 
 
+def timestamp():
+    return datetime.datetime.now().strftime("%H:%M:%S")
+
+
 # This class is a concrete implementation of the abstract base class tzinfo
 # docs: https://docs.python.org/2.3/lib/datetime-tzinfo.html
 class UTC(datetime.tzinfo):

--- a/tableauserverclient/helpers/logging.py
+++ b/tableauserverclient/helpers/logging.py
@@ -1,0 +1,6 @@
+import logging
+
+# TODO change: this defaults to logging *everything* to stdout
+logger = logging.getLogger("TSC")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler())

--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -5,6 +5,7 @@ from defusedxml.ElementTree import fromstring
 
 from .connection_credentials import ConnectionCredentials
 from .property_decorators import property_is_boolean
+from tableauserverclient.helpers.logging import logger
 
 
 class ConnectionItem(object):
@@ -46,7 +47,6 @@ class ConnectionItem(object):
     def query_tagging(self, value: Optional[bool]):
         # if connection type = hyper, Snowflake, or Teradata, we can't change this value: it is always true
         if self._connection_type in ["hyper", "snowflake", "teradata"]:
-            logger = logging.getLogger("tableauserverclient.models.connection_item")
             logger.debug(
                 "Cannot update value: Query tagging is always enabled for {} connections".format(self._connection_type)
             )

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -32,7 +32,7 @@ class DatasourceItem(object):
             self.project_id,
         )
 
-    def __init__(self, project_id: str, name: Optional[str] = None) -> None:
+    def __init__(self, project_id: Optional[str] = None, name: Optional[str] = None) -> None:
         self._ask_data_enablement = None
         self._certified = None
         self._certification_note = None
@@ -135,12 +135,11 @@ class DatasourceItem(object):
         return self._id
 
     @property
-    def project_id(self) -> str:
+    def project_id(self) -> Optional[str]:
         return self._project_id
 
     @project_id.setter
-    @property_not_nullable
-    def project_id(self, value: str):
+    def project_id(self, value: Optional[str]):
         self._project_id = value
 
     @property

--- a/tableauserverclient/models/favorites_item.py
+++ b/tableauserverclient/models/favorites_item.py
@@ -8,8 +8,7 @@ from .project_item import ProjectItem
 from .view_item import ViewItem
 from .workbook_item import WorkbookItem
 
-logger = logging.getLogger("tableau.models.favorites_item")
-
+from tableauserverclient.helpers.logging import logger
 from typing import Dict, List, Union
 
 FavoriteType = Dict[

--- a/tableauserverclient/models/fileupload_item.py
+++ b/tableauserverclient/models/fileupload_item.py
@@ -11,8 +11,8 @@ class FileuploadItem(object):
         return self._upload_session_id
 
     @property
-    def file_size(self):
-        return self._file_size
+    def file_size(self) -> int:
+        return int(self._file_size)
 
     @classmethod
     def from_response(cls, resp, ns):

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -9,7 +9,7 @@ from .group_item import GroupItem
 from .reference_item import ResourceReference
 from .user_item import UserItem
 
-logger = logging.getLogger("tableau.models.permissions_item")
+from tableauserverclient.helpers.logging import logger
 
 
 class Permission:

--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -3,6 +3,7 @@ import warnings
 import xml
 
 from defusedxml.ElementTree import fromstring
+from tableauserverclient.helpers.logging import logger
 
 
 class ServerInfoItem(object):
@@ -36,7 +37,6 @@ class ServerInfoItem(object):
 
     @classmethod
     def from_response(cls, resp, ns):
-        logger = logging.getLogger("TSC.ServerInfo")
         try:
             parsed_response = fromstring(resp)
         except xml.etree.ElementTree.ParseError as error:

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -45,6 +45,7 @@ class UserItem(object):
     class Auth:
         OpenID = "OpenID"
         SAML = "SAML"
+        TableauIDWithMFA = "TableauIDWithMFA"
         ServerDefault = "ServerDefault"
 
     def __init__(

--- a/tableauserverclient/server/__init__.py
+++ b/tableauserverclient/server/__init__.py
@@ -10,9 +10,7 @@ from .request_options import (
 
 from .filter import Filter
 from .sort import Sort
-from ..models import *
 from .endpoint import *
 from .server import Server
 from .pager import Pager
-from .exceptions import NotSignedInError
-from ..helpers import *
+from .endpoint.exceptions import NotSignedInError

--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -5,11 +5,7 @@ from .data_alert_endpoint import DataAlerts
 from .databases_endpoint import Databases
 from .datasources_endpoint import Datasources
 from .endpoint import Endpoint, QuerysetEndpoint
-from .exceptions import (
-    ServerResponseError,
-    MissingRequiredFieldError,
-    ServerInfoEndpointNotFoundError,
-)
+from .exceptions import ServerResponseError, MissingRequiredFieldError
 from .favorites_endpoint import Favorites
 from .fileuploads_endpoint import Fileuploads
 from .flow_runs_endpoint import FlowRuns

--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -6,7 +6,7 @@ from .endpoint import Endpoint, api
 from .exceptions import ServerResponseError
 from ..request_factory import RequestFactory
 
-logger = logging.getLogger("tableau.endpoint.auth")
+from tableauserverclient.helpers.logging import logger
 
 
 class Auth(Endpoint):

--- a/tableauserverclient/server/endpoint/custom_views_endpoint.py
+++ b/tableauserverclient/server/endpoint/custom_views_endpoint.py
@@ -6,7 +6,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.models import CustomViewItem, PaginationItem
 from tableauserverclient.server import RequestFactory, RequestOptions, ImageRequestOptions
 
-logger = logging.getLogger("tableau.endpoint.custom_views")
+from tableauserverclient.helpers.logging import logger
 
 """
 Get a list of custom views on a site

--- a/tableauserverclient/server/endpoint/data_acceleration_report_endpoint.py
+++ b/tableauserverclient/server/endpoint/data_acceleration_report_endpoint.py
@@ -5,7 +5,7 @@ from .endpoint import api, Endpoint
 from .permissions_endpoint import _PermissionsEndpoint
 from tableauserverclient.models import DataAccelerationReportItem
 
-logger = logging.getLogger("tableau.endpoint.data_acceleration_report")
+from tableauserverclient.helpers.logging import logger
 
 
 class DataAccelerationReport(Endpoint):

--- a/tableauserverclient/server/endpoint/data_alert_endpoint.py
+++ b/tableauserverclient/server/endpoint/data_alert_endpoint.py
@@ -5,7 +5,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import DataAlertItem, PaginationItem, UserItem
 
-logger = logging.getLogger("tableau.endpoint.dataAlerts")
+from tableauserverclient.helpers.logging import logger
 
 from typing import List, Optional, TYPE_CHECKING, Tuple, Union
 

--- a/tableauserverclient/server/endpoint/databases_endpoint.py
+++ b/tableauserverclient/server/endpoint/databases_endpoint.py
@@ -8,7 +8,7 @@ from .permissions_endpoint import _PermissionsEndpoint
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import DatabaseItem, TableItem, PaginationItem, Resource
 
-logger = logging.getLogger("tableau.endpoint.databases")
+from tableauserverclient.helpers.logging import logger
 
 
 class Databases(Endpoint):

--- a/tableauserverclient/server/endpoint/default_permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/default_permissions_endpoint.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..server import Server
     from ..request_options import RequestOptions
 
-logger = logging.getLogger(__name__)
+from tableauserverclient.helpers.logging import logger
 
 # these are the only two items that can hold default permissions for another type
 BaseItem = Union[DatabaseItem, ProjectItem]

--- a/tableauserverclient/server/endpoint/dqw_endpoint.py
+++ b/tableauserverclient/server/endpoint/dqw_endpoint.py
@@ -5,7 +5,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import DQWItem
 
-logger = logging.getLogger(__name__)
+from tableauserverclient.helpers.logging import logger
 
 
 class _DataQualityWarningEndpoint(Endpoint):

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,24 +1,31 @@
+from threading import Thread
+from time import sleep
+from tableauserverclient import datetime_helpers as datetime
+
 import requests
-import logging
 from packaging.version import Version
 from functools import wraps
 from xml.etree.ElementTree import ParseError
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union
 
 from .exceptions import (
     ServerResponseError,
     InternalServerError,
     NonXMLResponseError,
-    EndpointUnavailableError,
+    NotSignedInError,
 )
+from ..exceptions import EndpointUnavailableError
+
 from tableauserverclient.server.query import QuerySet
 from tableauserverclient import helpers, get_versions
+
+from tableauserverclient.helpers.logging import logger
+from tableauserverclient.config import DELAY_SLEEP_SECONDS
 
 if TYPE_CHECKING:
     from ..server import Server
     from requests import Response
 
-logger = logging.getLogger("tableau.endpoint")
 
 Success_codes = [200, 201, 202, 204]
 
@@ -33,6 +40,8 @@ USER_AGENT_HEADER = "User-Agent"
 class Endpoint(object):
     def __init__(self, parent_srv: "Server"):
         self.parent_srv = parent_srv
+
+    async_response = None
 
     @staticmethod
     def set_parameters(http_options, auth_token, content, content_type, parameters) -> Dict[str, Any]:
@@ -53,6 +62,8 @@ class Endpoint(object):
 
     @staticmethod
     def set_user_agent(parameters):
+        if "headers" not in parameters:
+            parameters["headers"] = {}
         if USER_AGENT_HEADER not in parameters["headers"]:
             if USER_AGENT_HEADER in parameters:
                 parameters["headers"][USER_AGENT_HEADER] = parameters[USER_AGENT_HEADER]
@@ -64,6 +75,59 @@ class Endpoint(object):
         # result: parameters["headers"]["User-Agent"] is set
         # return explicitly for testing only
         return parameters
+
+    def _blocking_request(self, method, url, parameters={}) -> Optional["Response"]:
+        self.async_response = None
+        response = None
+        logger.debug("[{}] Begin blocking request to {}".format(datetime.timestamp(), url))
+        try:
+            response = method(url, **parameters)
+            self.async_response = response
+            logger.debug("[{}] Call finished".format(datetime.timestamp()))
+        except Exception as e:
+            logger.debug("Error making request to server: {}".format(e))
+            self.async_response = e
+        finally:
+            if response and not self.async_response:
+                logger.debug("Request response not saved")
+                return None
+        logger.debug("[{}] Request complete".format(datetime.timestamp()))
+        return self.async_response
+
+    def send_request_while_show_progress_threaded(
+        self, method, url, parameters={}, request_timeout=0
+    ) -> Optional["Response"]:
+        try:
+            request_thread = Thread(target=self._blocking_request, args=(method, url, parameters))
+            request_thread.async_response = -1  # type:ignore # this is an invented attribute for thread comms
+            request_thread.start()
+        except Exception as e:
+            logger.debug("Error starting server request on separate thread: {}".format(e))
+            return None
+        seconds = 0
+        minutes = 0
+        sleep(1)
+        if self.async_response != -1:
+            # a quick return for any immediate responses
+            return self.async_response
+        while self.async_response == -1 and (request_timeout == 0 or seconds < request_timeout):
+            self.log_wait_time_then_sleep(minutes, seconds, url)
+            seconds = seconds + DELAY_SLEEP_SECONDS
+            if seconds >= 60:
+                seconds = 0
+                minutes = minutes + 1
+        return self.async_response
+
+    def log_wait_time_then_sleep(self, minutes, seconds, url):
+        logger.debug("{} Waiting....".format(datetime.timestamp()))
+        if seconds >= 60:  # detailed log message ~every minute
+            if minutes % 5 == 0:
+                logger.info(
+                    "[{}] Waiting ({} minutes so far) for request to {}".format(datetime.timestamp(), minutes, url)
+                )
+            else:
+                logger.debug("[{}] Waiting for request to {}".format(datetime.timestamp(), url))
+        sleep(DELAY_SLEEP_SECONDS)
 
     def _make_request(
         self,
@@ -80,36 +144,59 @@ class Endpoint(object):
 
         logger.debug("request method {}, url: {}".format(method.__name__, url))
         if content:
-            redacted = helpers.strings.redact_xml(content[:1000])
+            redacted = helpers.strings.redact_xml(content[:200])
+            # this needs to be under a trace or something, it's a LOT
             # logger.debug("request content: {}".format(redacted))
 
-        server_response = method(url, **parameters)
+        # a request can, for stuff like publishing, spin for ages waiting for a response.
+        # we need some user-facing activity so they know it's not dead.
+        request_timeout = self.parent_srv.http_options.get("timeout") or 0
+        server_response: Optional["Response"] = self.send_request_while_show_progress_threaded(
+            method, url, parameters, request_timeout
+        )
+        logger.debug("[{}] Async request returned: received {}".format(datetime.timestamp(), server_response))
+        # is this blocking retry really necessary? I guess if it was just the threading messing it up?
+        if server_response is None:
+            logger.debug(server_response)
+            logger.debug("[{}] Async request failed: retrying".format(datetime.timestamp()))
+            server_response = self._blocking_request(method, url, parameters)
+        if server_response is None:
+            logger.debug("[{}] Request failed".format(datetime.timestamp()))
+            raise RuntimeError
         self._check_status(server_response, url)
 
         loggable_response = self.log_response_safely(server_response)
-        # logger.debug("Server response from {0}:\n\t{1}".format(url, loggable_response))
+        logger.debug("Server response from {0}".format(url))
+        # logger.debug("\n\t{1}".format(loggable_response))
 
         if content_type == "application/xml":
             self.parent_srv._namespace.detect(server_response.content)
 
         return server_response
 
-    def _check_status(self, server_response, url: Optional[str] = None):
+    def _check_status(self, server_response: "Response", url: Optional[str] = None):
+        logger.debug("Response status: {}".format(server_response))
+        if not hasattr(server_response, "status_code"):
+            raise EnvironmentError("Response is not a http response?")
         if server_response.status_code >= 500:
             raise InternalServerError(server_response, url)
         elif server_response.status_code not in Success_codes:
             try:
+                if server_response.status_code == 401:
+                    # TODO: catch this in server.py and attempt to sign in again, in case it's a session expiry
+                    raise NotSignedInError(server_response.content, url)
+
                 raise ServerResponseError.from_response(server_response.content, self.parent_srv.namespace, url)
             except ParseError:
                 # This will happen if we get a non-success HTTP code that doesn't return an xml error object
-                # e.g metadata endpoints, 503 pages, totally different servers
+                # e.g. metadata endpoints, 503 pages, totally different servers
                 # we convert this to a better exception and pass through the raw response body
                 raise NonXMLResponseError(server_response.content)
             except Exception:
                 # anything else re-raise here
                 raise
 
-    def log_response_safely(self, server_response: requests.Response) -> str:
+    def log_response_safely(self, server_response: "Response") -> str:
         # Checking the content type header prevents eager evaluation of streaming requests.
         content_type = server_response.headers.get("Content-Type")
 
@@ -117,7 +204,7 @@ class Endpoint(object):
         # content-type is an octet-stream accomplishes the same goal without eagerly loading content.
         # This check is to determine if the response is a text response (xml or otherwise)
         # so that we do not attempt to log bytes and other binary data.
-        loggable_response = "Content type {}".format(content_type)
+        loggable_response = "Content type `{}`".format(content_type)
         if content_type == "application/octet-stream":
             loggable_response = "A stream of type {} [Truncated File Contents]".format(content_type)
         elif server_response.encoding and len(server_response.content) > 0:

--- a/tableauserverclient/server/endpoint/exceptions.py
+++ b/tableauserverclient/server/endpoint/exceptions.py
@@ -47,11 +47,7 @@ class MissingRequiredFieldError(TableauError):
     pass
 
 
-class ServerInfoEndpointNotFoundError(TableauError):
-    pass
-
-
-class EndpointUnavailableError(TableauError):
+class NotSignedInError(TableauError):
     pass
 
 

--- a/tableauserverclient/server/endpoint/favorites_endpoint.py
+++ b/tableauserverclient/server/endpoint/favorites_endpoint.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ...models import DatasourceItem, FlowItem, ProjectItem, UserItem, ViewItem, WorkbookItem
     from ..request_options import RequestOptions
 
-logger = logging.getLogger("tableau.endpoint.favorites")
+from tableauserverclient.helpers.logging import logger
 
 
 class Favorites(Endpoint):

--- a/tableauserverclient/server/endpoint/favorites_endpoint.py
+++ b/tableauserverclient/server/endpoint/favorites_endpoint.py
@@ -1,24 +1,21 @@
-import logging
-
 from .endpoint import Endpoint, api
 from requests import Response
 
-from tableauserverclient.server import RequestFactory, RequestOptions, Resource
+from tableauserverclient.helpers.logging import logger
 from tableauserverclient.models import (
     DatasourceItem,
     FavoriteItem,
     FlowItem,
     MetricItem,
     ProjectItem,
+    Resource,
+    TableauItem,
     UserItem,
     ViewItem,
     WorkbookItem,
-    TableauItem,
 )
-
+from tableauserverclient.server import RequestFactory, RequestOptions
 from typing import Optional
-
-from tableauserverclient.helpers.logging import logger
 
 
 class Favorites(Endpoint):

--- a/tableauserverclient/server/endpoint/fileuploads_endpoint.py
+++ b/tableauserverclient/server/endpoint/fileuploads_endpoint.py
@@ -1,13 +1,10 @@
-import logging
-
 from .endpoint import Endpoint, api
-from tableauserverclient.server import RequestFactory
+from tableauserverclient import datetime_helpers as datetime
+from tableauserverclient.helpers.logging import logger
+
+from tableauserverclient.config import BYTES_PER_MB, CHUNK_SIZE_MB
 from tableauserverclient.models import FileuploadItem
-
-# For when a datasource is over 64MB, break it into 5MB(standard chunk size) chunks
-CHUNK_SIZE = 1024 * 1024 * 5  # 5MB
-
-logger = logging.getLogger("tableau.endpoint.fileuploads")
+from tableauserverclient.server import RequestFactory
 
 
 class Fileuploads(Endpoint):
@@ -44,7 +41,7 @@ class Fileuploads(Endpoint):
 
         try:
             while True:
-                chunked_content = file_content.read(CHUNK_SIZE)
+                chunked_content = file_content.read(CHUNK_SIZE_MB * BYTES_PER_MB)
                 if not chunked_content:
                     break
                 yield chunked_content
@@ -55,8 +52,12 @@ class Fileuploads(Endpoint):
     def upload(self, file):
         upload_id = self.initiate()
         for chunk in self._read_chunks(file):
+            logger.debug("{} processing chunk...".format(datetime.timestamp()))
             request, content_type = RequestFactory.Fileupload.chunk_req(chunk)
+            logger.debug("{} created chunk request".format(datetime.timestamp()))
             fileupload_item = self.append(upload_id, request, content_type)
-            logger.info("\tPublished {0}MB".format(fileupload_item.file_size))
+            logger.info(
+                "\t{0} Published {1}MB".format(datetime.timestamp(), (fileupload_item.file_size / BYTES_PER_MB))
+            )
         logger.info("File upload finished (ID: {0})".format(upload_id))
         return upload_id

--- a/tableauserverclient/server/endpoint/flow_runs_endpoint.py
+++ b/tableauserverclient/server/endpoint/flow_runs_endpoint.py
@@ -6,7 +6,7 @@ from .exceptions import FlowRunFailedException, FlowRunCancelledException
 from tableauserverclient.models import FlowRunItem, PaginationItem
 from tableauserverclient.exponential_backoff import ExponentialBackoffTimer
 
-logger = logging.getLogger("tableau.endpoint.flowruns")
+from tableauserverclient.helpers.logging import logger
 
 if TYPE_CHECKING:
     from ..server import Server

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -32,13 +32,13 @@ FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB
 
 ALLOWED_FILE_EXTENSIONS = ["tfl", "tflx"]
 
-logger = logging.getLogger("tableau.endpoint.flows")
+from tableauserverclient.helpers.logging import logger
 
 if TYPE_CHECKING:
-    from .. import DQWItem
-    from ..request_options import RequestOptions
-    from ...models.permissions_item import PermissionsRule
-    from .schedules_endpoint import AddResponse
+    from tableauserverclient.models import DQWItem
+    from tableauserverclient.models.permissions_item import PermissionsRule
+    from tableauserverclient.server.request_options import RequestOptions
+    from tableauserverclient.server.endpoint.schedules_endpoint import AddResponse
 
 
 FilePath = Union[str, os.PathLike]

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -6,7 +6,7 @@ from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import GroupItem, UserItem, PaginationItem, JobItem
 from ..pager import Pager
 
-logger = logging.getLogger("tableau.endpoint.groups")
+from tableauserverclient.helpers.logging import logger
 
 from typing import List, Optional, TYPE_CHECKING, Tuple, Union
 

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -6,7 +6,7 @@ from tableauserverclient.models import JobItem, BackgroundJobItem, PaginationIte
 from ..request_options import RequestOptionsBase
 from tableauserverclient.exponential_backoff import ExponentialBackoffTimer
 
-logger = logging.getLogger("tableau.endpoint.jobs")
+from tableauserverclient.helpers.logging import logger
 
 from typing import List, Optional, Tuple, Union
 

--- a/tableauserverclient/server/endpoint/metadata_endpoint.py
+++ b/tableauserverclient/server/endpoint/metadata_endpoint.py
@@ -4,7 +4,7 @@ import logging
 from .endpoint import Endpoint, api
 from .exceptions import GraphQLError, InvalidGraphQLQuery
 
-logger = logging.getLogger("tableau.endpoint.metadata")
+from tableauserverclient.helpers.logging import logger
 
 
 def is_valid_paged_query(parsed_query):

--- a/tableauserverclient/server/endpoint/metrics_endpoint.py
+++ b/tableauserverclient/server/endpoint/metrics_endpoint.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ...server import Server
 
 
-logger = logging.getLogger("tableau.endpoint.metrics")
+from tableauserverclient.helpers.logging import logger
 
 
 class Metrics(QuerysetEndpoint):

--- a/tableauserverclient/server/endpoint/permissions_endpoint.py
+++ b/tableauserverclient/server/endpoint/permissions_endpoint.py
@@ -8,7 +8,7 @@ from .exceptions import MissingRequiredFieldError
 
 from typing import Callable, TYPE_CHECKING, List, Optional, Union
 
-logger = logging.getLogger(__name__)
+from tableauserverclient.helpers.logging import logger
 
 if TYPE_CHECKING:
     from ..server import Server

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..server import Server
     from ..request_options import RequestOptions
 
-logger = logging.getLogger("tableau.endpoint.projects")
+from tableauserverclient.helpers.logging import logger
 
 
 class Projects(QuerysetEndpoint):

--- a/tableauserverclient/server/endpoint/resource_tagger.py
+++ b/tableauserverclient/server/endpoint/resource_tagger.py
@@ -1,13 +1,13 @@
 import copy
-import logging
 import urllib.parse
 
 from .endpoint import Endpoint
-from .exceptions import EndpointUnavailableError, ServerResponseError
+from .exceptions import ServerResponseError
+from ..exceptions import EndpointUnavailableError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import TagItem
 
-logger = logging.getLogger("tableau.endpoint.resource_tagger")
+from tableauserverclient.helpers.logging import logger
 
 
 class _ResourceTagger(Endpoint):

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -9,7 +9,8 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import PaginationItem, ScheduleItem, TaskItem
 
-logger = logging.getLogger("tableau.endpoint.schedules")
+from tableauserverclient.helpers.logging import logger
+
 AddResponse = namedtuple("AddResponse", ("result", "error", "warnings", "task_created"))
 OK = AddResponse(result=True, error=None, warnings=None, task_created=None)
 

--- a/tableauserverclient/server/endpoint/server_info_endpoint.py
+++ b/tableauserverclient/server/endpoint/server_info_endpoint.py
@@ -1,14 +1,12 @@
 import logging
 
 from .endpoint import Endpoint, api
-from .exceptions import (
-    ServerResponseError,
+from .exceptions import ServerResponseError
+from ..exceptions import (
     ServerInfoEndpointNotFoundError,
     EndpointUnavailableError,
 )
 from tableauserverclient.models import ServerInfoItem
-
-logger = logging.getLogger("tableau.endpoint.server_info")
 
 
 class ServerInfo(Endpoint):

--- a/tableauserverclient/server/endpoint/sites_endpoint.py
+++ b/tableauserverclient/server/endpoint/sites_endpoint.py
@@ -6,7 +6,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import SiteItem, PaginationItem
 
-logger = logging.getLogger("tableau.endpoint.sites")
+from tableauserverclient.helpers.logging import logger
 
 from typing import TYPE_CHECKING, List, Optional, Tuple
 

--- a/tableauserverclient/server/endpoint/subscriptions_endpoint.py
+++ b/tableauserverclient/server/endpoint/subscriptions_endpoint.py
@@ -5,7 +5,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import SubscriptionItem, PaginationItem
 
-logger = logging.getLogger("tableau.endpoint.subscriptions")
+from tableauserverclient.helpers.logging import logger
 
 from typing import List, Optional, TYPE_CHECKING, Tuple
 

--- a/tableauserverclient/server/endpoint/tables_endpoint.py
+++ b/tableauserverclient/server/endpoint/tables_endpoint.py
@@ -8,7 +8,7 @@ from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import TableItem, ColumnItem, PaginationItem
 from ..pager import Pager
 
-logger = logging.getLogger("tableau.endpoint.tables")
+from tableauserverclient.helpers.logging import logger
 
 
 class Tables(Endpoint):

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -5,7 +5,7 @@ from .exceptions import MissingRequiredFieldError
 from tableauserverclient.models import TaskItem, PaginationItem
 from tableauserverclient.server import RequestFactory
 
-logger = logging.getLogger("tableau.endpoint.tasks")
+from tableauserverclient.helpers.logging import logger
 
 
 class Tasks(Endpoint):

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -8,7 +8,7 @@ from tableauserverclient.server import RequestFactory, RequestOptions
 from tableauserverclient.models import UserItem, WorkbookItem, PaginationItem, GroupItem
 from ..pager import Pager
 
-logger = logging.getLogger("tableau.endpoint.users")
+from tableauserverclient.helpers.logging import logger
 
 
 class Users(QuerysetEndpoint):

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -7,7 +7,7 @@ from .permissions_endpoint import _PermissionsEndpoint
 from .resource_tagger import _ResourceTagger
 from tableauserverclient.models import ViewItem, PaginationItem
 
-logger = logging.getLogger("tableau.endpoint.views")
+from tableauserverclient.helpers.logging import logger
 
 from typing import Iterator, List, Optional, Tuple, TYPE_CHECKING
 

--- a/tableauserverclient/server/endpoint/webhooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/webhooks_endpoint.py
@@ -4,7 +4,7 @@ from .endpoint import Endpoint, api
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.models import WebhookItem, PaginationItem
 
-logger = logging.getLogger("tableau.endpoint.webhooks")
+from tableauserverclient.helpers.logging import logger
 
 from typing import List, Optional, TYPE_CHECKING, Tuple
 

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -44,7 +44,8 @@ FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB
 
 ALLOWED_FILE_EXTENSIONS = ["twb", "twbx"]
 
-logger = logging.getLogger("tableau.endpoint.workbooks")
+from tableauserverclient.helpers.logging import logger
+
 FilePath = Union[str, os.PathLike]
 FileObject = Union[io.BufferedReader, io.BytesIO]
 FileObjectR = Union[io.BufferedReader, io.BytesIO]

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -310,6 +310,7 @@ class Workbooks(QuerysetEndpoint):
         as_job: bool = False,
         hidden_views: Optional[Sequence[str]] = None,
         skip_connection_check: bool = False,
+        parameters=None,
     ):
         if connection_credentials is not None:
             import warnings
@@ -413,7 +414,7 @@ class Workbooks(QuerysetEndpoint):
 
         # Send the publishing request to server
         try:
-            server_response = self.post_request(url, xml_request, content_type)
+            server_response = self.post_request(url, xml_request, content_type, parameters)
         except InternalServerError as err:
             if err.code == 504 and not as_job:
                 err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."

--- a/tableauserverclient/server/exceptions.py
+++ b/tableauserverclient/server/exceptions.py
@@ -1,2 +1,9 @@
-class NotSignedInError(Exception):
+# These errors can be thrown without even talking to Tableau Server
+
+
+class ServerInfoEndpointNotFoundError(Exception):
+    pass
+
+
+class EndpointUnavailableError(Exception):
     pass

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -9,6 +9,8 @@ from tableauserverclient.models import *
 if TYPE_CHECKING:
     from tableauserverclient.server import Server
 
+# this file could be largely replaced if we were willing to import the huge file from generateDS
+
 
 def _add_multipart(parts: Dict) -> Tuple[Any, str]:
     mime_multipart_parts = list()
@@ -146,10 +148,11 @@ class DatabaseRequest(object):
 
 
 class DatasourceRequest(object):
-    def _generate_xml(self, datasource_item, connection_credentials=None, connections=None):
+    def _generate_xml(self, datasource_item: DatasourceItem, connection_credentials=None, connections=None):
         xml_request = ET.Element("tsRequest")
         datasource_element = ET.SubElement(xml_request, "datasource")
-        datasource_element.attrib["name"] = datasource_item.name
+        if datasource_item.name:
+            datasource_element.attrib["name"] = datasource_item.name
         if datasource_item.description:
             datasource_element.attrib["description"] = str(datasource_item.description)
         if datasource_item.use_remote_query_agent is not None:
@@ -157,10 +160,16 @@ class DatasourceRequest(object):
 
         if datasource_item.ask_data_enablement:
             ask_data_element = ET.SubElement(datasource_element, "askData")
-            ask_data_element.attrib["enablement"] = datasource_item.ask_data_enablement
+            ask_data_element.attrib["enablement"] = datasource_item.ask_data_enablement.__str__()
 
-        project_element = ET.SubElement(datasource_element, "project")
-        project_element.attrib["id"] = datasource_item.project_id
+        if datasource_item.certified:
+            datasource_element.attrib["isCertified"] = datasource_item.certified.__str__()
+        if datasource_item.certification_note:
+            datasource_element.attrib["certificationNote"] = datasource_item.certification_note
+
+        if datasource_item.project_id:
+            project_element = ET.SubElement(datasource_element, "project")
+            project_element.attrib["id"] = datasource_item.project_id
 
         if connection_credentials is not None and connections is not None:
             raise RuntimeError("You cannot set both `connections` and `connection_credentials`")

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -197,6 +197,8 @@ class DatasourceRequest(object):
         if datasource_item.owner_id:
             owner_element = ET.SubElement(datasource_element, "owner")
             owner_element.attrib["id"] = datasource_item.owner_id
+        if datasource_item.use_remote_query_agent is not None:
+            datasource_element.attrib["useRemoteQueryAgent"] = str(datasource_item.use_remote_query_agent).lower()
 
         datasource_element.attrib["isCertified"] = str(datasource_item.certified).lower()
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -38,6 +38,7 @@ class RequestOptions(RequestOptionsBase):
     class Field:
         Args = "args"
         CompletedAt = "completedAt"
+        ContentUrl = "contentUrl"
         CreatedAt = "createdAt"
         DomainName = "domainName"
         DomainNickname = "domainNickname"
@@ -147,7 +148,7 @@ class CSVRequestOptions(_FilterOptionsBase):
         return params
 
 
-class ExcelRequestOptions(RequestOptionsBase):
+class ExcelRequestOptions(_FilterOptionsBase):
     def __init__(self, maxage: int = -1) -> None:
         super().__init__()
         self.max_age = maxage

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -1,7 +1,7 @@
 from tableauserverclient.models.property_decorators import property_is_int
 import logging
 
-logger = logging.getLogger("tableau.request_options")
+from tableauserverclient.helpers.logging import logger
 
 
 class RequestOptionsBase(object):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -63,7 +63,7 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + "/signin", text=response_xml, status_code=401)
             tableau_auth = TSC.TableauAuth("testuser", "wrongpassword")
-            self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
+            self.assertRaises(TSC.NotSignedInError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_in_invalid_token(self):
         with open(SIGN_IN_ERROR_XML, "rb") as f:
@@ -71,7 +71,7 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + "/signin", text=response_xml, status_code=401)
             tableau_auth = TSC.PersonalAccessTokenAuth(token_name="mytoken", personal_access_token="invalid")
-            self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
+            self.assertRaises(TSC.NotSignedInError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_in_without_auth(self):
         with open(SIGN_IN_ERROR_XML, "rb") as f:
@@ -79,7 +79,7 @@ class AuthTests(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.baseurl + "/signin", text=response_xml, status_code=401)
             tableau_auth = TSC.TableauAuth("", "")
-            self.assertRaises(TSC.ServerResponseError, self.server.auth.sign_in, tableau_auth)
+            self.assertRaises(TSC.NotSignedInError, self.server.auth.sign_in, tableau_auth)
 
     def test_sign_out(self):
         with open(SIGN_IN_XML, "rb") as f:

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -145,9 +145,9 @@ class DatasourceTests(unittest.TestCase):
     def test_update_tags(self) -> None:
         add_tags_xml, update_xml = read_xml_assets(ADD_TAGS_XML, UPDATE_XML)
         with requests_mock.mock() as m:
-            m.put(self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/tags", text=add_tags_xml)
             m.delete(self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/tags/b", status_code=204)
             m.delete(self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/tags/d", status_code=204)
+            m.put(self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/tags", text=add_tags_xml)
             m.put(self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", text=update_xml)
             single_datasource = TSC.DatasourceItem("1d0304cd-3796-429f-b815-7258370b9b74")
             single_datasource._id = "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb"
@@ -191,7 +191,7 @@ class DatasourceTests(unittest.TestCase):
                 self.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/connections/be786ae0-d2bf-4a4b-9b34-e2de8d2d4488",
                 text=response_xml,
             )
-            single_datasource = TSC.DatasourceItem("1d0304cd-3796-429f-b815-7258370b9b74")
+            single_datasource = TSC.DatasourceItem("be786ae0-d2bf-4a4b-9b34-e2de8d2d4488")
             single_datasource.owner_id = "dd2239f6-ddf1-4107-981a-4cf94e415794"
             single_datasource._id = "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb"
             self.server.datasources.populate_connections(single_datasource)
@@ -610,7 +610,7 @@ class DatasourceTests(unittest.TestCase):
 
             new_datasource = TSC.DatasourceItem(project_id="")
             publish_mode = self.server.PublishMode.CreateNew
-
+            # http://test/api/2.4/sites/dad65087-b08b-4603-af4e-2887b8aafc67/datasources?datasourceType=tds
             self.assertRaisesRegex(
                 InternalServerError,
                 "Please use asynchronous publishing to avoid timeouts.",

--- a/test/test_datasource_model.py
+++ b/test/test_datasource_model.py
@@ -3,11 +3,9 @@ import tableauserverclient as TSC
 
 
 class DatasourceModelTests(unittest.TestCase):
-    def test_invalid_project_id(self):
-        self.assertRaises(ValueError, TSC.DatasourceItem, None)
-        datasource = TSC.DatasourceItem("10")
-        with self.assertRaises(ValueError):
-            datasource.project_id = None
+    def test_nullable_project_id(self):
+        datasource = TSC.DatasourceItem(name="10")
+        self.assertEqual(datasource.project_id, None)
 
     def test_require_boolean_flag_bridge_fail(self):
         datasource = TSC.DatasourceItem("10")

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -15,8 +15,31 @@ class TestEndpoint(unittest.TestCase):
         # Fake signin
         self.server._site_id = "dad65087-b08b-4603-af4e-2887b8aafc67"
         self.server._auth_token = "j80k54ll2lfMZ0tv97mlPvvSCRyD0DOM"
-
         return super().setUp()
+
+    def test_fallback_request_logic(self) -> None:
+        url = "http://test/"
+        endpoint = TSC.server.Endpoint(self.server)
+        with requests_mock.mock() as m:
+            m.get(url)
+            response = endpoint.get_request(url=url)
+            self.assertIsNotNone(response)
+
+    def test_user_friendly_request_returns(self) -> None:
+        url = "http://test/"
+        endpoint = TSC.server.Endpoint(self.server)
+        with requests_mock.mock() as m:
+            m.get(url)
+            response = endpoint.send_request_while_show_progress_threaded(
+                endpoint.parent_srv.session.get, url=url, request_timeout=2
+            )
+            self.assertIsNotNone(response)
+
+    def test_blocking_request_returns(self) -> None:
+        url = "http://test/"
+        endpoint = TSC.server.Endpoint(self.server)
+        response = endpoint._blocking_request(endpoint.parent_srv.session.get, url=url)
+        self.assertIsNotNone(response)
 
     def test_get_request_stream(self) -> None:
         url = "http://test/"

--- a/test/test_fileuploads.py
+++ b/test/test_fileuploads.py
@@ -43,7 +43,7 @@ class FileuploadsTests(unittest.TestCase):
             append_response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             m.post(self.baseurl, text=initialize_response_xml)
-            m.put(self.baseurl + "/" + upload_id, text=append_response_xml)
+            m.put("{}/{}".format(self.baseurl, upload_id), text=append_response_xml)
             actual = self.server.fileuploads.upload(file_path)
 
         self.assertEqual(upload_id, actual)
@@ -58,7 +58,7 @@ class FileuploadsTests(unittest.TestCase):
                 append_response_xml = f.read().decode("utf-8")
             with requests_mock.mock() as m:
                 m.post(self.baseurl, text=initialize_response_xml)
-                m.put(self.baseurl + "/" + upload_id, text=append_response_xml)
+                m.put("{}/{}".format(self.baseurl, upload_id), text=append_response_xml)
                 actual = self.server.fileuploads.upload(file_content)
 
         self.assertEqual(upload_id, actual)

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -22,7 +22,7 @@ SLICING_QUERYSET_PAGE_2 = TEST_ASSET_DIR / "queryset_slicing_page_2.xml"
 
 class RequestOptionTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.server = TSC.Server("http://test", False)
+        self.server = TSC.Server("http://test", False, http_options={"timeout": 5})
 
         # Fake signin
         self.server.version = "3.10"
@@ -151,7 +151,7 @@ class RequestOptionTests(unittest.TestCase):
                 )
             )
             req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, "foo"))
-            for _ in range(100):
+            for _ in range(5):
                 matching_workbooks, pagination_item = self.server.workbooks.get(req_option)
                 self.assertEqual(3, pagination_item.total_available)
 
@@ -245,7 +245,7 @@ class RequestOptionTests(unittest.TestCase):
             )
             m.get(url, text=response_xml)
 
-            for _ in range(100):
+            for _ in range(5):
                 matching_workbooks = self.server.workbooks.filter(tags__in=["sample", "safari", "weather"], name="foo")
                 self.assertEqual(3, matching_workbooks.total_available)
 

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -299,3 +299,19 @@ class ViewTests(unittest.TestCase):
 
             excel_file = b"".join(single_view.excel)
             self.assertEqual(response, excel_file)
+
+    def test_filter_excel(self) -> None:
+        self.server.version = "3.8"
+        self.baseurl = self.server.views.baseurl
+        with open(POPULATE_EXCEL, "rb") as f:
+            response = f.read()
+        with requests_mock.mock() as m:
+            m.get(self.baseurl + "/d79634e1-6063-4ec9-95ff-50acbf609ff5/crosstab/excel?maxAge=1", content=response)
+            single_view = TSC.ViewItem()
+            single_view._id = "d79634e1-6063-4ec9-95ff-50acbf609ff5"
+            request_option = TSC.ExcelRequestOptions(maxage=1)
+            request_option.vf("stuff", "1")
+            self.server.views.populate_excel(single_view, request_option)
+
+            excel_file = b"".join(single_view.excel)
+            self.assertEqual(response, excel_file)

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -4,7 +4,8 @@ import unittest
 import requests_mock
 
 import tableauserverclient as TSC
-from tableauserverclient.server import RequestFactory, WebhookItem
+from tableauserverclient.server import RequestFactory
+from tableauserverclient.models import WebhookItem
 from ._utils import asset
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")


### PR DESCRIPTION
run long requests on second thread (https://github.com/tableau/server-client-python/pull/1212)
includes update to use one centrally configured logger
Add auth type TableauIDWithMFA (https://github.com/tableau/server-client-python/pull/1217)
Add metrics to favoriting (https://github.com/tableau/server-client-python/pull/1085)
https://github.com/tableau/server-client-python/issues/1210
https://github.com/tableau/server-client-python/issues/1087
https://github.com/tableau/server-client-python/issues/1058
https://github.com/tableau/server-client-python/issues/456
https://github.com/tableau/server-client-python/issues/1209