### PR TITLE
feat: allow setting page_size in .all and .filter

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -309,17 +309,17 @@ T = TypeVar("T")
 
 class QuerysetEndpoint(Endpoint, Generic[T]):
     @api(version="2.0")
-    def all(self, *args, **kwargs) -> QuerySet[T]:
+    def all(self, *args, page_size: Optional[int] = None, **kwargs) -> QuerySet[T]:
         if args or kwargs:
             raise ValueError(".all method takes no arguments.")
-        queryset = QuerySet(self)
+        queryset = QuerySet(self, page_size=page_size)
         return queryset
 
     @api(version="2.0")
-    def filter(self, *_, **kwargs) -> QuerySet[T]:
+    def filter(self, *_, page_size: Optional[int] = None, **kwargs) -> QuerySet[T]:
         if _:
             raise RuntimeError("Only keyword arguments accepted.")
-        queryset = QuerySet(self).filter(**kwargs)
+        queryset = QuerySet(self, page_size=page_size).filter(**kwargs)
         return queryset
 
     @api(version="2.0")

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -332,10 +332,29 @@ class RequestOptionTests(unittest.TestCase):
             self.assertIn("type", query_params)
             self.assertIn("tabloid", query_params["type"])
 
-    def test_queryset_pagesize(self) -> None:
+    def test_queryset_endpoint_pagesize_all(self) -> None:
         for page_size in (1, 10, 100, 1000):
             with self.subTest(page_size):
                 with requests_mock.mock() as m:
                     m.get(f"{self.baseurl}/views?pageSize={page_size}", text=SLICING_QUERYSET_PAGE_1.read_text())
-                    queryset = self.server.views.all().with_page_size(page_size)
+                    queryset = self.server.views.all(page_size=page_size)
+                    assert queryset.request_options.pagesize == page_size
+                    _ = list(queryset)
+
+    def test_queryset_endpoint_pagesize_filter(self) -> None:
+        for page_size in (1, 10, 100, 1000):
+            with self.subTest(page_size):
+                with requests_mock.mock() as m:
+                    m.get(f"{self.baseurl}/views?pageSize={page_size}", text=SLICING_QUERYSET_PAGE_1.read_text())
+                    queryset = self.server.views.filter(page_size=page_size)
+                    assert queryset.request_options.pagesize == page_size
+                    _ = list(queryset)
+
+    def test_queryset_pagesize_filter(self) -> None:
+        for page_size in (1, 10, 100, 1000):
+            with self.subTest(page_size):
+                with requests_mock.mock() as m:
+                    m.get(f"{self.baseurl}/views?pageSize={page_size}", text=SLICING_QUERYSET_PAGE_1.read_text())
+                    queryset = self.server.views.all().filter(page_size=page_size)
+                    assert queryset.request_options.pagesize == page_size
                     _ = list(queryset)


### PR DESCRIPTION
#1399 introduced a `with_page_size` method that allowed a user to specify the page_size of requests in the chains. It felt awkward in practice, so this moves it to be a keyword only argument of the `.all` and `.filter` methods for querysets.

As #1399 has not yet been merged into master, this should be a non breaking change for consumers of TSC.