### PR TITLE
Adds support for latest Tableau Srever version.

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -441,7 +441,8 @@ class Datasources(QuerysetEndpoint):
                     filepath.write(chunk)
                 return_path = filepath
             else:
-                filename = to_filename(os.path.basename(params["filename"]))
+                params_filename = params.get("filename", params.get("filename*"))
+                filename = to_filename(os.path.basename(params_filename))
                 download_path = make_download_path(filepath, filename)
                 with open(download_path, "wb") as f:
                     for chunk in server_response.iter_content(1024):  # 1KB

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -124,7 +124,8 @@ class Flows(QuerysetEndpoint):
                     filepath.write(chunk)
                 return_path = filepath
             else:
-                filename = to_filename(os.path.basename(params["filename"]))
+                params_filename = params.get("filename", params.get("filename*"))
+                filename = to_filename(os.path.basename(params_filename))
                 download_path = make_download_path(filepath, filename)
                 with open(download_path, "wb") as f:
                     for chunk in server_response.iter_content(1024):  # 1KB

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -487,7 +487,8 @@ class Workbooks(QuerysetEndpoint):
                     filepath.write(chunk)
                 return_path = filepath
             else:
-                filename = to_filename(os.path.basename(params["filename"]))
+                params_filename = params.get("filename", params.get("filename*"))
+                filename = to_filename(os.path.basename(params_filename))
                 download_path = make_download_path(filepath, filename)
                 with open(download_path, "wb") as f:
                     for chunk in server_response.iter_content(1024):  # 1KB


### PR DESCRIPTION
Fixes #1312.

In the latest version of Tableau Server (2023.1.7) the params dictionary no longer has a `filename` key, instead it has a `filename*` key. The proposed change will work with both keys and the change will be backwards compatible.