### PR TITLE
chore(versions): update remaining f-strings

### DIFF
--- a/tableauserverclient/_version.py
+++ b/tableauserverclient/_version.py
@@ -94,7 +94,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried {}".format(commands))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -131,7 +131,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories {} but none started with prefix {}".format(str(rootdirs), parentdir_prefix))
+        print(f"Tried directories {str(rootdirs)} but none started with prefix {parentdir_prefix}")
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -140,7 +140,7 @@ class Endpoint:
         self._check_status(server_response, url)
 
         loggable_response = self.log_response_safely(server_response)
-        logger.debug("Server response from {0}".format(url))
+        logger.debug(f"Server response from {url}")
         # uncomment the following to log full responses in debug mode
         # BE CAREFUL WHEN SHARING THESE RESULTS - MAY CONTAIN YOUR SENSITIVE DATA
         # logger.debug(loggable_response)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -165,7 +165,7 @@ class ScheduleTests(unittest.TestCase):
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
             schedule_id = "8c5caf33-6223-4724-83c3-ccdc1e730a07"
-            baseurl = "{}/schedules/{}".format(self.server.baseurl, schedule_id)
+            baseurl = f"{self.server.baseurl}/schedules/{schedule_id}"
             m.get(baseurl, text=response_xml)
             schedule = self.server.schedules.get_by_id(schedule_id)
             self.assertIsNotNone(schedule)


### PR DESCRIPTION
Missed a few string formats in the last upgrade.