### PR TITLE
Update license information in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name="tableauserverclient"
 dynamic = ["version"]
 description='A Python module for working with the Tableau Server REST API.'
 authors = [{name="Tableau", email="github@tableau.com"}]
-license = "Apache-2.0"
+license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ name="tableauserverclient"
 dynamic = ["version"]
 description='A Python module for working with the Tableau Server REST API.'
 authors = [{name="Tableau", email="github@tableau.com"}]
+license="Apache-2.0",
 license-files = ["LICENSE"]
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name="tableauserverclient"
 dynamic = ["version"]
 description='A Python module for working with the Tableau Server REST API.'
 authors = [{name="Tableau", email="github@tableau.com"}]
-license="Apache-2.0",
+license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
 


### PR DESCRIPTION
Fixes license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.