### PR TITLE
fix Unauthorized Error in 0.29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ $RECYCLE.BIN/
 docs/_site/
 docs/.jekyll-metadata
 docs/Gemfile.lock
+samples/credentials

--- a/contributing.md
+++ b/contributing.md
@@ -10,8 +10,7 @@ Contribution can include, but are not limited to, any of the following:
 * Fix an Issue/Bug
 * Add/Fix documentation
 
-Contributions must follow the guidelines outlined on the [Tableau Organization](http://tableau.github.io/) page, though filing an issue or requesting
-a feature do not require the CLA.
+Contributions must follow the guidelines outlined on the [Tableau Organization](http://tableau.github.io/) page, though filing an issue or requesting a feature do not require the CLA.
 
 ## Issues and Feature Requests
 

--- a/samples/getting_started/3_hello_universe.py
+++ b/samples/getting_started/3_hello_universe.py
@@ -62,11 +62,6 @@ def main():
             print("{} jobs".format(pagination.total_available))
             print(jobs[0])
 
-        metrics, pagination = server.metrics.get()
-        if metrics:
-            print("{} metrics".format(pagination.total_available))
-            print(metrics[0])
-
         schedules, pagination = server.schedules.get()
         if schedules:
             print("{} schedules".format(pagination.total_available))
@@ -82,7 +77,7 @@ def main():
             print("{} webhooks".format(pagination.total_available))
             print(webhooks[0])
 
-        users, pagination = server.metrics.get()
+        users, pagination = server.users.get()
         if users:
             print("{} users".format(pagination.total_available))
             print(users[0])
@@ -92,5 +87,5 @@ def main():
             print("{} groups".format(pagination.total_available))
             print(groups[0])
 
-    if __name__ == "__main__":
-        main()
+if __name__ == "__main__":
+    main()

--- a/samples/getting_started/3_hello_universe.py
+++ b/samples/getting_started/3_hello_universe.py
@@ -87,5 +87,6 @@ def main():
             print("{} groups".format(pagination.total_available))
             print(groups[0])
 
+
 if __name__ == "__main__":
     main()

--- a/tableauserverclient/models/interval_item.py
+++ b/tableauserverclient/models/interval_item.py
@@ -69,7 +69,7 @@ class HourlyInterval(object):
 
     @interval.setter
     def interval(self, intervals):
-        VALID_INTERVALS = {0.25, 0.5, 1, 2, 4, 6, 8, 12}
+        VALID_INTERVALS = {0.25, 0.5, 1, 2, 4, 6, 8, 12, 24}
         for interval in intervals:
             # if an hourly interval is a string, then it is a weekDay interval
             if isinstance(interval, str) and not interval.isnumeric() and not hasattr(IntervalItem.Day, interval):

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import pytest
+import requests
 import unittest
 
 import tableauserverclient as TSC
@@ -35,11 +37,12 @@ class TestEndpoint(unittest.TestCase):
             )
             self.assertIsNotNone(response)
 
-    def test_blocking_request_returns(self) -> None:
-        url = "http://test/"
-        endpoint = TSC.server.Endpoint(self.server)
-        response = endpoint._blocking_request(endpoint.parent_srv.session.get, url=url)
-        self.assertIsNotNone(response)
+    def test_blocking_request_raises_request_error(self) -> None:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            url = "http://test/"
+            endpoint = TSC.server.Endpoint(self.server)
+            response = endpoint._blocking_request(endpoint.parent_srv.session.get, url=url)
+            self.assertIsNotNone(response)
 
     def test_get_request_stream(self) -> None:
         url = "http://test/"


### PR DESCRIPTION
This fixes #1342 and #1339 
The retry code was being triggered wrongly so the requests were made twice.

Validated against live server with the hello_universe sample, and also by running tabcmd built with the fixed version of tsc.