### PR TITLE
fix: don't default authSetting to ServerDefault in bulk user add

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -997,8 +997,8 @@ class UserRequest:
                 raise ValueError("User cannot have both authSetting and idpConfigurationId.")
             elif user.idp_configuration_id is not None:
                 user_element.attrib["idpConfigurationId"] = user.idp_configuration_id
-            else:
-                user_element.attrib["authSetting"] = user.auth_setting or "ServerDefault"
+            elif user.auth_setting is not None:
+                user_element.attrib["authSetting"] = user.auth_setting
 
         parts = {
             "tableau_user_import": ("tsc_users_file.csv", csv_content, "file"),

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -467,7 +467,7 @@ def test_bulk_add(server: TSC.Server) -> None:
         for user, xml_user in zip(users, xml_users):
             assert user.name == xml_user.get("name")
             if user.idp_configuration_id is None:
-                assert xml_user.get("authSetting") == (user.auth_setting or "ServerDefault")
+                assert xml_user.get("authSetting") == user.auth_setting
             else:
                 assert xml_user.get("idpConfigurationId") == user.idp_configuration_id
                 assert xml_user.get("authSetting") is None


### PR DESCRIPTION
## Summary

- `authSetting` was hardcoded to `"ServerDefault"` when not explicitly set in the bulk user add request, which is incorrect for Tableau Cloud
- Changed to only send `authSetting` when explicitly set, matching the existing behaviour in single-user add/update

Fixes #1777

## Test plan

- [x] Verify bulk user add without explicit `auth_setting` no longer sends `authSetting=ServerDefault` in the request payload
- [x] Verify bulk user add with explicit `auth_setting` still sends it correctly
- [x] Verify Cloud bulk user add works without the erroneous default

🤖 Generated with [Claude Code](https://claude.com/claude-code)