### PR TITLE
fix: Pager typing

### DIFF
--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -1,24 +1,24 @@
+from collections.abc import Iterable, Iterator
 import copy
 from functools import partial
-from typing import Generic, Iterable, Iterator, List, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
+from typing import List, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
 
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.request_options import RequestOptions
 
 
 T = TypeVar("T")
-ReturnType = Tuple[List[T], PaginationItem]
 
 
 @runtime_checkable
-class Endpoint(Protocol):
-    def get(self, req_options: Optional[RequestOptions], **kwargs) -> ReturnType:
+class Endpoint(Protocol[T]):
+    def get(self, req_options: Optional[RequestOptions]) -> Tuple[List[T], PaginationItem]:
         ...
 
 
 @runtime_checkable
-class CallableEndpoint(Protocol):
-    def __call__(self, __req_options: Optional[RequestOptions], **kwargs) -> ReturnType:
+class CallableEndpoint(Protocol[T]):
+    def __call__(self, __req_options: Optional[RequestOptions], **kwargs) -> Tuple[List[T], PaginationItem]:
         ...
 
 
@@ -33,7 +33,7 @@ class Pager(Iterable[T]):
 
     def __init__(
         self,
-        endpoint: Union[CallableEndpoint, Endpoint],
+        endpoint: Union[CallableEndpoint[T], Endpoint[T]],
         request_opts: Optional[RequestOptions] = None,
         **kwargs,
     ) -> None:

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -1,7 +1,6 @@
-from collections.abc import Iterable, Iterator
 import copy
 from functools import partial
-from typing import List, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
+from typing import Iterable, Iterator, List, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
 
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.request_options import RequestOptions

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -119,6 +119,6 @@ class PagerTests(unittest.TestCase):
         with open(GET_VIEW_XML, "rb") as f:
             view_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
-            m.get(self.baseurl, text=view_xml)
+            m.get(self.server.views.baseurl, text=view_xml)
             for view in TSC.Pager(self.server.views):
-                assert view.name == "Test View"
+                assert view.name is not None

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -9,6 +9,7 @@ from tableauserverclient.config import config
 
 TEST_ASSET_DIR = os.path.join(os.path.dirname(__file__), "assets")
 
+GET_VIEW_XML = os.path.join(TEST_ASSET_DIR, "view_get.xml")
 GET_XML_PAGE1 = os.path.join(TEST_ASSET_DIR, "workbook_get_page_1.xml")
 GET_XML_PAGE2 = os.path.join(TEST_ASSET_DIR, "workbook_get_page_2.xml")
 GET_XML_PAGE3 = os.path.join(TEST_ASSET_DIR, "workbook_get_page_3.xml")
@@ -35,7 +36,7 @@ class PagerTests(unittest.TestCase):
 
         self.baseurl = self.server.workbooks.baseurl
 
-    def test_pager_with_no_options(self):
+    def test_pager_with_no_options(self) -> None:
         with open(GET_XML_PAGE1, "rb") as f:
             page_1 = f.read().decode("utf-8")
         with open(GET_XML_PAGE2, "rb") as f:
@@ -61,7 +62,7 @@ class PagerTests(unittest.TestCase):
             self.assertEqual(wb2.name, "Page2Workbook")
             self.assertEqual(wb3.name, "Page3Workbook")
 
-    def test_pager_with_options(self):
+    def test_pager_with_options(self) -> None:
         with open(GET_XML_PAGE1, "rb") as f:
             page_1 = f.read().decode("utf-8")
         with open(GET_XML_PAGE2, "rb") as f:
@@ -102,14 +103,22 @@ class PagerTests(unittest.TestCase):
             wb3 = workbooks.pop()
             self.assertEqual(wb3.name, "Page3Workbook")
 
-    def test_pager_with_env_var(self):
+    def test_pager_with_env_var(self) -> None:
         with set_env(TSC_PAGE_SIZE="1000"):
             assert config.PAGE_SIZE == 1000
             loop = TSC.Pager(self.server.workbooks)
             assert loop._options.pagesize == 1000
 
-    def test_queryset_with_env_var(self):
+    def test_queryset_with_env_var(self) -> None:
         with set_env(TSC_PAGE_SIZE="1000"):
             assert config.PAGE_SIZE == 1000
             loop = self.server.workbooks.all()
             assert loop.request_options.pagesize == 1000
+
+    def test_pager_view(self) -> None:
+        with open(GET_VIEW_XML, "rb") as f:
+            view_xml = f.read().decode("utf-8")
+        with requests_mock.mock() as m:
+            m.get(self.baseurl, text=view_xml)
+            for view in TSC.Pager(self.server.views):
+                assert view.name == "Test View"


### PR DESCRIPTION
Pager Protocols were missing the generic flags. Added those in so the Pager correctly passes through the typing information. Also removes the kwargs from the function signature of the Endpoint.get protocol to make the Workbook endpoint match.

Adding a return annotation of `None` to the tests is very important because it is what enables static type checkers, like mypy, to inspect those functions. With these annotations now in place, users of TSC should more transparently be able to carry through typing information when using the Pager.