### PR TITLE
Fix W-21968404: Make authentication_type optional in update_connections

### DIFF
--- a/samples/update_connections_auth.py
+++ b/samples/update_connections_auth.py
@@ -22,8 +22,8 @@ def main():
     # Resource-specific
     parser.add_argument("resource_type", choices=["workbook", "datasource"])
     parser.add_argument("resource_id")
-    parser.add_argument("datasource_username")
-    parser.add_argument("authentication_type")
+    parser.add_argument("--datasource_username", default=None, help="Datasource username (optional)")
+    parser.add_argument("--authentication_type", default=None, help="Authentication type (optional)")
     parser.add_argument("--datasource_password", default=None, help="Datasource password (optional)")
     parser.add_argument(
         "--embed_password", default="true", choices=["true", "false"], help="Embed password (default: true)"

--- a/samples/update_connections_auth.py
+++ b/samples/update_connections_auth.py
@@ -22,9 +22,9 @@ def main():
     # Resource-specific
     parser.add_argument("resource_type", choices=["workbook", "datasource"])
     parser.add_argument("resource_id")
-    parser.add_argument("--datasource_username", default=None, help="Datasource username (optional)")
-    parser.add_argument("--authentication_type", default=None, help="Authentication type (optional)")
-    parser.add_argument("--datasource_password", default=None, help="Datasource password (optional)")
+    parser.add_argument("--datasource_username", help="Datasource username (optional)")
+    parser.add_argument("--authentication_type", help="Authentication type (optional)")
+    parser.add_argument("--datasource_password", help="Datasource password (optional)")
     parser.add_argument(
         "--embed_password", default="true", choices=["true", "false"], help="Embed password (default: true)"
     )

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -379,13 +379,16 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         self,
         datasource_item: DatasourceItem,
         connection_luids: Iterable[str],
-        authentication_type: str,
+        authentication_type: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         embed_password: Optional[bool] = None,
     ) -> list[ConnectionItem]:
         """
         Bulk updates one or more datasource connections by LUID.
+
+        This method allows updating authentication type, credentials, and other
+        connection properties for multiple connections at once.
 
         Parameters
         ----------
@@ -395,8 +398,9 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         connection_luids : Iterable of str
             The connection LUIDs to update.
 
-        authentication_type : str
-            The authentication type to use (e.g., 'auth-keypair').
+        authentication_type : str, optional
+            The authentication type to use (e.g., 'auth-keypair', 'AD Service Principal').
+            If not provided, the existing authentication type is preserved.
 
         username : str, optional
             The username to set.

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -341,13 +341,16 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
         self,
         workbook_item: WorkbookItem,
         connection_luids: Iterable[str],
-        authentication_type: str,
+        authentication_type: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         embed_password: Optional[bool] = None,
     ) -> list[ConnectionItem]:
         """
-        Bulk updates one or more workbook connections by LUID, including authenticationType, username, password, and embedPassword.
+        Bulk updates one or more workbook connections by LUID.
+
+        This method allows updating authentication type, credentials, and other
+        connection properties for multiple connections at once.
 
         Parameters
         ----------
@@ -357,8 +360,9 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
         connection_luids : Iterable of str
             The connection LUIDs to update.
 
-        authentication_type : str
-            The authentication type to use (e.g., 'AD Service Principal').
+        authentication_type : str, optional
+            The authentication type to use (e.g., 'AD Service Principal', 'auth-keypair').
+            If not provided, the existing authentication type is preserved.
 
         username : str, optional
             The username to set (e.g., client ID for keypair auth).

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -254,7 +254,7 @@ class DatasourceRequest:
         self,
         element: ET.Element,
         connection_luids: Iterable[str],
-        authentication_type: str,
+        authentication_type: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         embed_password: Optional[bool] = None,
@@ -264,7 +264,8 @@ class DatasourceRequest:
             ET.SubElement(conn_luids_elem, "connectionLUID").text = luid
 
         connection_elem = ET.SubElement(element, "connection")
-        connection_elem.set("authenticationType", authentication_type)
+        if authentication_type is not None:
+            connection_elem.set("authenticationType", authentication_type)
 
         if username is not None:
             connection_elem.set("userName", username)
@@ -1172,7 +1173,7 @@ class WorkbookRequest:
         self,
         element: ET.Element,
         connection_luids: Iterable[str],
-        authentication_type: str,
+        authentication_type: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         embed_password: Optional[bool] = None,
@@ -1182,7 +1183,8 @@ class WorkbookRequest:
             ET.SubElement(conn_luids_elem, "connectionLUID").text = luid
 
         connection_elem = ET.SubElement(element, "connection")
-        connection_elem.set("authenticationType", authentication_type)
+        if authentication_type is not None:
+            connection_elem.set("authenticationType", authentication_type)
 
         if username is not None:
             connection_elem.set("userName", username)

