### PR TITLE
0.36 Hotfix release 

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -190,7 +190,8 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
     def refresh(self, datasource_item: DatasourceItem, incremental: bool = False) -> JobItem:
         id_ = getattr(datasource_item, "id", datasource_item)
         url = f"{self.baseurl}/{id_}/refresh"
-        refresh_req = RequestFactory.Task.refresh_req(incremental)
+        # refresh_req = RequestFactory.Task.refresh_req(incremental)
+        refresh_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, refresh_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]
         return new_job

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -366,6 +366,25 @@ class DatasourceTests(unittest.TestCase):
         # We only check the `id`; remaining fields are already tested in `test_refresh_id`
         self.assertEqual("7c3d599e-949f-44c3-94a1-f30ba85757e4", new_job.id)
 
+    def test_datasource_refresh_request_empty(self) -> None:
+        self.server.version = "2.8"
+        self.baseurl = self.server.datasources.baseurl
+        item = TSC.DatasourceItem("")
+        item._id = "1234"
+        text = read_xml_asset(REFRESH_XML)
+
+        def match_request_body(request):
+            try:
+                root = fromstring(request.body)
+                assert root.tag == "tsRequest"
+                assert len(root) == 0
+                return True
+            except Exception:
+                return False
+
+        with requests_mock.mock() as m:
+            m.post(f"{self.baseurl}/1234/refresh", text=text, additional_matcher=match_request_body)
+
     def test_update_hyper_data_datasource_object(self) -> None:
         """Calling `update_hyper_data` with a `DatasourceItem` should update that datasource"""
         self.server.version = "3.13"


### PR DESCRIPTION
Datasource refresh expects empty requests.
Closes #1553 