### PR TITLE
fix: datasource owner/project missing parsing

### DIFF
--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -535,6 +535,7 @@ class DatasourceItem:
 
         project_id = None
         project_name = None
+        project = None
         project_elem = datasource_xml.find(".//t:project", namespaces=ns)
         if project_elem is not None:
             project = ProjectItem.from_xml(project_elem, ns)
@@ -542,6 +543,7 @@ class DatasourceItem:
             project_name = project_elem.get("name", None)
 
         owner_id = None
+        owner = None
         owner_elem = datasource_xml.find(".//t:owner", namespaces=ns)
         if owner_elem is not None:
             owner = UserItem.from_xml(owner_elem, ns)

--- a/test/assets/datasource_get_no_owner.xml
+++ b/test/assets/datasource_get_no_owner.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<tsResponse xmlns="http://tableau.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableau.com/api http://tableau.com/api/ts-api-2.3.xsd">
+    <pagination pageNumber="1" pageSize="100" totalAvailable="2" />
+    <datasources>
+        <datasource id="e76a1461-3b1d-4588-bf1b-17551a879ad9" name="SampleDS" size="4096" contentUrl="SampleDS" description="SampleDsDescription" type="dataengine" createdAt="2016-08-11T21:22:40Z" updatedAt="2016-08-11T21:34:17Z" encryptExtracts="false" hasExtracts="true" useRemoteQueryAgent="false" webpageUrl="https://web.com">
+            <tags />
+        </datasource>
+        <datasource id="9dbd2263-16b5-46e1-9c43-a76bb8ab65fb" name="Sample datasource" description="description Sample" size="10240" contentUrl="Sampledatasource" type="dataengine" createdAt="2016-08-04T21:31:55Z" updatedAt="2016-08-04T21:31:55Z" encryptExtracts="true" hasExtracts="false" useRemoteQueryAgent="true" webpageUrl="https://page.com">
+            <tags>
+                <tag label="world" />
+                <tag label="indicators" />
+                <tag label="sample" />
+            </tags>
+        </datasource>
+    </datasources>
+</tsResponse>

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -24,6 +24,7 @@ GET_XML = TEST_ASSET_DIR / "datasource_get.xml"
 GET_EMPTY_XML = TEST_ASSET_DIR / "datasource_get_empty.xml"
 GET_BY_ID_XML = TEST_ASSET_DIR / "datasource_get_by_id.xml"
 GET_XML_ALL_FIELDS = TEST_ASSET_DIR / "datasource_get_all_fields.xml"
+GET_NO_OWNER = TEST_ASSET_DIR / "datasource_get_no_owner.xml"
 POPULATE_CONNECTIONS_XML = TEST_ASSET_DIR / "datasource_populate_connections.xml"
 POPULATE_PERMISSIONS_XML = TEST_ASSET_DIR / "datasource_populate_permissions.xml"
 PUBLISH_XML = TEST_ASSET_DIR / "datasource_publish.xml"
@@ -850,3 +851,13 @@ def test_get_datasource_all_fields(server) -> None:
     assert datasources[0].owner.last_login == parse_datetime("2025-02-04T06:39:20Z")
     assert datasources[0].owner.name == "bob@example.com"
     assert datasources[0].owner.site_role == "SiteAdministratorCreator"
+
+
+def test_get_datasource_no_owner(server: TSC.Server) -> None:
+    with requests_mock.mock() as m:
+        m.get(server.datasources.baseurl, text=GET_NO_OWNER.read_text())
+        datasources, _ = server.datasources.get()
+
+    datasource = datasources[0]
+    assert datasource.owner is None
+    assert datasource.project is None


### PR DESCRIPTION
Eric Summers pointed out that when the User Visibility setting is set to "Limited," TSC fails to parse because it can't retrieve any owner information. This bug is due to an `UnboundLocalError` where the `owner` and `project` variables were not assigned in cases where the owner and project elements were not included in the XML response.

This PR also includes a test for the parsing where the owner and project elements are missing and properly set to `None` on the DatasourceItem.

Closes #1704