### PR TITLE
encode spaces in filter conditions as %20 to enable searching for projects with spaces in the project name

### DIFF
--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -11,7 +11,7 @@ class Filter(object):
     def __str__(self):
         value_string = str(self._value)
         if isinstance(self._value, list):
-            value_string = value_string.replace(" ", "").replace("'", "")
+            value_string = value_string.replace(" ", "%20").replace("'", "")
         return "{0}:{1}:{2}".format(self.field, self.operator, value_string)
 
     @property

--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -11,7 +11,11 @@ class Filter(object):
     def __str__(self):
         value_string = str(self._value)
         if isinstance(self._value, list):
-            value_string = value_string.replace(" ", "%20").replace("'", "")
+            # this should turn the string representation of the list 
+            # from ['<string1>', '<string2>', ...]
+            # to [<string1>,<string2>]
+            # so effectively, remove any spaces between "," and "'" and then remove all "'"
+            value_string = value_string.replace(", '", ",'").replace("'", "")
         return "{0}:{1}:{2}".format(self.field, self.operator, value_string)
 
     @property


### PR DESCRIPTION
This change encodes spaces in server.filter conditions as `%20` so that that project names with spaces can be found. 
Previously, the spaces were replaced by empty strings, which made projects with spaces not findable. 
 