### PR TITLE
docs: add environment variables to sidebar links

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -23,6 +23,9 @@
             <a href="{{ site.baseurl }}/docs/filter-sort">Filter and Sort</a>
         </li>
         <li>
+            <a href="{{ site.baseurl }}/docs/environment-variables">Environment Variables</a>
+        </li>
+        <li>
             <a href="{{ site.baseurl }}/docs/samples">Samples</a>
         </li>
         <li>


### PR DESCRIPTION
Missed adding a link to the side bar for the environment variables page.