### PR TITLE
refer to single package entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ test = ["black==24.10", "build", "mypy==1.4", "pytest>=7.0", "pytest-cov", "pyte
     "pytest-xdist", "requests-mock>=1.0,<2.0", "types-requests>=2.32.4.20250913"]
 
 [tool.setuptools.packages.find]
-where = ["tableauserverclient", "tableauserverclient.helpers", "tableauserverclient.models", "tableauserverclient.server", "tableauserverclient.server.endpoint"]
-
+where = ["tableauserverclient"]
 [tool.setuptools.dynamic]
 version = {attr = "versioneer.get_version"}
 


### PR DESCRIPTION
enumerating subpackages doesn't (shouldn't) actually do anything