--- a/test/assets/datasource_connections_update_no_auth.xml
+++ b/test/assets/datasource_connections_update_no_auth.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsResponse xmlns="http://tableau.com/api"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_25.xsd">
+    <connections>
+        <connection id="be786ae0-d2bf-4a4b-9b34-e2de8d2d4488"
+                    type="sqlserver"
+                    serverAddress="updated-server"
+                    serverPort="1433"
+                    userName="user1"
+                    embedPassword="true"
+                    authenticationType="UsernamePassword" />
+        <connection id="a1b2c3d4-e5f6-7a8b-9c0d-123456789abc"
+                    type="sqlserver"
+                    serverAddress="updated-server"
+                    serverPort="1433"
+                    userName="user1"
+                    embedPassword="true"
+                    authenticationType="UsernamePassword" />
+    </connections>
+</tsResponse>

--- a/test/assets/workbook_update_connections_no_auth.xml
+++ b/test/assets/workbook_update_connections_no_auth.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tsResponse xmlns="http://tableau.com/api"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://tableau.com/api https://help.tableau.com/samples/en-us/rest_api/ts-api_3_25.xsd">
+    <connections>
+        <connection id="abc12345-def6-7890-gh12-ijklmnopqrst"
+                    type="sqlserver"
+                    serverAddress="updated-db-host"
+                    serverPort="1433"
+                    userName="svc-client"
+                    embedPassword="true"
+                    authenticationType="UsernamePassword" />
+        <connection id="1234abcd-5678-efgh-ijkl-0987654321mn"
+                    type="sqlserver"
+                    serverAddress="updated-db-host"
+                    serverPort="1433"
+                    userName="svc-client"
+                    embedPassword="true"
+                    authenticationType="UsernamePassword" />
+    </connections>
+</tsResponse>

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -35,6 +35,7 @@ UPDATE_XML = TEST_ASSET_DIR / "datasource_update.xml"
 UPDATE_HYPER_DATA_XML = TEST_ASSET_DIR / "datasource_data_update.xml"
 UPDATE_CONNECTION_XML = TEST_ASSET_DIR / "datasource_connection_update.xml"
 UPDATE_CONNECTIONS_XML = TEST_ASSET_DIR / "datasource_connections_update.xml"
+UPDATE_CONNECTIONS_NO_AUTH_XML = TEST_ASSET_DIR / "datasource_connections_update_no_auth.xml"
 
 
 @pytest.fixture(scope="function")

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -277,6 +277,44 @@ def test_update_connections(server) -> None:
         assert "auth-keypair" == connection_items[0].auth_type
 
 
+def test_update_connections_without_auth_type(server) -> None:
+    """Test that update_connections works when authentication_type is not provided."""
+    populate_xml = POPULATE_CONNECTIONS_XML.read_text()
+    response_xml = UPDATE_CONNECTIONS_NO_AUTH_XML.read_text()
+
+    with requests_mock.Mocker() as m:
+
+        datasource_id = "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb"
+        connection_luids = ["be786ae0-d2bf-4a4b-9b34-e2de8d2d4488", "a1b2c3d4-e5f6-7a8b-9c0d-123456789abc"]
+
+        datasource = TSC.DatasourceItem(datasource_id)
+        datasource._id = "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb"
+        datasource.owner_id = "dd2239f6-ddf1-4107-981a-4cf94e415794"
+        server.version = "3.26"
+
+        m.get(
+            "http://test/api/3.26/sites/dad65087-b08b-4603-af4e-2887b8aafc67/datasources/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/connections",
+            text=populate_xml,
+        )
+        m.put(
+            "http://test/api/3.26/sites/dad65087-b08b-4603-af4e-2887b8aafc67/datasources/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/connections",
+            text=response_xml,
+        )
+
+        # Update connections without specifying authentication_type
+        connection_items = server.datasources.update_connections(
+            datasource_item=datasource,
+            connection_luids=connection_luids,
+            username="user1",
+            embed_password=True,
+        )
+        updated_ids = [conn.id for conn in connection_items]
+
+        assert updated_ids == connection_luids
+        # Verify that the auth type from the response is preserved (UsernamePassword)
+        assert connection_items[0].auth_type == "UsernamePassword"
+
+
 def test_populate_permissions(server) -> None:
     response_xml = POPULATE_PERMISSIONS_XML.read_text()
     with requests_mock.mock() as m:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -1048,6 +1048,42 @@ def test_update_workbook_connections(server: TSC.Server) -> None:
         assert "AD Service Principal" == connection_items[0].auth_type
 
 
