### PR TITLE
Add support for daily (24 hour) intervals for tasks

### DIFF
--- a/tableauserverclient/models/interval_item.py
+++ b/tableauserverclient/models/interval_item.py
@@ -136,7 +136,7 @@ class DailyInterval(object):
 
     @interval.setter
     def interval(self, intervals):
-        VALID_INTERVALS = {0.25, 0.5, 1, 2, 4, 6, 8, 12}
+        VALID_INTERVALS = {0.25, 0.5, 1, 2, 4, 6, 8, 12, 24}
 
         for interval in intervals:
             # if an hourly interval is a string, then it is a weekDay interval

--- a/test/assets/tasks_with_interval.xml
+++ b/test/assets/tasks_with_interval.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse
+    xmlns="http://tableau.com/api"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_20.xsd">
+    <tasks>
+        <task>
+            <extractRefresh id="12b07582-7c8b-4f1b-318b-51f6e58e4517" priority="50" consecutiveFailedCount="0" type="RefreshExtractTask">
+                <schedule frequency="Daily" nextRunAt="2024-02-21T02:20:00Z">
+                    <frequencyDetails start="18:20:00" end="18:20:00">
+                        <intervals>
+                            <interval hours="24" />
+                            <interval weekDay="Tuesday" />
+                        </intervals>
+                    </frequencyDetails>
+                </schedule>
+                <datasource id="e4de0575-fcc7-4232-5659-be09bb8e7654" />
+            </extractRefresh>
+        </task>
+    </tasks>
+</tsResponse>

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -19,6 +19,7 @@ GET_XML_DATAACCELERATION_TASK = os.path.join(TEST_ASSET_DIR, "tasks_with_dataacc
 GET_XML_RUN_NOW_RESPONSE = os.path.join(TEST_ASSET_DIR, "tasks_run_now_response.xml")
 GET_XML_CREATE_TASK_RESPONSE = os.path.join(TEST_ASSET_DIR, "tasks_create_extract_task.xml")
 GET_XML_WITHOUT_SCHEDULE = TEST_ASSET_DIR / "tasks_without_schedule.xml"
+GET_XML_WITH_INTERVAL = TEST_ASSET_DIR / "tasks_with_interval.xml"
 
 
 class TaskTests(unittest.TestCase):
@@ -95,6 +96,15 @@ class TaskTests(unittest.TestCase):
 
         task = all_tasks[0]
         self.assertEqual("c7a9327e-1cda-4504-b026-ddb43b976d1d", task.target.id)
+        self.assertEqual("datasource", task.target.type)
+
+    def test_get_task_with_interval(self):
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=GET_XML_WITH_INTERVAL.read_text())
+            all_tasks, pagination_item = self.server.tasks.get()
+
+        task = all_tasks[0]
+        self.assertEqual("e4de0575-fcc7-4232-5659-be09bb8e7654", task.target.id)
         self.assertEqual("datasource", task.target.type)
 
     def test_delete(self):


### PR DESCRIPTION
Fixes #1354 by adding "24" as a valid interval. The model still doesn't do anything with the interval returned, but with this change you won't get an exception by just fetching tasks.