### PR TITLE
fix typo in server.views.get_by_id example

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -4672,7 +4672,7 @@ tableau_auth = TSC.TableauAuth('username', 'password')
 server = TSC.Server('https://servername')
 
 with server.auth.sign_in(tableau_auth):
-    view = server.view.get_by_id('d79634e1-6063-4ec9-95ff-50acbf609ff5')
+    view = server.views.get_by_id('d79634e1-6063-4ec9-95ff-50acbf609ff5')
     print(view.name)
 ```
 


### PR DESCRIPTION
running current example gives: 
`AttributeError: 'Server' object has no attribute 'view'`