### PR TITLE
fix: repr for auth objects

### DIFF
--- a/tableauserverclient/models/tableau_auth.py
+++ b/tableauserverclient/models/tableau_auth.py
@@ -87,7 +87,7 @@ class TableauAuth(Credentials):
             uid = f", user_id_to_impersonate=f{self.user_id_to_impersonate}"
         else:
             uid = ""
-        return f"<Credentials username={self.username} password=redacted (site={self.site_id}{uid})>"
+        return f"<{self.__class__.__qualname__} username={self.username} password=redacted (site={self.site_id}{uid})>"
 
 
 # A Tableau-generated Personal Access Token
@@ -155,8 +155,8 @@ class PersonalAccessTokenAuth(Credentials):
         else:
             uid = ""
         return (
-            f"<PersonalAccessToken name={self.token_name} token={self.personal_access_token[:2]}..."
-            f"(site={self.site_id}{uid} >"
+            f"<{self.__class__.__qualname__}(name={self.token_name} token={self.personal_access_token[:2]}..."
+            f"site={self.site_id}{uid}) >"
         )
 
 


### PR DESCRIPTION
PersonalAccessTokenAuth repr was malformed. Fixing it to be more representative and show the actual class name used in cases where the client user decides to subclass.