### PR TITLE
Update JWT Login Docs to include Unified Access Token, and and fix PAT table formatting

### DIFF
--- a/docs/sign-in-out.md
+++ b/docs/sign-in-out.md
@@ -94,7 +94,7 @@ To learn more about Unified Access Token, read the docs on [Unified Access Token
 
 ```py
 class JWTAuth(Credentials):
-    def __init__(self, jwt=None, site_id=None, user_id_to_impersonate=None):
+    def __init__(self, jwt, isUat=False, site_id=None, user_id_to_impersonate=None):
 ```
 
 Name | Description
@@ -110,10 +110,10 @@ This example illustrates using the above values to sign in with a JWT, do some o
 import tableauserverclient as TSC
 
 # Connected App JWT
-tableau_auth = TSC.JWTAuth('JWT', 'SITENAME')
+tableau_auth = TSC.JWTAuth(jwt='JWT', site_id='SITENAME')
 
 # UAT JWT
-tableau_auth = TSC.JWTAuth('JWT', 'SITENAME', isUat=True)
+tableau_auth = TSC.JWTAuth(jwt='JWT', site_id='SITENAME', isUat=True)
 
 server = TSC.Server('https://SERVER_URL', use_server_version=True)
 server.auth.sign_in(tableau_auth)


### PR DESCRIPTION
In December 2025, we added UAT, a new JWT-based auth type for Tableau Cloud: https://help.tableau.com/current/api/cloud-manager/en-us/docs/unified_access_tokens.html

@BereketBirbo added UAT to the TSC library here: https://github.com/tableau/server-client-python/pulls?q=is%3Apr+author%3ABereketBirbo+is%3Aclosed., which has been merged into the development branch. 

This MR updates the docs to show the new parameter, and fixed a formatting issue on the PAT section (the table wasn't showing up)
Before:
<img width="907" height="407" alt="Screenshot 2025-12-19 at 5 01 06 PM" src="https://github.com/user-attachments/assets/965097e5-2f6e-4df9-8db4-fbd2bd490a7f" />
After:
<img width="888" height="512" alt="Screenshot 2025-12-19 at 5 01 41 PM" src="https://github.com/user-attachments/assets/b1a9b7c4-459b-4bae-90cf-eeb52c1af4f7" />
JWT updates:
<img width="887" height="802" alt="Screenshot 2025-12-19 at 5 01 58 PM" src="https://github.com/user-attachments/assets/0dc92472-0fa2-4da8-8736-0348f4a9b37c" />
