### PR TITLE
chore: typing decorators

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -126,7 +126,7 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin):
         datasource_id: str,
         filepath: Optional[PathOrFileW] = None,
         include_extract: bool = True,
-    ) -> str:
+    ) -> PathOrFileW:
         return self.download_revision(
             datasource_id,
             None,
@@ -405,7 +405,7 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin):
     def download_revision(
         self,
         datasource_id: str,
-        revision_number: str,
+        revision_number: Optional[str],
         filepath: Optional[PathOrFileW] = None,
         include_extract: bool = True,
     ) -> PathOrFileW:

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -55,7 +55,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin):
+class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Datasources, self).__init__(parent_srv)
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,4 +1,4 @@
-from typing_extensions import Concatenate
+from typing_extensions import Concatenate, ParamSpec
 from tableauserverclient import datetime_helpers as datetime
 
 import abc
@@ -13,7 +13,6 @@ from typing import (
     List,
     Optional,
     TYPE_CHECKING,
-    ParamSpec,
     Tuple,
     TypeVar,
     Union,

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,30 +1,42 @@
+from typing_extensions import Concatenate
 from tableauserverclient import datetime_helpers as datetime
 
 import abc
 from packaging.version import Version
 from functools import wraps
 from xml.etree.ElementTree import ParseError
-from typing import Any, Callable, Dict, Generic, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    ParamSpec,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.request_options import RequestOptions
 
-from .exceptions import (
+from tableauserverclient.server.endpoint.exceptions import (
     ServerResponseError,
     InternalServerError,
     NonXMLResponseError,
     NotSignedInError,
 )
-from ..exceptions import EndpointUnavailableError
+from tableauserverclient.server.exceptions import EndpointUnavailableError
 
 from tableauserverclient.server.query import QuerySet
 from tableauserverclient import helpers, get_versions
 
 from tableauserverclient.helpers.logging import logger
-from tableauserverclient.config import DELAY_SLEEP_SECONDS
 
 if TYPE_CHECKING:
-    from ..server import Server
+    from tableauserverclient.server.server import Server
     from requests import Response
 
 
@@ -38,7 +50,7 @@ TABLEAU_AUTH_HEADER = "x-tableau-auth"
 USER_AGENT_HEADER = "User-Agent"
 
 
-class Endpoint(object):
+class Endpoint:
     def __init__(self, parent_srv: "Server"):
         self.parent_srv = parent_srv
 
@@ -232,7 +244,12 @@ class Endpoint(object):
         )
 
 
-def api(version):
+E = TypeVar("E", bound="Endpoint")
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def api(version: str) -> Callable[[Callable[Concatenate[E, P], R]], Callable[Concatenate[E, P], R]]:
     """Annotate the minimum supported version for an endpoint.
 
     Checks the version on the server object and compares normalized versions.
@@ -251,9 +268,9 @@ def api(version):
     >>>     ...
     """
 
-    def _decorator(func):
+    def _decorator(func: Callable[Concatenate[E, P], R]) -> Callable[Concatenate[E, P], R]:
         @wraps(func)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(self: E, *args: P.args, **kwargs: P.kwargs) -> R:
             self.parent_srv.assert_at_least_version(version, self.__class__.__name__)
             return func(self, *args, **kwargs)
 
@@ -262,7 +279,7 @@ def api(version):
     return _decorator
 
 
-def parameter_added_in(**params):
+def parameter_added_in(**params: str) -> Callable[[Callable[Concatenate[E, P], R]], Callable[Concatenate[E, P], R]]:
     """Annotate minimum versions for new parameters or request options on an endpoint.
 
     The api decorator documents when an endpoint was added, this decorator annotates
@@ -285,9 +302,9 @@ def parameter_added_in(**params):
     >>>     ...
     """
 
-    def _decorator(func):
+    def _decorator(func: Callable[Concatenate[E, P], R]) -> Callable[Concatenate[E, P], R]:
         @wraps(func)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(self: E, *args: P.args, **kwargs: P.kwargs) -> R:
             import warnings
 
             server_ver = Version(self.parent_srv.version or "0.0")
@@ -335,5 +352,5 @@ class QuerysetEndpoint(Endpoint, Generic[T]):
         return queryset
 
     @abc.abstractmethod
-    def get(self, request_options: RequestOptions) -> Tuple[List[T], PaginationItem]:
+    def get(self, request_options: Optional[RequestOptions] = None) -> Tuple[List[T], PaginationItem]:
         raise NotImplementedError(f".get has not been implemented for {self.__class__.__qualname__}")

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -51,7 +51,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Flows(QuerysetEndpoint[FlowItem], TaggingMixin):
+class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem]):
     def __init__(self, parent_srv):
         super(Flows, self).__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -1,4 +1,5 @@
 import logging
+from typing_extensions import Self, overload
 
 from tableauserverclient.server.query import QuerySet
 
@@ -13,15 +14,25 @@ from tableauserverclient.helpers.logging import logger
 from typing import List, Optional, Tuple, Union
 
 
-class Jobs(QuerysetEndpoint[JobItem]):
+class Jobs(QuerysetEndpoint[BackgroundJobItem]):
     @property
     def baseurl(self):
         return "{0}/sites/{1}/jobs".format(self.parent_srv.baseurl, self.parent_srv.site_id)
 