+def test_update_workbook_connections_without_auth_type(server: TSC.Server) -> None:
+    """Test that update_connections works when authentication_type is not provided."""
+    populate_xml = POPULATE_CONNECTIONS_XML.read_text()
+    response_xml = UPDATE_CONNECTIONS_NO_AUTH_XML.read_text()
+
+    with requests_mock.Mocker() as m:
+        workbook_id = "1a2b3c4d-5e6f-7a8b-9c0d-112233445566"
+        connection_luids = ["abc12345-def6-7890-gh12-ijklmnopqrst", "1234abcd-5678-efgh-ijkl-0987654321mn"]
+
+        workbook = TSC.WorkbookItem(workbook_id)
+        workbook._id = workbook_id
+        server.version = "3.26"
+        url = f"{server.baseurl}/{workbook_id}/connections"
+        m.get(
+            "http://test/api/3.26/sites/dad65087-b08b-4603-af4e-2887b8aafc67/workbooks/1a2b3c4d-5e6f-7a8b-9c0d-112233445566/connections",
+            text=populate_xml,
+        )
+        m.put(
+            "http://test/api/3.26/sites/dad65087-b08b-4603-af4e-2887b8aafc67/workbooks/1a2b3c4d-5e6f-7a8b-9c0d-112233445566/connections",
+            text=response_xml,
+        )
+
+        # Update connections without specifying authentication_type
+        connection_items = server.workbooks.update_connections(
+            workbook_item=workbook,
+            connection_luids=connection_luids,
+            username="user1",
+            embed_password=True,
+        )
+        updated_ids = [conn.id for conn in connection_items]
+
+        assert updated_ids == connection_luids
+        # Verify that the auth type from the response is preserved (UsernamePassword)
+        assert connection_items[0].auth_type == "UsernamePassword"
+
+
 def test_get_workbook_all_fields(server: TSC.Server) -> None:
     server.version = "3.21"
     baseurl = server.workbooks.baseurl

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -39,6 +39,7 @@ REVISION_XML = TEST_ASSET_DIR / "workbook_revision.xml"
 UPDATE_XML = TEST_ASSET_DIR / "workbook_update.xml"
 UPDATE_PERMISSIONS = TEST_ASSET_DIR / "workbook_update_permissions.xml"
 UPDATE_CONNECTIONS_XML = TEST_ASSET_DIR / "workbook_update_connections.xml"
+UPDATE_CONNECTIONS_NO_AUTH_XML = TEST_ASSET_DIR / "workbook_update_connections_no_auth.xml"
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
  Make the authentication_type parameter optional in update_connections                                                                                                                                                                             
  methods for both datasources and workbooks, allowing users to update                                                                                                                                                                              
  connection credentials without modifying the authentication type.                                                                                                                                                                                 
                                                                                                                                                                                                                                                    
  ## Problem                                                                                                                                                                                                                                        
  Users were confused by the update_connections method, attempting to use                                                                                                                                                                           
  it for general credential updates but encountering errors because                                                                                                                                                                                 
  authentication_type was required. This forced them to specify an auth                                                                                                                                                                             
  type even when they only wanted to update usernames/passwords.                                                                                                                                                                                    
                                                                                                                                                                                                                                                    
  ## Solution                                                                                                                                                                                                                                       
  - Made authentication_type parameter optional (default=None) in:                                                                                                                                                                                  
    * Datasources.update_connections()                                                                                                                                                                                                              
    * Workbooks.update_connections()
    * DatasourceRequest.update_connections_req()                                                                                                                                                                                                    
    * WorkbookRequest.update_connections_req()                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  - Updated XML request generation to only include authenticationType                                                                                                                                                                               
    attribute when explicitly provided                                                                                                                                                                                                              
                                                                                                                                                                                                                                                    
  - Enhanced docstrings to clarify that omitting authentication_type                                                                                                                                                                                
    preserves the existing configuration                                                                                                                                                                                                            
                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                        
  - tableauserverclient/server/endpoint/datasources_endpoint.py                                                                                                                                                                                     
  - tableauserverclient/server/endpoint/workbooks_endpoint.py                                                                                                                                                                                       
  - tableauserverclient/server/request_factory.py           
  - samples/update_connections_auth.py (made CLI args optional)                                                                                                                                                                                     
  - test/test_datasource.py (added test without auth_type)                                                                                                                                                                                          
  - test/test_workbook.py (added test without auth_type)                                                                                                                                                                                            
  - test/assets/*.xml (added test fixtures)                                                                                                                                                                                                         
                                                                                                                                                                                                                                                    
  ## Benefits                                                                                                                                                                                                                                       
  ✓ Backward compatible - existing code continues to work                                                                                                                                                                                           
  ✓ More flexible - update credentials independently of auth type                                                                                                                                                                                   
  ✓ Better UX - eliminates confusion about method purpose                                                                                                                                                                                           
  ✓ Safer - no risk of accidentally changing auth type                                                                                                                                                                                              
                                                                                                                                                                                                                                                    
  ## Testing                                                                                                                                                                                                                                        
  Added comprehensive tests for both datasources and workbooks that verify:                                                                                                                                                                         
  - Connections can be updated without providing authentication_type                                                                                                                                                                                
  - Existing authentication_type is preserved in response                                                                                                                                                                                           
  - All connection LUIDs are successfully updated    