### PR TITLE
docs: docstrings for custom_views

### DIFF
--- a/tableauserverclient/models/custom_view_item.py
+++ b/tableauserverclient/models/custom_view_item.py
@@ -5,14 +5,58 @@ from defusedxml.ElementTree import fromstring, tostring
 from typing import Callable, Optional
 from collections.abc import Iterator
 
-from .exceptions import UnpopulatedPropertyError
-from .user_item import UserItem
-from .view_item import ViewItem
-from .workbook_item import WorkbookItem
-from ..datetime_helpers import parse_datetime
+from tableauserverclient.models.exceptions import UnpopulatedPropertyError
+from tableauserverclient.models.user_item import UserItem
+from tableauserverclient.models.view_item import ViewItem
+from tableauserverclient.models.workbook_item import WorkbookItem
+from tableauserverclient.datetime_helpers import parse_datetime
 
 
 class CustomViewItem:
+    """
+    Represents a Custom View item on Tableau Server.
+
+    Parameters
+    ----------
+    id : Optional[str]
+        The ID of the Custom View item.
+
+    name : Optional[str]
+        The name of the Custom View item.
+
+    Attributes
+    ----------
+    content_url : Optional[str]
+        The content URL of the Custom View item.
+
+    created_at : Optional[datetime]
+        The date and time the Custom View item was created.
+
+    image: bytes
+        The image of the Custom View item. Must be populated first.
+
+    pdf: bytes
+        The PDF of the Custom View item. Must be populated first.
+
+    csv: Iterator[bytes]
+        The CSV of the Custom View item. Must be populated first.
+
+    shared : Optional[bool]
+        Whether the Custom View item is shared.
+
+    updated_at : Optional[datetime]
+        The date and time the Custom View item was last updated.
+
+    owner : Optional[UserItem]
+        The id of the owner of the Custom View item.
+
+    workbook : Optional[WorkbookItem]
+        The id of the workbook the Custom View item belongs to.
+
+    view : Optional[ViewItem]
+        The id of the view the Custom View item belongs to.
+    """
+
     def __init__(self, id: Optional[str] = None, name: Optional[str] = None) -> None:
         self._content_url: Optional[str] = None  # ?
         self._created_at: Optional["datetime"] = None

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -122,6 +122,7 @@ class RequestOptions(RequestOptionsBase):
         NotificationType = "notificationType"
         OwnerDomain = "ownerDomain"
         OwnerEmail = "ownerEmail"
+        OwnerId = "ownerId"
         OwnerName = "ownerName"
         ParentProjectId = "parentProjectId"
         Priority = "priority"
@@ -148,8 +149,10 @@ class RequestOptions(RequestOptionsBase):
         UpdatedAt = "updatedAt"
         UserCount = "userCount"
         UserId = "userId"
+        ViewId = "viewId"
         ViewUrlName = "viewUrlName"
         WorkbookDescription = "workbookDescription"
+        WorkbookId = "workbookId"
         WorkbookName = "workbookName"
 
     class Direction:


### PR DESCRIPTION
Also adds support for using view_id, workbook_id and owner_id to filter custom_views returned by the REST API