### PR TITLE
Jorwoods/tasks no schedule

### DIFF
--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from defusedxml.ElementTree import fromstring
 
 from tableauserverclient.datetime_helpers import parse_datetime
@@ -44,7 +46,7 @@ class TaskItem(object):
         )
 
     @classmethod
-    def from_response(cls, xml, ns, task_type=Type.ExtractRefresh):
+    def from_response(cls, xml, ns, task_type=Type.ExtractRefresh) -> List["TaskItem"]:
         parsed_response = fromstring(xml)
         all_tasks_xml = parsed_response.findall(".//t:task/t:{}".format(task_type), namespaces=ns)
 
@@ -94,7 +96,7 @@ class TaskItem(object):
         )
 
     @staticmethod
-    def _translate_task_type(task_type):
+    def _translate_task_type(task_type: str) -> str:
         if task_type in TaskItem._TASK_TYPE_MAPPING:
             return TaskItem._TASK_TYPE_MAPPING[task_type]
         else:

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -28,7 +28,7 @@ class TaskItem(object):
         consecutive_failed_count: int = 0,
         schedule_id: Optional[str] = None,
         schedule_item: Optional[str] = None,
-        last_run_at: Optional[datetime]=None,
+        last_run_at: Optional[datetime] = None,
         target: Optional[Target] = None,
     ):
         self.id = id_

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -1,4 +1,5 @@
-from typing import List
+from datetime import datetime
+from typing import List, Optional
 
 from defusedxml.ElementTree import fromstring
 
@@ -21,14 +22,14 @@ class TaskItem(object):
 
     def __init__(
         self,
-        id_,
-        task_type,
-        priority,
-        consecutive_failed_count=0,
-        schedule_id=None,
-        schedule_item=None,
-        last_run_at=None,
-        target=None,
+        id_: str,
+        task_type: str,
+        priority: int,
+        consecutive_failed_count: int = 0,
+        schedule_id: Optional[str] = None,
+        schedule_item: Optional[str] = None,
+        last_run_at: Optional[datetime]=None,
+        target: Optional[Target] = None,
     ):
         self.id = id_
         self.task_type = task_type
@@ -39,7 +40,7 @@ class TaskItem(object):
         self.last_run_at = last_run_at
         self.target = target
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "<Task#{id} {task_type} pri({priority}) failed({consecutive_failed_count}) schedule_id({"
             "schedule_id}) target({target})>".format(**self.__dict__)

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -27,7 +27,7 @@ class TaskItem(object):
         priority: int,
         consecutive_failed_count: int = 0,
         schedule_id: Optional[str] = None,
-        schedule_item: Optional[str] = None,
+        schedule_item: Optional[ScheduleItem] = None,
         last_run_at: Optional[datetime] = None,
         target: Optional[Target] = None,
     ):

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -65,8 +65,7 @@ class TaskItem(object):
         last_run_at_element = element.find(".//t:lastRunAt", namespaces=ns)
 
         schedule_item_list = ScheduleItem.from_element(element, ns)
-        if len(schedule_item_list) >= 1:
-            schedule_item = schedule_item_list[0]
+        schedule_item = next(iter(schedule_item_list), None)
 
         # according to the Tableau Server REST API documentation,
         # there should be only one of workbook or datasource
@@ -90,7 +89,7 @@ class TaskItem(object):
             task_type,
             priority,
             consecutive_failed_count,
-            schedule_item.id,
+            schedule_item.id if schedule_item is not None else None,
             schedule_item,
             last_run_at,
             target,

--- a/tableauserverclient/models/task_item.py
+++ b/tableauserverclient/models/task_item.py
@@ -1,8 +1,8 @@
 from defusedxml.ElementTree import fromstring
 
 from tableauserverclient.datetime_helpers import parse_datetime
-from .schedule_item import ScheduleItem
-from .target import Target
+from tableauserverclient.models.schedule_item import ScheduleItem
+from tableauserverclient.models.target import Target
 
 
 class TaskItem(object):

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -34,7 +34,7 @@ class Tasks(Endpoint):
         if task_type == TaskItem.Type.DataAcceleration:
             self.parent_srv.assert_at_least_version("3.8", "Data Acceleration Tasks")
 
-        logger.info("Querying all {} tasks for the site".format(task_type))
+        logger.info("Querying all %s tasks for the site", task_type)
 
         url = "{0}/{1}".format(self.baseurl, self.__normalize_task_type(task_type))
         server_response = self.get_request(url, req_options)
@@ -48,7 +48,7 @@ class Tasks(Endpoint):
         if not task_id:
             error = "No Task ID provided"
             raise ValueError(error)
