### PR TITLE
Added Filtering Capability for Tableau Download View Crosstab Excel

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -167,6 +167,7 @@ class ExcelRequestOptions(_FilterOptionsBase):
         if self.max_age != -1:
             params["maxAge"] = self.max_age
 
+        self._append_view_filters(params)
         return params
 
 


### PR DESCRIPTION
Enhancement:

Implemented the capability to add filters when downloading a View as an Excel Crosstab from Tableau.

Context:
Previously, the Tableau REST API documentation didn't specify the possibility of using `vf_<fieldname>=filter-value` to filter crosstab data during a download. However, the recent [Tableau REST API documentation](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#download_view_excel) has made this functionality clear.

Changes:
Added filter parameters as per the updated documentation.
Tested the functionality to ensure filtering works as expected when downloading crosstab data.