### PR TITLE
docs: document views endpoint

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -5842,6 +5842,176 @@ Version 3.2 and later. See [REST API versions](https://help.tableau.com/current/
 <br>
 <br>
 
+#### views.add_tags
+
+```py
+views.add_tags(item, tags)
+```
+
+Adds one or more tags to the specified view.
+
+REST API: [Add Tags to View](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#add_tags_to_view)
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`item` | The `ViewItem` or view ID to add tags to.
+`tags` | A single tag string or iterable of tag strings to add.
+
+**Returns**
+
+Returns a `set[str]` of the tags added.
+
+**Example**
+
+```py
+server.views.add_tags(view_item, ['finance', 'quarterly'])
+```
+
+<br>
+<br>
+
+#### views.delete_tags
+
+```py
+views.delete_tags(item, tags)
+```
+
+Removes one or more tags from the specified view.
+
+REST API: [Delete Tags from View](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#delete_tags_from_view)
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`item` | The `ViewItem` or view ID to remove tags from.
+`tags` | A single tag string or iterable of tag strings to remove.
+
+**Returns**
+
+None.
+
+**Example**
+
+```py
+server.views.delete_tags(view_item, 'finance')
+```
+
+<br>
+<br>
+
+#### views.update_tags
+
+```py
+views.update_tags(item)
+```
+
+Updates the tags on the server to match the tags on the specified view item. Changes to tags must be made on the `ViewItem.tags` attribute before calling this method.
+
+REST API: [Add Tags to View](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#add_tags_to_view)
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`item` | The `ViewItem` whose tags to synchronize to the server.
+
+**Returns**
+
+None.
+
+**Example**
+
+```py
+view_item.tags.add('quarterly')
+server.views.update_tags(view_item)
+```
+
+<br>
+<br>
+
+#### views.delete
+
+```py
+views.delete(view)
+```
+
+Deletes a view. If you delete the only view in a workbook, the workbook is also deleted. This can be used to remove hidden views when migrating content.
+
+REST API: [Delete View](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#delete_view)
+
+**Version**
+
+This endpoint is available with REST API version 3.27 and up.
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view` | The `ViewItem` or view ID (str) to delete.
+
+**Returns**
+
+None.
+
+**Example**
+
+```py
+server.views.delete(view_item.id)
+```
+
+<br>
+<br>
+
+#### views.filter
+
+```py
+views.filter(**kwargs)
+```
+
+Returns a list of views that match the specified filters. Fields and operators are passed as keyword arguments in the form `field_name=value` or `field_name__operator=value`.
+
+**Supported fields and operators**
+
+Field | Operators
+:--- | :---
+`caption` | `eq`, `in`
+`content_url` | `eq`, `in`
+`created_at` | `eq`, `gt`, `gte`, `lt`, `lte`
+`favorites_total` | `eq`, `gt`, `gte`, `lt`, `lte`
+`fields` | `eq`, `in`
+`hits_total` | `eq`, `gt`, `gte`, `lt`, `lte`
+`name` | `eq`, `in`
+`owner_domain` | `eq`, `in`
+`owner_email` | `eq`, `in`
+`owner_name` | `eq`
+`project_name` | `eq`, `in`
+`sheet_number` | `eq`, `gt`, `gte`, `lt`, `lte`
+`sheet_type` | `eq`, `in`
+`tags` | `eq`, `in`
+`title` | `eq`, `in`
+`updated_at` | `eq`, `gt`, `gte`, `lt`, `lte`
+`view_url_name` | `eq`, `in`
+`workbook_description` | `eq`, `in`
+`workbook_name` | `eq`, `in`
+
+**Returns**
+
+Returns a `QuerySet` of `ViewItem` objects.
+
+**Example**
+
+```py
+matching_views = server.views.filter(project_name='Finance', sheet_type='story')
+for view in matching_views:
+    print(view.name)
+```
+
+<br>
+<br>
+
 ---
 ## Webhooks
 <br>

--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -5701,6 +5701,146 @@ See [ViewItem class](#viewitem-class)
 <br>
 <br>
 
+#### views.populate_excel
+
+```py
+views.populate_excel(view_item, req_options=None)
+```
+
+Populates the Excel content of the specified view.
+
+After calling this method, the Excel data is available through the view's `excel` property.
+
+REST API: [Download View Excel](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#download_view_excel){:target="_blank"}
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view_item` | The `ViewItem` to populate with Excel data.
+`req_options` | (Optional) You can pass in request options to filter data or set the maximum age of the Excel content cached on the server. See [ExcelRequestOptions class](#excelrequestoptions-class) for more details.
+
+**Returns**
+
+None. The Excel content is added to the `view_item` and can be accessed by its `excel` field.
+
+**Version**
+
+Version 3.8 and later. See [REST API versions](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm).
+
+**Example**
+
+```py
+server.views.populate_excel(view_item)
+with open('./view_data.xlsx', 'wb') as f:
+    f.write(view_item.excel)
+```
+
+<br>
+<br>
+
+#### views.update
+
+```py
+views.update(view_item)
+```
+
+Modifies the specified view. Use this method to change the owner of a view or update its settings.
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view_item` | The `ViewItem` with updated attributes.
+
+**Returns**
+
+Returns the updated `ViewItem`.
+
+**Example**
+
+```py
+view = server.views.get_by_id('1a2a3b4b-5c6c-7d8d-9e0e-1f2f3a4a5b6b')
+view.owner_id = 'new-owner-id'
+updated_view = server.views.update(view)
+```
+
+<br>
+<br>
+
+#### views.populate_permissions
+
+```py
+views.populate_permissions(view_item)
+```
+
+Populates the permissions for the specified view.
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view_item` | The `ViewItem` to populate with permissions.
+
+**Version**
+
+Version 3.2 and later. See [REST API versions](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm).
+
+**Example**
+
+```py
+view = server.views.get_by_id('1a2a3b4b-5c6c-7d8d-9e0e-1f2f3a4a5b6b')
+server.views.populate_permissions(view)
+for permission in view.permissions:
+    print(permission.grantee_id, permission.capabilities)
+```
+
+<br>
+<br>
+
+#### views.update_permissions
+
+```py
+views.update_permissions(view_item, permission_item)
+```
+
+Adds or updates permissions for the specified view.
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view_item` | The `ViewItem` to update permissions for.
+`permission_item` | A list of `PermissionsRule` objects representing the permissions to add or update.
+
+**Version**
+
+Version 3.2 and later. See [REST API versions](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm).
+
+<br>
+<br>
+
+#### views.delete_permission
+
+```py
+views.delete_permission(view_item, capability_item)
+```
+
+Removes a permission from the specified view.
+
+**Parameters**
+
+Name | Description
+:--- | :---
+`view_item` | The `ViewItem` to remove the permission from.
+`capability_item` | The `PermissionsRule` object representing the permission to remove.
+
+**Version**
+
+Version 3.2 and later. See [REST API versions](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm).
+
+<br>
+<br>
 
 ---
 ## Webhooks


### PR DESCRIPTION
Documents the `views` endpoint methods in `docs/api-ref.md`.