### PR TITLE
Fixed type annotation for workbook.refresh

### DIFF
--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -88,8 +88,8 @@ class Workbooks(QuerysetEndpoint):
         return WorkbookItem.from_response(server_response.content, self.parent_srv.namespace)[0]
 
     @api(version="2.8")
-    def refresh(self, workbook_id: str) -> JobItem:
-        id_ = getattr(workbook_id, "id", workbook_id)
+    def refresh(self, workbook_item: Union[WorkbookItem, str]) -> JobItem:
+        id_ = getattr(workbook_item, "id", workbook_item)
         url = "{0}/{1}/refresh".format(self.baseurl, id_)
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)


### PR DESCRIPTION
`workbook.refresh` is implemented to accept both `WorkbookItem` and `str` as arguments, but the type annotation describes it as receiving `str`, which can cause false warnings in static analysis.

Since the documentation states that it receives `workbook_item`, the name of the argument is also changed from `workbook_id` to `workbook_item`.

Issue: https://github.com/tableau/server-client-python/issues/1318