+    @overload  # type: ignore[override]
+    def get(self: Self, job_id: str, req_options: Optional[RequestOptionsBase] = None) -> JobItem:  # type: ignore[override]
+        ...
+
+    @overload  # type: ignore[override]
+    def get(self: Self, job_id: RequestOptionsBase, req_options: None) -> Tuple[List[BackgroundJobItem], PaginationItem]:  # type: ignore[override]
+        ...
+
+    @overload  # type: ignore[override]
+    def get(self: Self, job_id: None, req_options: Optional[RequestOptionsBase]) -> Tuple[List[BackgroundJobItem], PaginationItem]:  # type: ignore[override]
+        ...
+
     @api(version="2.6")
-    def get(
-        self, job_id: Optional[str] = None, req_options: Optional[RequestOptionsBase] = None
-    ) -> Tuple[List[BackgroundJobItem], PaginationItem]:
+    def get(self, job_id=None, req_options=None):
         # Backwards Compatibility fix until we rev the major version
         if job_id is not None and isinstance(job_id, str):
             import warnings
@@ -77,7 +88,7 @@ class Jobs(QuerysetEndpoint[JobItem]):
         else:
             raise AssertionError("Unexpected finish_code in job", job)
 
-    def filter(self, *invalid, page_size: Optional[int] = None, **kwargs) -> QuerySet[JobItem]:
+    def filter(self, *invalid, page_size: Optional[int] = None, **kwargs) -> QuerySet[BackgroundJobItem]:
         """
         Queries the Tableau Server for items using the specified filters. Page
         size can be specified to limit the number of items returned in a single

--- a/tableauserverclient/server/endpoint/tables_endpoint.py
+++ b/tableauserverclient/server/endpoint/tables_endpoint.py
@@ -13,7 +13,7 @@ from tableauserverclient.server.pager import Pager
 from tableauserverclient.helpers.logging import logger
 
 
-class Tables(Endpoint, TaggingMixin):
+class Tables(Endpoint, TaggingMixin[TableItem]):
     def __init__(self, parent_srv):
         super(Tables, self).__init__(parent_srv)
 

--- a/tableauserverclient/server/endpoint/views_endpoint.py
+++ b/tableauserverclient/server/endpoint/views_endpoint.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     )
 
 
-class Views(QuerysetEndpoint[ViewItem], TaggingMixin):
+class Views(QuerysetEndpoint[ViewItem], TaggingMixin[ViewItem]):
     def __init__(self, parent_srv):
         super(Views, self).__init__(parent_srv)
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -59,7 +59,7 @@ PathOrFileR = Union[FilePath, FileObjectR]
 PathOrFileW = Union[FilePath, FileObjectW]
 
 
-class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin):
+class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
     def __init__(self, parent_srv: "Server") -> None:
         super(Workbooks, self).__init__(parent_srv)
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -184,7 +184,7 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin):
         workbook_id: str,
         filepath: Optional[PathOrFileW] = None,
         include_extract: bool = True,
-    ) -> str:
+    ) -> PathOrFileW:
         return self.download_revision(
             workbook_id,
             None,

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1,5 +1,7 @@
 import xml.etree.ElementTree as ET
-from typing import Any, Callable, Dict, Iterable, List, Optional, ParamSpec, Set, Tuple, TypeVar, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, TYPE_CHECKING, Union
+
+from typing_extensions import ParamSpec
 
 from requests.packages.urllib3.fields import RequestField
 from requests.packages.urllib3.filepost import encode_multipart_formdata

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -153,6 +153,7 @@ def test_delete_tags(get_server, endpoint_type, item, tags) -> None:
     urls = {r.url.split("/")[-1] for r in history}
     assert urls == tag_set
 
+
 @pytest.mark.parametrize("endpoint_type, item", *sample_taggable_items)
 @pytest.mark.parametrize("tags", sample_tags)
 def test_update_tags(get_server, endpoint_type, item, tags) -> None:
@@ -163,7 +164,7 @@ def test_update_tags(get_server, endpoint_type, item, tags) -> None:
     tags = set([tags] if isinstance(tags, str) else tags)
     with ExitStack() as stack:
         if hasattr(item, "_initial_tags"):
-            initial_tags = set(['x','y','z'])
+            initial_tags = set(["x", "y", "z"])
             item._initial_tags = initial_tags
             add_tags_xml = add_tag_xml_response_factory(tags - initial_tags)
             delete_tags_xml = add_tag_xml_response_factory(initial_tags - tags)
@@ -186,7 +187,6 @@ def test_update_tags(get_server, endpoint_type, item, tags) -> None:
         else:
             stack.enter_context(pytest.raises(NotImplementedError))
 
-    
         endpoint.update_tags(item)
 
 

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -157,13 +157,13 @@ def test_delete_tags(get_server, endpoint_type, item, tags) -> None:
 @pytest.mark.parametrize("endpoint_type, item", *sample_taggable_items)
 @pytest.mark.parametrize("tags", sample_tags)
 def test_update_tags(get_server, endpoint_type, item, tags) -> None:
-    if isinstance(item, str):
-        return
     endpoint = getattr(get_server, endpoint_type)
     id_ = getattr(item, "id", item)
     tags = set([tags] if isinstance(tags, str) else tags)
     with ExitStack() as stack:
-        if hasattr(item, "_initial_tags"):
+        if isinstance(item, str):
+            stack.enter_context(pytest.raises((ValueError, NotImplementedError)))
+        elif hasattr(item, "_initial_tags"):
             initial_tags = set(["x", "y", "z"])
             item._initial_tags = initial_tags
             add_tags_xml = add_tag_xml_response_factory(tags - initial_tags)


### PR DESCRIPTION
Decorators like `api`, `parameter_added_in`, and `_tsrequest_wrapped` altered the typing signatures and obfuscated mypy from inspecting any of the functions wrapped by these decorators. This PR aims to type these decorators, and fix any underlying typing issues revealed by fixing this.