### PR TITLE
chore: bump black from 24.10 to 26.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 repository = "https://github.com/tableau/server-client-python"
 
 [project.optional-dependencies]
-test = ["black==24.10", "build", "mypy==1.4", "pytest>=7.0", "pytest-cov", "pytest-subtests",
+test = ["black==26.3.1", "build", "mypy==1.4", "pytest>=7.0", "pytest-cov", "pytest-subtests",
     "pytest-xdist", "requests-mock>=1.0,<2.0", "types-requests>=2.32.4.20250913"]
 
 [tool.setuptools.package-data]

--- a/samples/export.py
+++ b/samples/export.py
@@ -73,7 +73,7 @@ def main():
         # We encode that information above in the const=(...) parameter to the add_argument function to make
         # the code automatically adapt for the type of export the user is doing.
         # We unroll that information into methods we can call, or objects we can create by using getattr()
-        (populate_func_name, option_factory_name, member_name, extension) = args.type
+        populate_func_name, option_factory_name, member_name, extension = args.type
         populate = getattr(server.views, populate_func_name)
         if args.workbook:
             populate = getattr(server.workbooks, populate_func_name)

--- a/samples/smoke_test.py
+++ b/samples/smoke_test.py
@@ -4,7 +4,6 @@
 import logging
 import tableauserverclient as TSC
 
-
 logger = logging.getLogger("Sample")
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler())

--- a/tableauserverclient/datetime_helpers.py
+++ b/tableauserverclient/datetime_helpers.py
@@ -1,6 +1,5 @@
 import datetime
 
-
 ZERO = datetime.timedelta(0)
 HOUR = datetime.timedelta(hours=1)
 

--- a/tableauserverclient/helpers/strings.py
+++ b/tableauserverclient/helpers/strings.py
@@ -2,7 +2,6 @@ from defusedxml.ElementTree import fromstring, tostring
 from functools import singledispatch
 from typing import TypeVar, overload
 
-
 # the redact method can handle either strings or bytes, but it can't mix them.
 # Generic type so we can write the actual logic once, then use singledispatch to
 # create the replacement text with the correct type

--- a/tableauserverclient/models/column_item.py
+++ b/tableauserverclient/models/column_item.py
@@ -54,7 +54,7 @@ class ColumnItem:
         all_column_xml = parsed_response.findall(".//t:column", namespaces=ns)
 
         for column_xml in all_column_xml:
-            (id, name, description, remote_type) = cls._parse_element(column_xml, ns)
+            id, name, description, remote_type = cls._parse_element(column_xml, ns)
             column_item = cls(name)
             column_item._set_values(id, name, description, remote_type)
             all_column_items.append(column_item)

--- a/tableauserverclient/models/data_alert_item.py
+++ b/tableauserverclient/models/data_alert_item.py
@@ -37,9 +37,7 @@ class DataAlertItem:
 
     def __repr__(self) -> str:
         return "<Data Alert {_id} subject={_subject} frequency={_frequency} \
-                public={_public}>".format(
-            **self.__dict__
-        )
+                public={_public}>".format(**self.__dict__)
 
     @property
     def id(self) -> str | None:

--- a/tableauserverclient/models/subscription_item.py
+++ b/tableauserverclient/models/subscription_item.py
@@ -29,14 +29,10 @@ class SubscriptionItem:
     def __repr__(self) -> str:
         if self.id is not None:
             return "<Subscription#{_id} subject({subject}) schedule_id({schedule_id}) user_id({user_id}) \
-                target({target})".format(
-                **self.__dict__
-            )
+                target({target})".format(**self.__dict__)
         else:
             return "<Subscription subject({subject}) schedule_id({schedule_id}) user_id({user_id}) \
-                target({target})".format(
-                **self.__dict__
-            )
+                target({target})".format(**self.__dict__)
 
     @property
     def id(self):

--- a/tableauserverclient/server/endpoint/data_alert_endpoint.py
+++ b/tableauserverclient/server/endpoint/data_alert_endpoint.py
@@ -9,7 +9,6 @@ from tableauserverclient.helpers.logging import logger
 
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
     from ..server import Server
     from ..request_options import RequestOptions

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -226,7 +226,7 @@ class Schedules(Endpoint):
                 task_type = TaskItem.Type.RunFlow
             items.append(
                 (schedule_id, flow, "flow", RequestFactory.Schedule.add_flow_req, task_type)
-            )  # type:ignore[arg-type]
+            )  # type: ignore[arg-type]
 
         results = (self._add_to(*x) for x in items)
         return [x for x in results if not x.result]

--- a/tableauserverclient/server/pager.py
+++ b/tableauserverclient/server/pager.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Iterator
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.request_options import RequestOptions
 
-
 T = TypeVar("T")
 
 

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -611,7 +611,7 @@ class ScheduleRequest:
             intervals_element = ET.SubElement(frequency_element, "intervals")
             if hasattr(interval_item, "interval"):
                 for interval in interval_item._interval_type_pairs():
-                    (expression, value) = interval
+                    expression, value = interval
                     single_interval_element = ET.SubElement(intervals_element, "interval")
                     single_interval_element.attrib[expression] = value
         return ET.tostring(xml_request)

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -48,7 +48,6 @@ from tableauserverclient.server.exceptions import (
 from tableauserverclient.server.endpoint.exceptions import NotSignedInError
 from tableauserverclient.namespace import Namespace
 
-
 _PRODUCT_TO_REST_VERSION = {
     "10.0": "2.3",
     "9.3": "2.2",

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -6,7 +6,6 @@ import pytest
 
 import tableauserverclient as TSC
 
-
 TEST_ASSET_DIR = Path(__file__).parent / "assets"
 
 GET_SERVER_EXT_SETTINGS = TEST_ASSET_DIR / "extensions_server_settings_true.xml"

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -9,7 +9,6 @@ from tableauserverclient.datetime_helpers import utc
 from tableauserverclient.server.endpoint.exceptions import JobFailedException
 from ._utils import mocked_time
 
-
 TEST_ASSET_DIR = Path(__file__).parent / "assets"
 GET_XML = TEST_ASSET_DIR / "job_get.xml"
 GET_BY_ID_XML = TEST_ASSET_DIR / "job_get_by_id.xml"


### PR DESCRIPTION
Bumps `black` from 24.10 to 26.3.1 to fix a high severity CVE in black's cache file name handling (arbitrary file writes from unsanitized user input).

`black` is a dev-only dependency (`.[test]`) — end users of the published package are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)