### PR TITLE
fix: don't lowercase OData server addresses

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1061,8 +1061,13 @@ class Connection(object):
     @_tsrequest_wrapped
     def update_req(self, xml_request: ET.Element, connection_item: "ConnectionItem") -> None:
         connection_element = ET.SubElement(xml_request, "connection")
-        if connection_item.server_address is not None:
-            connection_element.attrib["serverAddress"] = connection_item.server_address.lower()
+        if (server_address := connection_item.server_address) is not None:
+            if (conn_type := connection_item.connection_type) is not None:
+                if conn_type.casefold() != "odata".casefold():
+                    server_address = server_address.lower()
+            else:
+                server_address = server_address.lower()
+            connection_element.attrib["serverAddress"] = server_address
         if connection_item.server_port is not None:
             connection_element.attrib["serverPort"] = str(connection_item.server_port)
         if connection_item.username is not None:

--- a/test/assets/odata_connection.xml
+++ b/test/assets/odata_connection.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?><tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_23.xsd">
+    <connections>
+        <connection id="17376070-64d1-4d17-acb4-a56e4b5b1768" type="odata" embedPassword="false" serverAddress="https://odata.website.com/TestODataEndpoint" userName="" queryTaggingEnabled="false">
+            <datasource id="d82f784e-178f-4b7e-a723-d8f615155a42" name="People (services.odata.org/ODataPeopleService/People)"/>
+        </connection>
+    </connections>
+</tsResponse>


### PR DESCRIPTION
Closes #1392

OData strings are case sensitive. If the ConnectionItem has a connection_type indicating it is an OData connection, do not force the server address of the ConnectionItem to lowercase.