### PR TITLE
fix: JobItem repr

### DIFF
--- a/tableauserverclient/models/job_item.py
+++ b/tableauserverclient/models/job_item.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from defusedxml.ElementTree import fromstring
 
 from tableauserverclient.datetime_helpers import parse_datetime
-from .flow_run_item import FlowRunItem
+from tableauserverclient.models.flow_run_item import FlowRunItem
 
 
 class JobItem(object):

--- a/tableauserverclient/models/job_item.py
+++ b/tableauserverclient/models/job_item.py
@@ -222,7 +222,7 @@ class BackgroundJobItem(object):
         self._subtitle = subtitle
 
     def __str__(self):
-        return f"<{self.__class__.name} {self._id} {self._type}>"
+        return f"<{self.__class__.__qualname__} {self._id} {self._type}>"
 
     def __repr__(self):
         return self.__str__() + "  { " + ", ".join(" % s: % s" % item for item in vars(self).items()) + "}"

--- a/tableauserverclient/server/endpoint/jobs_endpoint.py
+++ b/tableauserverclient/server/endpoint/jobs_endpoint.py
@@ -1,11 +1,11 @@
 import logging
 
-from tableauserverclient.server.query import QuerySet
 
-from .endpoint import QuerysetEndpoint, api
-from .exceptions import JobCancelledException, JobFailedException
 from tableauserverclient.models import JobItem, BackgroundJobItem, PaginationItem
-from ..request_options import RequestOptionsBase
+from tableauserverclient.server.endpoint.endpoint import QuerysetEndpoint, api
+from tableauserverclient.server.endpoint.exceptions import JobCancelledException, JobFailedException
+from tableauserverclient.server.query import QuerySet
+from tableauserverclient.server.request_options import RequestOptionsBase
 from tableauserverclient.exponential_backoff import ExponentialBackoffTimer
 
 from tableauserverclient.helpers.logging import logger

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -136,3 +136,11 @@ class JobTests(unittest.TestCase):
             m.get(f"{self.baseurl}/{job_id}", text=response_xml)
             job = self.server.jobs.get_by_id(job_id)
         self.assertEqual(job.datasource_name, "World Indicators")
+
+    def test_background_job_str(self) -> None:
+        job = TSC.BackgroundJobItem(
+            "ee8c6e70-43b6-11e6-af4f-f7b0d8e20760", datetime.now(), 1, "extractRefresh", "Failed"
+        )
+        assert not str(job).startswith("<<property")
+        assert not repr(job).startswith("<<property")
+        assert "BackgroundJobItem" in str(job)


### PR DESCRIPTION
JobItem repr would fail, printing out "property" instead of the item type. This PR fixes that.