### PR TITLE
docs: fix switch_site docs

### DIFF
--- a/docs/sign-in-out.md
+++ b/docs/sign-in-out.md
@@ -200,6 +200,7 @@ The following example will switch the authenticated user to the NEW_SITENAME sit
 
 ```py
 # assume we already have an authenticated server object
-
-server.auth.switch_site('NEW_SITENAME')
+new_site = server.sites.get_by_name('NEW_SITENAME')
+# switch_site expects a SiteItem object
+server.auth.switch_site(new_site)
 ```


### PR DESCRIPTION
Docs incorrectly stated you could switch sites by passing in the target site's name. This updates the documentation to correctly reflect that it needs a `SiteItem` and how a user may find that `SiteItem` if they only have the name.