-        logger.info("Querying a single task by id ({})".format(task_id))
+        logger.info("Querying a single task by id %s", task_id)
         url = "{}/{}/{}".format(
             self.baseurl,
             self.__normalize_task_type(TaskItem.Type.ExtractRefresh),
@@ -62,7 +62,7 @@ class Tasks(Endpoint):
         if not extract_item:
             error = "No extract refresh provided"
             raise ValueError(error)
-        logger.info("Creating an extract refresh ({})".format(extract_item))
+        logger.info("Creating an extract refresh %s", extract_item)
         url = "{0}/{1}".format(self.baseurl, self.__normalize_task_type(TaskItem.Type.ExtractRefresh))
         create_req = RequestFactory.Task.create_extract_req(extract_item)
         server_response = self.post_request(url, create_req)
@@ -94,4 +94,4 @@ class Tasks(Endpoint):
             raise ValueError(error)
         url = "{0}/{1}/{2}".format(self.baseurl, self.__normalize_task_type(task_type), task_id)
         self.delete_request(url)
-        logger.info("Deleted single task (ID: {0})".format(task_id))
+        logger.info("Deleted single task (ID: %s)", task_id)

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -1,7 +1,7 @@
 import logging
 
-from .endpoint import Endpoint, api
-from .exceptions import MissingRequiredFieldError
+from tableauserverclient.server.endpoint import Endpoint, api
+from tableauserverclient.server.exceptions import MissingRequiredFieldError
 from tableauserverclient.models import TaskItem, PaginationItem
 from tableauserverclient.server import RequestFactory
 

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -1,7 +1,7 @@
 import logging
 
-from tableauserverclient.server.endpoint import Endpoint, api
-from tableauserverclient.server.exceptions import MissingRequiredFieldError
+from tableauserverclient.server.endpoint.endpoint import Endpoint, api
+from tableauserverclient.server.endpoint.exceptions import MissingRequiredFieldError
 from tableauserverclient.models import TaskItem, PaginationItem
 from tableauserverclient.server import RequestFactory
 

--- a/tableauserverclient/server/endpoint/tasks_endpoint.py
+++ b/tableauserverclient/server/endpoint/tasks_endpoint.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 from tableauserverclient.server.endpoint.endpoint import Endpoint, api
 from tableauserverclient.server.endpoint.exceptions import MissingRequiredFieldError
@@ -7,13 +8,16 @@ from tableauserverclient.server import RequestFactory
 
 from tableauserverclient.helpers.logging import logger
 
+if TYPE_CHECKING:
+    from tableauserverclient.server.request_options import RequestOptions
+
 
 class Tasks(Endpoint):
     @property
-    def baseurl(self):
+    def baseurl(self) -> str:
         return "{0}/sites/{1}/tasks".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
-    def __normalize_task_type(self, task_type):
+    def __normalize_task_type(self, task_type: str) -> str:
         """
         The word for extract refresh used in API URL is "extractRefreshes".
         It is different than the tag "extractRefresh" used in the request body.
@@ -24,7 +28,9 @@ class Tasks(Endpoint):
             return task_type
 
     @api(version="2.6")
-    def get(self, req_options=None, task_type=TaskItem.Type.ExtractRefresh):
+    def get(
+        self, req_options: Optional["RequestOptions"] = None, task_type: str = TaskItem.Type.ExtractRefresh
+    ) -> Tuple[List[TaskItem], PaginationItem]:
         if task_type == TaskItem.Type.DataAcceleration:
             self.parent_srv.assert_at_least_version("3.8", "Data Acceleration Tasks")
 
@@ -38,7 +44,7 @@ class Tasks(Endpoint):
         return all_tasks, pagination_item
 
     @api(version="2.6")
-    def get_by_id(self, task_id):
+    def get_by_id(self, task_id: str) -> TaskItem:
         if not task_id:
             error = "No Task ID provided"
             raise ValueError(error)
@@ -63,7 +69,7 @@ class Tasks(Endpoint):
         return server_response.content
 
     @api(version="2.6")
-    def run(self, task_item):
+    def run(self, task_item: TaskItem) -> bytes:
         if not task_item.id:
             error = "Task item missing ID."
             raise MissingRequiredFieldError(error)
@@ -79,7 +85,7 @@ class Tasks(Endpoint):
 
     # Delete 1 task by id
     @api(version="3.6")
-    def delete(self, task_id, task_type=TaskItem.Type.ExtractRefresh):
+    def delete(self, task_id: str, task_type: str = TaskItem.Type.ExtractRefresh) -> None:
         if task_type == TaskItem.Type.DataAcceleration:
             self.parent_srv.assert_at_least_version("3.8", "Data Acceleration Tasks")
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1032,6 +1032,16 @@ class TaskRequest(object):
     def create_extract_req(self, xml_request: ET.Element, extract_item: "TaskItem") -> bytes:
         extract_element = ET.SubElement(xml_request, "extractRefresh")
 
+        # Main attributes
+        extract_element.attrib["type"] = extract_item.task_type
+
+        if extract_item.target is not None:
+            target_element = ET.SubElement(extract_element, extract_item.target.type)
+            target_element.attrib["id"] = extract_item.target.id
+
+        if extract_item.schedule_item is None:
+            return ET.tostring(xml_request)
+
         # Schedule attributes
         schedule_element = ET.SubElement(xml_request, "schedule")
 
@@ -1043,16 +1053,10 @@ class TaskRequest(object):
             frequency_element.attrib["end"] = str(interval_item.end_time)
         if hasattr(interval_item, "interval") and interval_item.interval:
             intervals_element = ET.SubElement(frequency_element, "intervals")
-            for interval in interval_item._interval_type_pairs():
+            for interval in interval_item._interval_type_pairs():  # type: ignore
                 expression, value = interval
                 single_interval_element = ET.SubElement(intervals_element, "interval")
                 single_interval_element.attrib[expression] = value
-
-        # Main attributes
-        extract_element.attrib["type"] = extract_item.task_type
-
-        target_element = ET.SubElement(extract_element, extract_item.target.type)
-        target_element.attrib["id"] = extract_item.target.id
 
         return ET.tostring(xml_request)
 

--- a/test/assets/tasks_without_schedule.xml
+++ b/test/assets/tasks_without_schedule.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse 
+    xmlns="http://tableau.com/api" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.6.xsd">
+    <tasks>
+        <task>
+            <extractRefresh id="f84901ac-72ad-4f9b-a87e-7a3500402ad6" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
+                <datasource id="c7a9327e-1cda-4504-b026-ddb43b976d1d" />
+            </extractRefresh>
+        </task>
+    </tasks>
+</tsResponse>

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from datetime import time
+from pathlib import Path
 
 import requests_mock
 
@@ -8,7 +9,7 @@ import tableauserverclient as TSC
 from tableauserverclient.datetime_helpers import parse_datetime
 from tableauserverclient.models.task_item import TaskItem
 
-TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
+TEST_ASSET_DIR = Path(__file__).parent / "assets"
 
 GET_XML_NO_WORKBOOK = os.path.join(TEST_ASSET_DIR, "tasks_no_workbook_or_datasource.xml")
 GET_XML_WITH_WORKBOOK = os.path.join(TEST_ASSET_DIR, "tasks_with_workbook.xml")
@@ -17,6 +18,7 @@ GET_XML_WITH_WORKBOOK_AND_DATASOURCE = os.path.join(TEST_ASSET_DIR, "tasks_with_
 GET_XML_DATAACCELERATION_TASK = os.path.join(TEST_ASSET_DIR, "tasks_with_dataacceleration_task.xml")
 GET_XML_RUN_NOW_RESPONSE = os.path.join(TEST_ASSET_DIR, "tasks_run_now_response.xml")
 GET_XML_CREATE_TASK_RESPONSE = os.path.join(TEST_ASSET_DIR, "tasks_create_extract_task.xml")
+GET_XML_WITHOUT_SCHEDULE = TEST_ASSET_DIR / "tasks_without_schedule.xml"
 
 
 class TaskTests(unittest.TestCase):
@@ -85,6 +87,15 @@ class TaskTests(unittest.TestCase):
         self.assertEqual("c7a9327e-1cda-4504-b026-ddb43b976d1d", task.target.id)
         self.assertEqual("workbook", task.target.type)
         self.assertEqual("b60b4efd-a6f7-4599-beb3-cb677e7abac1", task.schedule_id)
+
+    def test_get_task_without_schedule(self):
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=GET_XML_WITHOUT_SCHEDULE.read_text())
+            all_tasks, pagination_item = self.server.tasks.get()
+
+        task = all_tasks[0]
+        self.assertEqual("c7a9327e-1cda-4504-b026-ddb43b976d1d", task.target.id)
+        self.assertEqual("datasource", task.target.type)
 
     def test_delete(self):
         with requests_mock.mock() as m:


### PR DESCRIPTION
My thoughts on resolving #1290 and adding type annotations on tasks. I noticed at the moment, running a task returns the raw `bytes` from the server response. A change to the TSC API would be consuming that response and returning a `JobItem`. 