### PR TITLE
ci: update slack action vm version

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, issues]
 jobs:
   slack-notifications:
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Sends a message to Slack when a push, a pull request or an issue is made
     steps:
       - name: Send message to Slack API

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, issues]
 jobs:
   slack-notifications:
     continue-on-error: true
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: Sends a message to Slack when a push, a pull request or an issue is made
     steps:
       - name: Send message to Slack API


### PR DESCRIPTION
Ubuntu 20.04 went out of support as of 2025-04-15. Updating to use ~24.04~ latest.