### PR TITLE
fix: improve timeout error messages and document TSC_CHUNK_SIZE_MB

### DIFF
--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -679,7 +679,9 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
                         "TSC_CHUNK_SIZE_MB environment variable to a lower value (current default: 50)."
                     )
                 else:
-                    err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+                    err.content = (
+                        "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+                    )
             raise err
 
         if as_job:

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -580,7 +580,9 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         as_job : bool, default False
             If True, the publish operation is asynchronous and returns a job
             item. If False, the publish operation is synchronous and returns a
-            datasource item.
+            datasource item. For large files on slow connections, if uploads
+            time out you can tune the chunk size with the TSC_CHUNK_SIZE_MB
+            environment variable (default: 50).
 
         Returns
         -------
@@ -670,8 +672,14 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         try:
             server_response = self.post_request(url, xml_request, content_type)
         except InternalServerError as err:
-            if err.code == 504 and not as_job:
-                err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+            if err.code == 504:
+                if as_job:
+                    err.content = (
+                        "Timeout error during chunked file upload. Try reducing the chunk size by setting the "
+                        "TSC_CHUNK_SIZE_MB environment variable to a lower value (current default: 50)."
+                    )
+                else:
+                    err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
             raise err
 
         if as_job:

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -985,7 +985,9 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
                         "TSC_CHUNK_SIZE_MB environment variable to a lower value (current default: 50)."
                     )
                 else:
-                    err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+                    err.content = (
+                        "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+                    )
             raise err
 
         if as_job:

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -854,7 +854,9 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
         as_job : bool, default False
             Set to True to run the upload as a job (asynchronous upload). If set
             to True a job will start to perform the publishing process and a Job
-            object is returned. Defaults to False.
+            object is returned. Defaults to False. For large files on slow
+            connections, if uploads time out you can tune the chunk size with
+            the TSC_CHUNK_SIZE_MB environment variable (default: 50).
 
         skip_connection_check : bool, default False
             Set to True to skip connection check at time of upload. Publishing
@@ -976,8 +978,14 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
         try:
             server_response = self.post_request(url, xml_request, content_type, parameters)
         except InternalServerError as err:
-            if err.code == 504 and not as_job:
-                err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
+            if err.code == 504:
+                if as_job:
+                    err.content = (
+                        "Timeout error during chunked file upload. Try reducing the chunk size by setting the "
+                        "TSC_CHUNK_SIZE_MB environment variable to a lower value (current default: 50)."
+                    )
+                else:
+                    err.content = "Timeout error while publishing. Please use asynchronous publishing to avoid timeouts."
             raise err
 
         if as_job:

--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -763,6 +763,22 @@ def test_synchronous_publish_timeout_error(server) -> None:
             )
 
 
+def test_async_publish_timeout_error(server) -> None:
+    with requests_mock.mock() as m:
+        m.register_uri("POST", server.datasources.baseurl, status_code=504)
+
+        new_datasource = TSC.DatasourceItem(project_id="")
+        publish_mode = server.PublishMode.CreateNew
+
+        with pytest.raises(InternalServerError, match="TSC_CHUNK_SIZE_MB"):
+            server.datasources.publish(
+                new_datasource,
+                TEST_ASSET_DIR / "SampleDS.tds",
+                publish_mode,
+                as_job=True,
+            )
+
+
 def test_delete_extracts(server) -> None:
     server.version = "3.10"
     with requests_mock.mock() as m:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -879,6 +879,17 @@ def test_synchronous_publish_timeout_error(server: TSC.Server) -> None:
             server.workbooks.publish(new_workbook, TEST_ASSET_DIR / "SampleWB.twbx", publish_mode)
 
 
+def test_async_publish_timeout_error(server: TSC.Server) -> None:
+    with requests_mock.mock() as m:
+        m.register_uri("POST", server.workbooks.baseurl, status_code=504)
+
+        new_workbook = TSC.WorkbookItem(project_id="")
+        publish_mode = server.PublishMode.CreateNew
+
+        with pytest.raises(InternalServerError, match="TSC_CHUNK_SIZE_MB"):
+            server.workbooks.publish(new_workbook, TEST_ASSET_DIR / "SampleWB.twbx", publish_mode, as_job=True)
+
+
 def test_delete_extracts_all(server: TSC.Server) -> None:
     server.version = "3.10"
     server.workbooks.baseurl


### PR DESCRIPTION
## Summary

- When a 504 occurs during a chunked upload with `as_job=True`, the error message previously said nothing useful. Now it points users at `TSC_CHUNK_SIZE_MB` to reduce chunk size
- Documenting `TSC_CHUNK_SIZE_MB` in the `publish` docstrings for both workbooks and datasources — previously undiscoverable
- Applies to both `workbooks.publish` and `datasources.publish`

Relates to #1387

## Test plan

- [x] Existing publish tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)