### PR TITLE
chore: type hint QuerySet and QuerySetEndpoint

### DIFF
--- a/tableauserverclient/server/endpoint/custom_views_endpoint.py
+++ b/tableauserverclient/server/endpoint/custom_views_endpoint.py
@@ -17,7 +17,7 @@ update the name or owner of a custom view.
 """
 
 
-class CustomViews(QuerysetEndpoint):
+class CustomViews(QuerysetEndpoint[CustomViewItem]):
     def __init__(self, parent_srv):
         super(CustomViews, self).__init__(parent_srv)
 

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -54,7 +54,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Datasources(QuerysetEndpoint):
+class Datasources(QuerysetEndpoint[DatasourceItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Datasources, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/endpoint/flow_runs_endpoint.py
+++ b/tableauserverclient/server/endpoint/flow_runs_endpoint.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..request_options import RequestOptions
 
 
-class FlowRuns(QuerysetEndpoint):
+class FlowRuns(QuerysetEndpoint[FlowRunItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(FlowRuns, self).__init__(parent_srv)
         return None

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -50,7 +50,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Flows(QuerysetEndpoint):
+class Flows(QuerysetEndpoint[FlowItem]):
     def __init__(self, parent_srv):
         super(Flows, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/endpoint/groups_endpoint.py
+++ b/tableauserverclient/server/endpoint/groups_endpoint.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ..request_options import RequestOptions
 
 
-class Groups(QuerysetEndpoint):
+class Groups(QuerysetEndpoint[GroupItem]):
     @property
     def baseurl(self) -> str:
         return "{0}/sites/{1}/groups".format(self.parent_srv.baseurl, self.parent_srv.site_id)

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -11,7 +11,7 @@ from tableauserverclient.helpers.logging import logger
 from typing import List, Optional, Tuple, Union
 
 
-class Jobs(QuerysetEndpoint):
+class Jobs(QuerysetEndpoint[JobItem]):
     @property
     def baseurl(self):
         return "{0}/sites/{1}/jobs".format(self.parent_srv.baseurl, self.parent_srv.site_id)

--- a/tableauserverclient/server/endpoint/metrics_endpoint.py
+++ b/tableauserverclient/server/endpoint/metrics_endpoint.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 from tableauserverclient.helpers.logging import logger
 
 
-class Metrics(QuerysetEndpoint):
+class Metrics(QuerysetEndpoint[MetricItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Metrics, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 from tableauserverclient.helpers.logging import logger
 
 
-class Projects(QuerysetEndpoint):
+class Projects(QuerysetEndpoint[ProjectItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Projects, self).__init__(parent_srv)
 

--- a/tableauserverclient/server/endpoint/users_endpoint.py
+++ b/tableauserverclient/server/endpoint/users_endpoint.py
@@ -11,7 +11,7 @@ from ..pager import Pager
 from tableauserverclient.helpers.logging import logger
 
 
-class Users(QuerysetEndpoint):
+class Users(QuerysetEndpoint[UserItem]):
     @property
     def baseurl(self) -> str:
         return "{0}/sites/{1}/users".format(self.parent_srv.baseurl, self.parent_srv.site_id)

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     )
 
 
-class Views(QuerysetEndpoint):
+class Views(QuerysetEndpoint[ViewItem]):
     def __init__(self, parent_srv):
         super(Views, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -56,7 +56,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Workbooks(QuerysetEndpoint):
+class Workbooks(QuerysetEndpoint[WorkbookItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Workbooks, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -39,7 +39,7 @@ class QuerySet(Iterable[T], Sized):
         self._result_cache: List[T] = []
         self._pagination_item = PaginationItem()
 
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self: Self) -> Iterator[T]:
         # Not built to be re-entrant. Starts back at page 1, and empties
         # the result cache. Ensure the result_cache is empty to not yield
         # items from prior usage.
@@ -55,11 +55,11 @@ class QuerySet(Iterable[T], Sized):
                 return
 
     @overload
-    def __getitem__(self, k: Slice) -> List[T]:
+    def __getitem__(self: Self, k: Slice) -> List[T]:
         ...
 
     @overload
-    def __getitem__(self, k: int) -> T:
+    def __getitem__(self: Self, k: int) -> T:
         ...
 
     def __getitem__(self, k):
@@ -109,32 +109,32 @@ class QuerySet(Iterable[T], Sized):
             # If k is unreasonable, raise an IndexError.
             raise IndexError
 
-    def _fetch_all(self) -> None:
+    def _fetch_all(self: Self) -> None:
         """
         Retrieve the data and store result and pagination item in cache
         """
         if not self._result_cache:
             self._result_cache, self._pagination_item = self.model.get(self.request_options)
 
-    def __len__(self) -> int:
+    def __len__(self: Self) -> int:
         return self.total_available
 
     @property
-    def total_available(self) -> int:
+    def total_available(self: Self) -> int:
         self._fetch_all()
         return self._pagination_item.total_available
 
     @property
-    def page_number(self) -> int:
+    def page_number(self: Self) -> int:
         self._fetch_all()
         return self._pagination_item.page_number
 
     @property
-    def page_size(self) -> int:
+    def page_size(self: Self) -> int:
         self._fetch_all()
         return self._pagination_item.page_size
 
-    def filter(self, *invalid, **kwargs) -> Self:
+    def filter(self: Self, *invalid, **kwargs) -> Self:
         if invalid:
             raise RuntimeError("Only accepts keyword arguments.")
         for kwarg_key, value in kwargs.items():
@@ -142,20 +142,20 @@ class QuerySet(Iterable[T], Sized):
             self.request_options.filter.add(Filter(field_name, operator, value))
         return self
 
-    def order_by(self, *args) -> Self:
+    def order_by(self: Self, *args) -> Self:
         for arg in args:
             field_name, direction = self._parse_shorthand_sort(arg)
             self.request_options.sort.add(Sort(field_name, direction))
         return self
 
-    def paginate(self, **kwargs) -> Self:
+    def paginate(self: Self, **kwargs) -> Self:
         if "page_number" in kwargs:
             self.request_options.pagenumber = kwargs["page_number"]
         if "page_size" in kwargs:
             self.request_options.pagesize = kwargs["page_size"]
         return self
 
-    def _parse_shorthand_filter(self, key: str) -> Tuple[str, str]:
+    def _parse_shorthand_filter(self: Self, key: str) -> Tuple[str, str]:
         tokens = key.split("__", 1)
         if len(tokens) == 1:
             operator = RequestOptions.Operator.Equals
@@ -169,7 +169,7 @@ class QuerySet(Iterable[T], Sized):
             raise ValueError("Field name `{}` is not valid.".format(field))
         return (field, operator)
 
-    def _parse_shorthand_sort(self, key: str) -> Tuple[str, str]:
+    def _parse_shorthand_sort(self: Self, key: str) -> Tuple[str, str]:
         direction = RequestOptions.Direction.Asc
         if key.startswith("-"):
             direction = RequestOptions.Direction.Desc

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -155,6 +155,10 @@ class QuerySet(Iterable[T], Sized):
             self.request_options.pagesize = kwargs["page_size"]
         return self
 
+    def with_page_size(self: Self, value: int) -> Self:
+        self.request_options.pagesize = value
+        return self
+
     def _parse_shorthand_filter(self: Self, key: str) -> Tuple[str, str]:
         tokens = key.split("__", 1)
         if len(tokens) == 1:

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -47,10 +47,10 @@ class QuerySet(Iterable[T], Sized):
 
         for page in count(1):
             self.request_options.pagenumber = page
+            self._result_cache = []
             self._fetch_all()
             yield from self._result_cache
             # Set result_cache to empty so the fetch will populate
-            self._result_cache = []
             if (page * self.page_size) >= len(self):
                 return
 

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -41,7 +41,9 @@ class QuerySet(Iterable[T], Sized):
 
     def __iter__(self) -> Iterator[T]:
         # Not built to be re-entrant. Starts back at page 1, and empties
-        # the result cache.
+        # the result cache. Ensure the result_cache is empty to not yield
+        # items from prior usage.
+        self._result_cache = []
 
         for page in count(1):
             self.request_options.pagenumber = page

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -1,6 +1,6 @@
-from collections.abc import Iterable, Sized
+from collections.abc import Sized
 from itertools import count
-from typing import Iterator, List, Optional, Protocol, Tuple, TYPE_CHECKING, TypeVar, overload
+from typing import Iterable, Iterator, List, Optional, Protocol, Tuple, TYPE_CHECKING, TypeVar, overload
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.filter import Filter
 from tableauserverclient.server.request_options import RequestOptions

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -337,4 +337,5 @@ class RequestOptionTests(unittest.TestCase):
             with self.subTest(page_size):
                 with requests_mock.mock() as m:
                     m.get(f"{self.baseurl}/views?pageSize={page_size}", text=SLICING_QUERYSET_PAGE_1.read_text())
-                    _ = self.server.views.all().with_page_size(page_size)
+                    queryset = self.server.views.all().with_page_size(page_size)
+                    _ = list(queryset)

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -331,3 +331,15 @@ class RequestOptionTests(unittest.TestCase):
             self.assertIn("value2", query_params["name2$"])
             self.assertIn("type", query_params)
             self.assertIn("tabloid", query_params["type"])
+
+    def test_queryset_pagesize(self) -> None:
+        for page_size in (1, 10, 100, 1000):
+            with self.subTest(page_size):
+                with requests_mock.mock() as m:
+                    m.get(
+                        f"{self.baseurl}/views?pageSize={page_size}",
+                        text=SLICING_QUERYSET_PAGE_1.read_text()
+                        )
+                    _ = self.server.views.all().with_page_size(page_size)
+        
+

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -336,10 +336,5 @@ class RequestOptionTests(unittest.TestCase):
         for page_size in (1, 10, 100, 1000):
             with self.subTest(page_size):
                 with requests_mock.mock() as m:
-                    m.get(
-                        f"{self.baseurl}/views?pageSize={page_size}",
-                        text=SLICING_QUERYSET_PAGE_1.read_text()
-                        )
+                    m.get(f"{self.baseurl}/views?pageSize={page_size}", text=SLICING_QUERYSET_PAGE_1.read_text())
                     _ = self.server.views.all().with_page_size(page_size)
-        
-


### PR DESCRIPTION
This PR makes heavier use of the generics and TypeVars like what is defined in PEP 484, so that usage of `.all` and `.filter` preserve type information of objects coming from the subclass's endpoints.

This also adds a `with_page_size` method onto the `QuerySet` object so that users can set the page request size in the same builder pattern chain.