### PR TITLE
fix: handle 0 item response in querysets

### DIFF
--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -85,6 +85,8 @@ class QuerySet(Iterable[T], Sized):
                     # up overrunning the total number of pages. Catch the
                     # error and break out of the loop.
                     raise StopIteration
+            if len(self._result_cache) == 0:
+                return
             yield from self._result_cache
             # If the length of the QuerySet is unknown, continue fetching until
             # the result cache is empty.
@@ -150,7 +152,7 @@ class QuerySet(Iterable[T], Sized):
         """
         Retrieve the data and store result and pagination item in cache
         """
-        if not self._result_cache:
+        if not self._result_cache and self._pagination_item._page_number is None:
             response = self.model.get(self.request_options)
             if isinstance(response, tuple):
                 self._result_cache, self._pagination_item = response
@@ -159,7 +161,7 @@ class QuerySet(Iterable[T], Sized):
                 self._pagination_item = PaginationItem()
 
     def __len__(self: Self) -> int:
-        return self.total_available or sys.maxsize
+        return sys.maxsize if self.total_available is None else self.total_available
 
     @property
     def total_available(self: Self) -> int:

--- a/tableauserverclient/server/query.py
+++ b/tableauserverclient/server/query.py
@@ -77,6 +77,7 @@ class QuerySet(Iterable[T], Sized):
         for page in count(1):
             self.request_options.pagenumber = page
             self._result_cache = []
+            self._pagination_item._page_number = None
             try:
                 self._fetch_all()
             except ServerResponseError as e:
@@ -141,6 +142,7 @@ class QuerySet(Iterable[T], Sized):
         elif k in range(self.total_available):
             # Otherwise, check if k is even sensible to return
             self._result_cache = []
+            self._pagination_item._page_number = None
             # Add one to k, otherwise it gets stuck at page boundaries, e.g. 100
             self.request_options.pagenumber = max(1, math.ceil((k + 1) / size))
             return self[k]

--- a/test/test_pager.py
+++ b/test/test_pager.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import unittest
+import xml.etree.ElementTree as ET
 
 import requests_mock
 
@@ -122,3 +123,14 @@ class PagerTests(unittest.TestCase):
             m.get(self.server.views.baseurl, text=view_xml)
             for view in TSC.Pager(self.server.views):
                 assert view.name is not None
+
+    def test_queryset_no_matches(self) -> None:
+        elem = ET.Element("tsResponse", xmlns="http://tableau.com/api")
+        ET.SubElement(elem, "pagination", totalAvailable="0")
+        ET.SubElement(elem, "groups")
+        xml = ET.tostring(elem).decode("utf-8")
+        with requests_mock.mock() as m:
+            m.get(self.server.groups.baseurl, text=xml)
+            all_groups = self.server.groups.all()
+            groups = list(all_groups)
+        assert len(groups) == 0


### PR DESCRIPTION
A flaw in the `__iter__` logic introduced to handle scenarios where a pagination element is not included in the response xml resulted in an infinite loop. This PR introduces a few changes to protect against this:

1. After running `QuerySet._fetch_all()`, if the `result_cache` is empty, return instead of performing other comparisons.
2. Ensure that any non-None `total_available` is returned from the `PaginationItem`'s object.
3. In `_fetch_all`, check if there is a `PaginationItem` that has been populated so as to not call the server side endpoint multiple times before returning.