### PR TITLE
Allow check to continue even if MishaKav/pytest-coverage-comment fails

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -33,6 +33,7 @@ jobs:
       run: pytest --junitxml=pytest.xml --cov=tableauserverclient test/ | tee pytest-coverage.txt
 
     - name: Comment on pull request with coverage
+      continue-on-error: true
       uses: MishaKav/pytest-coverage-comment@main
       with:
         pytest-coverage-path: ./pytest-coverage.txt


### PR DESCRIPTION
Right now this action is failing with what appears to be this issue: https://github.com/MishaKav/pytest-coverage-comment/issues/68

It seems to be failing on PRs from outside contributors only, so making this change will let thoses PRs through while we sort this out.