### PR TITLE
Improve robustness of Pager results

### DIFF
--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -47,7 +47,11 @@ class Pager(object):
 
         # Get the rest on demand as a generator
         while self._count < last_pagination_item.total_available:
-            if len(current_item_list) == 0:
+            if (
+                len(current_item_list) == 0
+                and (last_pagination_item.page_number * last_pagination_item.page_size)
+                < last_pagination_item.total_available
+            ):
                 current_item_list, last_pagination_item = self._load_next_page(last_pagination_item)
 
             try:


### PR DESCRIPTION
In some cases, Tableau Server might have a different between the advertised total number of object and the actual number returned via the Pager.

This change adds one more check to prevent errors from happening in these situations.

Fixes #1304