### PR TITLE
jorwoods/package install fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ repository = "https://github.com/tableau/server-client-python"
 test = ["black==24.10", "build", "mypy==1.4", "pytest>=7.0", "pytest-cov", "pytest-subtests",
     "pytest-xdist", "requests-mock>=1.0,<2.0", "types-requests>=2.32.4.20250913"]
 
-# [tool.setuptools]
-# exclude-package-data = { "" = ["samples/*", "test/*", "docs/*"] }
 [tool.setuptools.package-data]
 # Only include data for tableauserverclient, not for samples, test, docs
 tableauserverclient = ["*"]


### PR DESCRIPTION
- **Revert "refer to single package entrypoint (#1739)"**
- **fix: make pyproject.toml more explicity in what is included**

Closes #1745

This change to pyproject.toml ensures the package is namespaced correctly after
pip installing.
