### PR TITLE
feat: enable toggling attribute capture for a site

### DIFF
--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -85,6 +85,9 @@ class SiteItem:
     state: str
         Shows the current state of the site (Active or Suspended).
 
+    attribute_capture_enabled: Optional[str]
+        Enables user attributes for all Tableau Server embedding workflows.
+
     """
 
     _user_quota: Optional[int] = None
@@ -164,6 +167,7 @@ class SiteItem:
         time_zone=None,
         auto_suspend_refresh_enabled: bool = True,
         auto_suspend_refresh_inactivity_window: int = 30,
+        attribute_capture_enabled: Optional[bool] = None,
     ):
         self._admin_mode = None
         self._id: Optional[str] = None
@@ -217,6 +221,7 @@ class SiteItem:
         self.time_zone = time_zone
         self.auto_suspend_refresh_enabled = auto_suspend_refresh_enabled
         self.auto_suspend_refresh_inactivity_window = auto_suspend_refresh_inactivity_window
+        self.attribute_capture_enabled = attribute_capture_enabled
 
     @property
     def admin_mode(self) -> Optional[str]:
@@ -720,6 +725,7 @@ class SiteItem:
                 time_zone,
                 auto_suspend_refresh_enabled,
                 auto_suspend_refresh_inactivity_window,
+                attribute_capture_enabled,
             ) = self._parse_element(site_xml, ns)
 
             self._set_values(
@@ -774,6 +780,7 @@ class SiteItem:
                 time_zone,
                 auto_suspend_refresh_enabled,
                 auto_suspend_refresh_inactivity_window,
+                attribute_capture_enabled,
             )
         return self
 
@@ -830,6 +837,7 @@ class SiteItem:
         time_zone,
         auto_suspend_refresh_enabled,
         auto_suspend_refresh_inactivity_window,
+        attribute_capture_enabled,
     ):
         if id is not None:
             self._id = id
@@ -937,6 +945,7 @@ class SiteItem:
             self.auto_suspend_refresh_enabled = auto_suspend_refresh_enabled
         if auto_suspend_refresh_inactivity_window is not None:
             self.auto_suspend_refresh_inactivity_window = auto_suspend_refresh_inactivity_window
+        self.attribute_capture_enabled = attribute_capture_enabled
 
     @classmethod
     def from_response(cls, resp, ns) -> list["SiteItem"]:
@@ -996,6 +1005,7 @@ class SiteItem:
                 time_zone,
                 auto_suspend_refresh_enabled,
                 auto_suspend_refresh_inactivity_window,
+                attribute_capture_enabled,
             ) = cls._parse_element(site_xml, ns)
 
             site_item = cls(name, content_url)
@@ -1051,6 +1061,7 @@ class SiteItem:
                 time_zone,
                 auto_suspend_refresh_enabled,
                 auto_suspend_refresh_inactivity_window,
+                attribute_capture_enabled,
             )
             all_site_items.append(site_item)
         return all_site_items
@@ -1132,6 +1143,9 @@ class SiteItem:
 
         flows_enabled = string_to_bool(site_xml.get("flowsEnabled", ""))
         cataloging_enabled = string_to_bool(site_xml.get("catalogingEnabled", ""))
+        attribute_capture_enabled = (
+            string_to_bool(ace) if (ace := site_xml.get("attributeCaptureEnabled")) is not None else None
+        )
 
         return (
             id,
@@ -1185,6 +1199,7 @@ class SiteItem:
             time_zone,
             auto_suspend_refresh_enabled,
             auto_suspend_refresh_inactivity_window,
+            attribute_capture_enabled,
         )
 
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -715,6 +715,8 @@ class SiteRequest:
             site_element.attrib["autoSuspendRefreshInactivityWindow"] = str(
                 site_item.auto_suspend_refresh_inactivity_window
             )
+        if site_item.attribute_capture_enabled is not None:
+            site_element.attrib["attributeCaptureEnabled"] = str(site_item.attribute_capture_enabled).lower()
 
         return ET.tostring(xml_request)
 
@@ -819,6 +821,8 @@ class SiteRequest:
             site_element.attrib["autoSuspendRefreshInactivityWindow"] = str(
                 site_item.auto_suspend_refresh_inactivity_window
             )
+        if site_item.attribute_capture_enabled is not None:
+            site_element.attrib["attributeCaptureEnabled"] = str(site_item.attribute_capture_enabled).lower()
 
         return ET.tostring(xml_request)
 

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -1,5 +1,6 @@
 import os.path
 import unittest
+from typing import Optional
 from xml.etree import ElementTree as ET
 from contextlib import contextmanager
 
@@ -30,6 +31,19 @@ def server_response_error_factory(code: str, summary: str, detail: str) -> str:
     detail_element = ET.SubElement(error, "detail")
     detail_element.text = detail
     return ET.tostring(root, encoding="utf-8").decode("utf-8")
+
+
+def server_response_factory(tag: str, **attributes: str | bool | int | None) -> bytes:
+    ns = "http://tableau.com/api"
+    ET.register_namespace("", ns)
+    root = ET.Element(
+        f"{{{ns}}}tsResponse",
+    )
+    if attributes is None:
+        attributes = {}
+
+    elem = ET.SubElement(root, f"{{{ns}}}{tag}", **attributes)
+    return ET.tostring(root, encoding="utf-8")
 
 
 @contextmanager

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -33,7 +33,7 @@ def server_response_error_factory(code: str, summary: str, detail: str) -> str:
     return ET.tostring(root, encoding="utf-8").decode("utf-8")
 
 
-def server_response_factory(tag: str, **attributes: str | bool | int | None) -> bytes:
+def server_response_factory(tag: str, **attributes: str) -> bytes:
     ns = "http://tableau.com/api"
     ET.register_namespace("", ns)
     root = ET.Element(
@@ -42,7 +42,7 @@ def server_response_factory(tag: str, **attributes: str | bool | int | None) -> 
     if attributes is None:
         attributes = {}
 
-    elem = ET.SubElement(root, f"{{{ns}}}{tag}", **attributes)
+    elem = ET.SubElement(root, f"{{{ns}}}{tag}", attrib=attributes)
     return ET.tostring(root, encoding="utf-8")
 
 


### PR DESCRIPTION
According to https://help.tableau.com/current/api/embedding_api/en-us/docs/embedding_api_user_attributes.html#:~:text=For%20security%20purposes%2C%20user%20attributes,a%20site%20admin%20(on%20Tableau setting this site setting to `true` is required to enable use of user attributes with Tableau Server and embedding workflows.