### PR TITLE
feat: retrieve tableau server product name

### DIFF
--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -189,8 +189,8 @@ class Endpoint:
             loggable_response = helpers.strings.redact_xml(server_response.content.decode(server_response.encoding))
         return loggable_response
 
-    def get_unauthenticated_request(self, url):
-        return self._make_request(self.parent_srv.session.get, url)
+    def get_unauthenticated_request(self, url, parameters=None):
+        return self._make_request(self.parent_srv.session.get, url, parameters=parameters)
 
     def get_request(self, url, request_object=None, parameters=None):
         if request_object is not None:

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -145,6 +145,7 @@ class Server:
         self._site_id = None
         self._user_id = None
         self._ssl_context = None
+        self._product = "TableauServer"  # default product type
 
         # TODO: this needs to change to default to https, but without breaking existing code
         if not server_address.startswith("http://") and not server_address.startswith("https://"):
@@ -269,6 +270,7 @@ class Server:
 
     def use_server_version(self):
         self.version = self._determine_highest_version()
+        self._product = self.server_info._get_product_info()
 
     def use_highest_version(self):
         self.use_server_version()

--- a/test/assets/getServerSettingsUnauthenticated.json
+++ b/test/assets/getServerSettingsUnauthenticated.json
@@ -1,0 +1,1 @@
+{"result": {"product": "TableauOnline"}}


### PR DESCRIPTION
Closes #1592

Calls a VizPortal API to retrieve the detailed product name, and attaches it to the TSC.Server object which will make determining what requests to build for things like subscriptions easier. Adds this functionality into the pre-existing `use_server_version` function because:

1. Users of the library will already know to call that method.
2. Users already aware that method makes API calls.

If the request errors or if the payload doesn't match the expected format, defaults to assuming TSC is talking with an on-prem Server instance.

Co-authored-by: emeric-dsj