### PR TITLE
chore: run tests in parallel with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ exclude = ['/bin/']
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = "--junitxml=./test.junit.xml"
+addopts = "--junitxml=./test.junit.xml -n auto"
 
 [tool.versioneer]
 VCS = "git"


### PR DESCRIPTION
## Summary

- Adds `-n auto` to pytest `addopts` to parallelise the test suite across all available CPU cores
- `pytest-xdist` is already a test dependency — no new packages required
- Reduces local run time from ~6 min to ~2 min

## Test plan

- [x] Verified locally: 803 tests pass in ~110s with `-n auto` vs ~360s without

🤖 Generated with [Claude Code](https://claude.com/claude-code)