### PR TITLE
fix: virtual connection ConnectionItem attributes

### DIFF
--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -103,11 +103,11 @@ class ConnectionItem:
         all_connection_xml = parsed_response.findall(".//t:connection", namespaces=ns)
         for connection_xml in all_connection_xml:
             connection_item = cls()
-            connection_item._id = connection_xml.get("id", None)
+            connection_item._id = connection_xml.get("id", connection_xml.get("connectionId", None))
             connection_item._connection_type = connection_xml.get("type", connection_xml.get("dbClass", None))
             connection_item.embed_password = string_to_bool(connection_xml.get("embedPassword", ""))
-            connection_item.server_address = connection_xml.get("serverAddress", None)
-            connection_item.server_port = connection_xml.get("serverPort", None)
+            connection_item.server_address = connection_xml.get("serverAddress", connection_xml.get("server", None))
+            connection_item.server_port = connection_xml.get("serverPort", connection_xml.get("port", None))
             connection_item.username = connection_xml.get("userName", None)
             connection_item._query_tagging = (
                 string_to_bool(s) if (s := connection_xml.get("queryTagging", None)) else None

--- a/test/assets/virtual_connection_populate_connections2.xml
+++ b/test/assets/virtual_connection_populate_connections2.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <virtualConnectionConnections>
+    <connection connectionId="37ca6ced-58d7-4dcf-99dc-f0a85223cbef" dbClass="postgres" server="localhost" userName="pgadmin" port="5432"/>
+    </virtualConnectionConnections>
+</tsResponse>

--- a/test/test_virtual_connection.py
+++ b/test/test_virtual_connection.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import unittest
 
+import pytest
 import requests_mock
 
 import tableauserverclient as TSC
@@ -12,6 +13,7 @@ ASSET_DIR = Path(__file__).parent / "assets"
 
 VIRTUAL_CONNECTION_GET_XML = ASSET_DIR / "virtual_connections_get.xml"
 VIRTUAL_CONNECTION_POPULATE_CONNECTIONS = ASSET_DIR / "virtual_connection_populate_connections.xml"
+VIRTUAL_CONNECTION_POPULATE_CONNECTIONS2 = ASSET_DIR / "virtual_connection_populate_connections2.xml"
 VC_DB_CONN_UPDATE = ASSET_DIR / "virtual_connection_database_connection_update.xml"
 VIRTUAL_CONNECTION_DOWNLOAD = ASSET_DIR / "virtual_connections_download.xml"
 VIRTUAL_CONNECTION_UPDATE = ASSET_DIR / "virtual_connections_update.xml"
@@ -54,23 +56,27 @@ class TestVirtualConnections(unittest.TestCase):
         assert items[0].name == "vconn"
 
     def test_virtual_connection_populate_connections(self):
-        vconn = VirtualConnectionItem("vconn")
-        vconn._id = "8fd7cc02-bb55-4d15-b8b1-9650239efe79"
-        with requests_mock.mock() as m:
-            m.get(f"{self.baseurl}/{vconn.id}/connections", text=VIRTUAL_CONNECTION_POPULATE_CONNECTIONS.read_text())
-            vc_out = self.server.virtual_connections.populate_connections(vconn)
-            connection_list = list(vconn.connections)
+        for i, populate_connections_xml in enumerate(
+            (VIRTUAL_CONNECTION_POPULATE_CONNECTIONS, VIRTUAL_CONNECTION_POPULATE_CONNECTIONS2)
+        ):
+            with self.subTest(i):
+                vconn = VirtualConnectionItem("vconn")
+                vconn._id = "8fd7cc02-bb55-4d15-b8b1-9650239efe79"
+                with requests_mock.mock() as m:
+                    m.get(f"{self.baseurl}/{vconn.id}/connections", text=populate_connections_xml.read_text())
+                    vc_out = self.server.virtual_connections.populate_connections(vconn)
+                    connection_list = list(vconn.connections)
 
-        assert vc_out is vconn
-        assert vc_out._connections is not None
+                assert vc_out is vconn
+                assert vc_out._connections is not None
 
-        assert len(connection_list) == 1
-        connection = connection_list[0]
-        assert connection.id == "37ca6ced-58d7-4dcf-99dc-f0a85223cbef"
-        assert connection.connection_type == "postgres"
-        assert connection.server_address == "localhost"
-        assert connection.server_port == "5432"
-        assert connection.username == "pgadmin"
+                assert len(connection_list) == 1
+                connection = connection_list[0]
+                assert connection.id == "37ca6ced-58d7-4dcf-99dc-f0a85223cbef"
+                assert connection.connection_type == "postgres"
+                assert connection.server_address == "localhost"
+                assert connection.server_port == "5432"
+                assert connection.username == "pgadmin"
 
     def test_virtual_connection_update_connection_db_connection(self):
         vconn = VirtualConnectionItem("vconn")


### PR DESCRIPTION
Closes #1558

Connection XML element for VirtualConnections has different attribute keys compared to connection XML elements when returned by Datasources, Workbooks, and Flows. This PR adds in flexibility to ConnectionItem's reading of XML to account for both sets of attributes that may be present elements.