### PR TITLE
846 fix filter in operator spaces bug

### DIFF
--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -11,7 +11,7 @@ class Filter(object):
     def __str__(self):
         value_string = str(self._value)
         if isinstance(self._value, list):
-            value_string = value_string.replace(" ", "").replace("'", "")
+            value_string = value_string.replace(" ", "%20").replace("'", "")
         return "{0}:{1}:{2}".format(self.field, self.operator, value_string)
 
     @property

--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -11,7 +11,11 @@ class Filter(object):
     def __str__(self):
         value_string = str(self._value)
         if isinstance(self._value, list):
-            value_string = value_string.replace(" ", "%20").replace("'", "")
+            # this should turn the string representation of the list 
+            # from ['<string1>', '<string2>', ...]
+            # to [<string1>,<string2>]
+            # so effectively, remove any spaces between "," and "'" and then remove all "'"
+            value_string = value_string.replace(", '", ",'").replace("'", "")
         return "{0}:{1}:{2}".format(self.field, self.operator, value_string)
 
     @property

--- a/tableauserverclient/server/filter.py
+++ b/tableauserverclient/server/filter.py
@@ -11,7 +11,7 @@ class Filter(object):
     def __str__(self):
         value_string = str(self._value)
         if isinstance(self._value, list):
-            # this should turn the string representation of the list 
+            # this should turn the string representation of the list
             # from ['<string1>', '<string2>', ...]
             # to [<string1>,<string2>]
             # so effectively, remove any spaces between "," and "'" and then remove all "'"

--- a/test/assets/request_option_filter_name_in.xml
+++ b/test/assets/request_option_filter_name_in.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_18.xsd">
+    <pagination pageNumber="1" pageSize="100" totalAvailable="2"/>
+    <projects>
+        <project id="26558843-133c-45fc-9f67-697f30d25e62" name="default" description="The default project that was automatically created by Tableau." createdAt="2022-06-21T07:52:28Z" updatedAt="2022-06-21T07:52:28Z" contentPermissions="ManagedByOwner">
+            <owner id="19aadc25-d3d8-4467-96cc-09db69687b28"/>
+        </project>
+        <project id="7dce3c52-f058-4484-932c-3fc264638618" name="Salesforce Sales Projeśt" description="" createdAt="2023-02-21T02:53:34Z" updatedAt="2023-07-10T04:09:29Z" contentPermissions="ManagedByOwner">
+            <owner id="bc38ea93-af2b-4004-9ef8-2144a57d3777"/>
+        </project>
+    </projects>
+</tsResponse>

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+
+import tableauserverclient as TSC
+
+
+class FilterTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_filter_equal(self):
+        filter = TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, "Superstore")
+
+        self.assertEqual(str(filter), "name:eq:Superstore")
+
+    def test_filter_in(self):
+        # create a IN filter condition with project names that
+        # contain spaces and "special" characters
+        projects_to_find = ["default", "Salesforce Sales Projeśt"]
+        filter = TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.In, projects_to_find)
+
+        self.assertEqual(str(filter), "name:in:[default,Salesforce Sales Projeśt]")


### PR DESCRIPTION
This fix corrects the filter condition formatting in `server.filter.py` enabling searching for projects with spaces in the project name.
