### PR TITLE
fix: virtual connections username

### DIFF
--- a/tableauserverclient/models/connection_item.py
+++ b/tableauserverclient/models/connection_item.py
@@ -120,7 +120,7 @@ class ConnectionItem:
             connection_item.embed_password = string_to_bool(connection_xml.get("embedPassword", ""))
             connection_item.server_address = connection_xml.get("serverAddress", connection_xml.get("server", None))
             connection_item.server_port = connection_xml.get("serverPort", connection_xml.get("port", None))
-            connection_item.username = connection_xml.get("userName", None)
+            connection_item.username = connection_xml.get("userName", connection_xml.get("username", None))
             connection_item._query_tagging = (
                 string_to_bool(s) if (s := connection_xml.get("queryTagging", None)) else None
             )

--- a/test/assets/virtual_connection_populate_connections.xml
+++ b/test/assets/virtual_connection_populate_connections.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
     <virtualConnectionConnections>
-    <connection id="37ca6ced-58d7-4dcf-99dc-f0a85223cbef" dbClass="postgres" serverAddress="localhost" userName="pgadmin" serverPort="5432"/>
+    <connection id="37ca6ced-58d7-4dcf-99dc-f0a85223cbef" dbClass="postgres" serverAddress="localhost" username="pgadmin" serverPort="5432"/>
     </virtualConnectionConnections>
 </tsResponse>

--- a/test/assets/virtual_connection_populate_connections2.xml
+++ b/test/assets/virtual_connection_populate_connections2.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
     <virtualConnectionConnections>
-    <connection connectionId="37ca6ced-58d7-4dcf-99dc-f0a85223cbef" dbClass="postgres" server="localhost" userName="pgadmin" port="5432"/>
+    <connection connectionId="37ca6ced-58d7-4dcf-99dc-f0a85223cbef" dbClass="postgres" server="localhost" username="pgadmin" port="5432"/>
     </virtualConnectionConnections>
 </tsResponse>


### PR DESCRIPTION
Closes #1626

VirtualConnections leverages the ConnectionItem object to parse the database connections server response. Most of other endpoints return "userName" and the VirtualConnections' "Get Database Connections" endpoint returns "username." Resolves the issue by allowing the ConnectionItem to read either. Update the test assets to reflect the actual returned value.