### PR TITLE
feat: add description support on wb publish

### DIFF
--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -91,6 +91,10 @@ class WorkbookItem(object):
     def description(self) -> Optional[str]:
         return self._description
 
+    @description.setter
+    def description(self, value: str):
+        self._description = value
+
     @property
     def id(self) -> Optional[str]:
         return self._id

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -911,6 +911,9 @@ class WorkbookRequest(object):
             for connection in connections:
                 _add_connections_element(connections_element, connection)
 
+        if workbook_item.description is not None:
+            workbook_element.attrib["description"] = workbook_item.description
+
         if hidden_views is not None:
             import warnings
 

--- a/test/assets/workbook_publish.xml
+++ b/test/assets/workbook_publish.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
-	<workbook id="a8076ca1-e9d8-495e-bae6-c684dbb55836" name="RESTAPISample" contentUrl="RESTAPISample_0" showTabs="false" size="1" createdAt="2016-08-18T18:33:24Z" updatedAt="2016-08-18T20:31:34Z">
+	<workbook id="a8076ca1-e9d8-495e-bae6-c684dbb55836" name="RESTAPISample" contentUrl="RESTAPISample_0" showTabs="false" size="1" createdAt="2016-08-18T18:33:24Z" updatedAt="2016-08-18T20:31:34Z" description="REST API Testing">
 		<project id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760" name="default" />
 		<owner id="5de011f8-5aa9-4d5b-b991-f462c8dd6bb7" />
 		<tags />

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -488,6 +488,8 @@ class WorkbookTests(unittest.TestCase):
                 name="Sample", show_tabs=False, project_id="ee8c6e70-43b6-11e6-af4f-f7b0d8e20760"
             )
 
+            new_workbook.description = "REST API Testing"
+
             sample_workbook = os.path.join(TEST_ASSET_DIR, "SampleWB.twbx")
             publish_mode = self.server.PublishMode.CreateNew
 
@@ -506,6 +508,7 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual("fe0b4e89-73f4-435e-952d-3a263fbfa56c", new_workbook.views[0].id)
         self.assertEqual("GDP per capita", new_workbook.views[0].name)
         self.assertEqual("RESTAPISample_0/sheets/GDPpercapita", new_workbook.views[0].content_url)
+        self.assertEqual("REST API Testing", new_workbook.description)
 
     def test_publish_a_packaged_file_object(self) -> None:
         with open(PUBLISH_XML, "rb") as f:


### PR DESCRIPTION
Add support for setting description on publish for workbooks. Already supported server side, just undocumented.