### PR TITLE
Adding project permissions handling for databases, tables and virtual connections

### DIFF
--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -9,6 +9,8 @@ from tableauserverclient.models.property_decorators import property_is_enum, pro
 
 
 class ProjectItem:
+    ERROR_MSG = "Project item must be populated with permissions first."
+
     class ContentPermissions:
         LockedToProject: str = "LockedToProject"
         ManagedByOwner: str = "ManagedByOwner"
@@ -43,6 +45,9 @@ class ProjectItem:
         self._default_lens_permissions = None
         self._default_datarole_permissions = None
         self._default_metric_permissions = None
+        self._default_virtualconnection_permissions = None
+        self._default_database_permissions = None
+        self._default_table_permissions = None
 
     @property
     def content_permissions(self):
@@ -56,51 +61,62 @@ class ProjectItem:
     @property
     def permissions(self):
         if self._permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._permissions()
 
     @property
     def default_datasource_permissions(self):
         if self._default_datasource_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_datasource_permissions()
 
     @property
     def default_workbook_permissions(self):
         if self._default_workbook_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_workbook_permissions()
 
     @property
     def default_flow_permissions(self):
         if self._default_flow_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_flow_permissions()
 
     @property
     def default_lens_permissions(self):
         if self._default_lens_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_lens_permissions()
 
     @property
     def default_datarole_permissions(self):
         if self._default_datarole_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_datarole_permissions()
 
     @property
     def default_metric_permissions(self):
         if self._default_metric_permissions is None:
-            error = "Project item must be populated with permissions first."
-            raise UnpopulatedPropertyError(error)
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
         return self._default_metric_permissions()
+
+    @property
+    def default_virtualconnection_permissions(self):
+        if self._default_virtualconnection_permissions is None:
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
+        return self._default_virtualconnection_permissions()
+
+    @property
+    def default_database_permissions(self):
+        if self._default_database_permissions is None:
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
+        return self._default_database_permissions()
+
+    @property
+    def default_table_permissions(self):
+        if self._default_table_permissions is None:
+            raise UnpopulatedPropertyError(self.ERROR_MSG)
+        return self._default_table_permissions()
 
     @property
     def id(self) -> Optional[str]:

--- a/tableauserverclient/server/endpoint/projects_endpoint.py
+++ b/tableauserverclient/server/endpoint/projects_endpoint.py
@@ -109,6 +109,18 @@ class Projects(QuerysetEndpoint[ProjectItem]):
     def populate_lens_default_permissions(self, item):
         self._default_permissions.populate_default_permissions(item, Resource.Lens)
 
+    @api(version="3.23")
+    def populate_virtualconnection_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, Resource.VirtualConnection)
+
+    @api(version="3.23")
+    def populate_database_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, Resource.Database)
+
+    @api(version="3.23")
+    def populate_table_default_permissions(self, item):
+        self._default_permissions.populate_default_permissions(item, Resource.Table)
+
     @api(version="2.1")
     def update_workbook_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Resource.Workbook)
@@ -133,6 +145,18 @@ class Projects(QuerysetEndpoint[ProjectItem]):
     def update_lens_default_permissions(self, item, rules):
         return self._default_permissions.update_default_permissions(item, rules, Resource.Lens)
 
+    @api(version="3.23")
+    def update_virtualconnection_default_permissions(self, item, rules):
+        return self._default_permissions.update_default_permissions(item, rules, Resource.VirtualConnection)
+
+    @api(version="3.23")
+    def update_database_default_permissions(self, item, rules):
+        return self._default_permissions.update_default_permissions(item, rules, Resource.Database)
+
+    @api(version="3.23")
+    def update_table_default_permissions(self, item, rules):
+        return self._default_permissions.update_default_permissions(item, rules, Resource.Table)
+
     @api(version="2.1")
     def delete_workbook_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Resource.Workbook)
@@ -156,6 +180,18 @@ class Projects(QuerysetEndpoint[ProjectItem]):
     @api(version="3.4")
     def delete_lens_default_permissions(self, item, rule):
         self._default_permissions.delete_default_permission(item, rule, Resource.Lens)
+
+    @api(version="3.23")
+    def delete_virtualconnection_default_permissions(self, item, rule):
+        self._default_permissions.delete_default_permission(item, rule, Resource.VirtualConnection)
+
+    @api(version="3.23")
+    def delete_database_default_permissions(self, item, rule):
+        self._default_permissions.delete_default_permission(item, rule, Resource.Database)
+
+    @api(version="3.23")
+    def delete_table_default_permissions(self, item, rule):
+        self._default_permissions.delete_default_permission(item, rule, Resource.Table)
 
     def filter(self, *invalid, page_size: Optional[int] = None, **kwargs) -> QuerySet[ProjectItem]:
         """


### PR DESCRIPTION
Re-raising as #1463 was closed due to force-push caused issue

> In #1429, support for virtual connections was added, but the ability to set permissions to virtual connections at the project level was omitted. Adding support for virtual connections as well as databases and tables.