### PR TITLE
fix: put special fields first

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -96,7 +96,10 @@ class RequestOptions(RequestOptionsBase):
         if self.pagesize:
             params["pageSize"] = self.pagesize
         if self.fields:
-            params["fields"] = ",".join(self.fields)
+            if "_all_" in self.fields:
+                params["fields"] = "_all_"
+            else:
+                params["fields"] = ",".join(sorted(self.fields))
         return params
 
     def page_size(self, page_size):

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -378,3 +378,27 @@ class RequestOptionTests(unittest.TestCase):
         loop = self.server.users.only_fields("id")
         assert "id" in loop.request_options.fields
         assert "_default_" not in loop.request_options.fields
+
+    def test_queryset_field_order(self) -> None:
+        with requests_mock.mock() as m:
+            m.get(self.server.views.baseurl, text=SLICING_QUERYSET_PAGE_1.read_text())
+            loop = self.server.views.fields("id", "name")
+            list(loop)
+            history = m.request_history[0]
+
+        fields = history.qs.get("fields", [""])[0].split(",")
+
+        assert fields[0] == "_default_"
+        assert "id" in fields
+        assert "name" in fields
+
+    def test_queryset_field_all(self) -> None:
+        with requests_mock.mock() as m:
+            m.get(self.server.views.baseurl, text=SLICING_QUERYSET_PAGE_1.read_text())
+            loop = self.server.views.fields("id", "name", "_all_")
+            list(loop)
+            history = m.request_history[0]
+
+        fields = history.qs.get("fields", [""])[0]
+
+        assert fields == "_all_"


### PR DESCRIPTION
Closes #1620

Sorting the fields prior to putting them in the query string assures that '\_all\_' and '\_default\_' appear first in the field list, satisfying the criteria of Tableau Server/Cloud to process those first. Order of other fields appeared to be irrelevant, so the test simply ensures their presence.