### PR TITLE
feat: make refresh consistent between endpoints

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -430,7 +430,7 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         return connection_items
 
     @api(version="2.8")
-    def refresh(self, datasource_item: DatasourceItem, incremental: bool = False) -> JobItem:
+    def refresh(self, datasource_item: Union[DatasourceItem, str], incremental: bool = False) -> JobItem:
         """
         Refreshes the extract of an existing workbook.
 
@@ -438,8 +438,8 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
 
         Parameters
         ----------
-        workbook_item : WorkbookItem | str
-            The workbook item or workbook ID.
+        workbook_item : DatasourceItem | str
+            The datasource item or datasource ID.
         incremental: bool
             Whether to do a full refresh or incremental refresh of the extract data
 

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -308,7 +308,7 @@ class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem]):
         return connection
 
     @api(version="3.3")
-    def refresh(self, flow_item: FlowItem) -> JobItem:
+    def refresh(self, flow_item: Union[FlowItem, str]) -> JobItem:
         """
         Runs the flow to refresh the data.
 
@@ -316,15 +316,16 @@ class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem]):
 
         Parameters
         ----------
-        flow_item: FlowItem
-            The flow item to refresh.
+        flow_item: FlowItem | str
+            The FlowItem or str of the flow id to refresh.
 
         Returns
         -------
         JobItem
             The job item that was created to refresh the flow.
         """
-        url = f"{self.baseurl}/{flow_item.id}/run"
+        flow_id = getattr(flow_item, "id", flow_item)
+        url = f"{self.baseurl}/{flow_id}/run"
         empty_req = RequestFactory.Empty.empty_req()
         server_response = self.post_request(url, empty_req)
         new_job = JobItem.from_response(server_response.content, self.parent_srv.namespace)[0]

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -197,7 +197,7 @@ class FlowTests(unittest.TestCase):
         self.assertEqual("default", new_flow.project_name)
         self.assertEqual("5de011f8-5aa9-4d5b-b991-f462c8dd6bb7", new_flow.owner_id)
 
-    def test_refresh(self):
+    def test_refresh(self) -> None:
         with open(asset(REFRESH_XML), "rb") as f:
             response_xml = f.read().decode("utf-8")
         with requests_mock.mock() as m:
@@ -205,6 +205,22 @@ class FlowTests(unittest.TestCase):
             flow_item = TSC.FlowItem("test")
             flow_item._id = "92967d2d-c7e2-46d0-8847-4802df58f484"
             refresh_job = self.server.flows.refresh(flow_item)
+
+            self.assertEqual(refresh_job.id, "d1b2ccd0-6dfa-444a-aee4-723dbd6b7c9d")
+            self.assertEqual(refresh_job.mode, "Asynchronous")
+            self.assertEqual(refresh_job.type, "RunFlow")
+            self.assertEqual(format_datetime(refresh_job.created_at), "2018-05-22T13:00:29Z")
+            self.assertIsInstance(refresh_job.flow_run, TSC.FlowRunItem)
+            self.assertEqual(refresh_job.flow_run.id, "e0c3067f-2333-4eee-8028-e0a56ca496f6")
+            self.assertEqual(refresh_job.flow_run.flow_id, "92967d2d-c7e2-46d0-8847-4802df58f484")
+            self.assertEqual(format_datetime(refresh_job.flow_run.started_at), "2018-05-22T13:00:29Z")
+
+    def test_refresh_id_str(self) -> None:
+        with open(asset(REFRESH_XML), "rb") as f:
+            response_xml = f.read().decode("utf-8")
+        with requests_mock.mock() as m:
+            m.post(self.baseurl + "/92967d2d-c7e2-46d0-8847-4802df58f484/run", text=response_xml)
+            refresh_job = self.server.flows.refresh("92967d2d-c7e2-46d0-8847-4802df58f484")
 
             self.assertEqual(refresh_job.id, "d1b2ccd0-6dfa-444a-aee4-723dbd6b7c9d")
             self.assertEqual(refresh_job.mode, "Asynchronous")


### PR DESCRIPTION
Workbooks.refresh correctly accepted both an id string and a
WorkbookItem to handle triggering refreshes. Datasources.refresh
technically accepted both, but the type annotations did not reflect
that. Flows.refresh only accepted a FlowItem, but will now accept
a flow_id. This eliminates the need to create otherwise hollow
FlowItems to pass to the refresh method when you otherwise have
the id.
