### PR TITLE
Enable asJob for group update

### DIFF
--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -82,14 +82,17 @@ class Groups(QuerysetEndpoint):
             )
             group_item.minimum_site_role = default_site_role
 
+        url = "{0}/{1}".format(self.baseurl, group_item.id)
+
         if not group_item.id:
             error = "Group item missing ID."
             raise MissingRequiredFieldError(error)
         if as_job and (group_item.domain_name is None or group_item.domain_name == "local"):
             error = "Local groups cannot be updated asynchronously."
             raise ValueError(error)
+        elif as_job:
+            url = "?".join([url, "asJob=True"])
 
-        url = "{0}/{1}".format(self.baseurl, group_item.id)
         update_req = RequestFactory.Group.update_req(group_item, None)
         server_response = self.put_request(url, update_req)
         logger.info("Updated group item (ID: {0})".format(group_item.id))

--- a/test/assets/group_update_async.xml
+++ b/test/assets/group_update_async.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+  <job id="c2566efc-0767-4f15-89cb-56acb4349c1b"
+    mode="Asynchronous"
+    type="GroupSync"
+    progress="0"
+    createdAt="time-job-created" />
+</tsResponse>


### PR DESCRIPTION
Enables `as_job` parameter for `groups.update`. 

Resolves #1260.