### PR TITLE
feat: capture site content url from sign in

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -84,9 +84,10 @@ class Auth(Endpoint):
         self._check_status(server_response, url)
         parsed_response = fromstring(server_response.content)
         site_id = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("id", None)
+        site_url = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("contentUrl", None)
         user_id = parsed_response.find(".//t:user", namespaces=self.parent_srv.namespace).get("id", None)
         auth_token = parsed_response.find("t:credentials", namespaces=self.parent_srv.namespace).get("token", None)
-        self.parent_srv._set_auth(site_id, user_id, auth_token)
+        self.parent_srv._set_auth(site_id, user_id, auth_token, site_url)
         logger.info(f"Signed into {self.parent_srv.server_address} as user with id {user_id}")
         return Auth.contextmgr(self.sign_out)
 
@@ -155,9 +156,10 @@ class Auth(Endpoint):
         self._check_status(server_response, url)
         parsed_response = fromstring(server_response.content)
         site_id = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("id", None)
+        site_url = parsed_response.find(".//t:site", namespaces=self.parent_srv.namespace).get("contentUrl", None)
         user_id = parsed_response.find(".//t:user", namespaces=self.parent_srv.namespace).get("id", None)
         auth_token = parsed_response.find("t:credentials", namespaces=self.parent_srv.namespace).get("token", None)
-        self.parent_srv._set_auth(site_id, user_id, auth_token)
+        self.parent_srv._set_auth(site_id, user_id, auth_token, site_url)
         logger.info(f"Signed into {self.parent_srv.server_address} as user with id {user_id}")
         return Auth.contextmgr(self.sign_out)
 

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -207,12 +207,14 @@ class Server:
         self._site_id = None
         self._user_id = None
         self._auth_token = None
+        self._site_url = None
         self._session = self._session_factory()
 
-    def _set_auth(self, site_id, user_id, auth_token):
+    def _set_auth(self, site_id, user_id, auth_token, site_url=None):
         self._site_id = site_id
         self._user_id = user_id
         self._auth_token = auth_token
+        self._site_url = site_url
 
     def _get_legacy_version(self):
         # the serverInfo call was introduced in 2.4, earlier than that we have this different call
@@ -281,6 +283,13 @@ class Server:
             error = "Missing site ID. You must sign in first."
             raise NotSignedInError(error)
         return self._site_id
+
+    @property
+    def site_url(self):
+        if self._site_url is None:
+            error = "Missing site URL. You must sign in first."
+            raise NotSignedInError(error)
+        return self._site_url
 
     @property
     def user_id(self):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -27,6 +27,7 @@ class AuthTests(unittest.TestCase):
 
         self.assertEqual("eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l", self.server.auth_token)
         self.assertEqual("6b7179ba-b82b-4f0f-91ed-812074ac5da6", self.server.site_id)
+        self.assertEqual("Samples", self.server.site_url)
         self.assertEqual("1a96d216-e9b8-497b-a82a-0b899a965e01", self.server.user_id)
 
     def test_sign_in_with_personal_access_tokens(self):
@@ -41,6 +42,7 @@ class AuthTests(unittest.TestCase):
 
         self.assertEqual("eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l", self.server.auth_token)
         self.assertEqual("6b7179ba-b82b-4f0f-91ed-812074ac5da6", self.server.site_id)
+        self.assertEqual("Samples", self.server.site_url)
         self.assertEqual("1a96d216-e9b8-497b-a82a-0b899a965e01", self.server.user_id)
 
     def test_sign_in_impersonate(self):
@@ -93,6 +95,7 @@ class AuthTests(unittest.TestCase):
 
         self.assertIsNone(self.server._auth_token)
         self.assertIsNone(self.server._site_id)
+        self.assertIsNone(self.server._site_url)
         self.assertIsNone(self.server._user_id)
 
     def test_switch_site(self):
@@ -109,6 +112,7 @@ class AuthTests(unittest.TestCase):
 
         self.assertEqual("eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l", self.server.auth_token)
         self.assertEqual("6b7179ba-b82b-4f0f-91ed-812074ac5da6", self.server.site_id)
+        self.assertEqual("Samples", self.server.site_url)
         self.assertEqual("1a96d216-e9b8-497b-a82a-0b899a965e01", self.server.user_id)
 
     def test_revoke_all_server_admin_tokens(self):
@@ -125,4 +129,5 @@ class AuthTests(unittest.TestCase):
 
         self.assertEqual("eIX6mvFsqyansa4KqEI1UwOpS8ggRs2l", self.server.auth_token)
         self.assertEqual("6b7179ba-b82b-4f0f-91ed-812074ac5da6", self.server.site_id)
+        self.assertEqual("Samples", self.server.site_url)
         self.assertEqual("1a96d216-e9b8-497b-a82a-0b899a965e01", self.server.user_id)


### PR DESCRIPTION
Sign in attempts will return the site's content url in the response. This change parses that as well and includes it on the server object for later reference by the user.