### PR TITLE
feat: publish datasource as replacement

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -260,13 +260,12 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         else:
             raise TypeError("file should be a filepath or file object.")
 
-        if not mode or not hasattr(self.parent_srv.PublishMode, mode):
-            error = "Invalid mode defined."
-            raise ValueError(error)
-
         # Construct the url with the defined mode
         url = f"{self.baseurl}?datasourceType={file_extension}"
-        if mode == self.parent_srv.PublishMode.Overwrite or mode == self.parent_srv.PublishMode.Append:
+        if not mode or not hasattr(self.parent_srv.PublishMode, mode):
+            error = f"Invalid mode defined: {mode}"
+            raise ValueError(error)
+        else:
             url += f"&{mode.lower()}=true"
 
         if as_job:

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -119,6 +119,7 @@ class Server:
         Append = "Append"
         Overwrite = "Overwrite"
         CreateNew = "CreateNew"
+        Replace = "Replace"
 
     def __init__(self, server_address, use_server_version=False, http_options=None, session_factory=None):
         self._auth_token = None


### PR DESCRIPTION
Demonstration: 
1. publish datasource
2. create workbook that displays 'number of records' 
3. publish datasource again with mode Append
4. workbook -> number of records has doubled!
5. publish again with mode Replace
6. workbook -> number of records is back to original value  