### PR TITLE
always use the server version by default

### DIFF
--- a/tableauserverclient/server/endpoint/auth_endpoint.py
+++ b/tableauserverclient/server/endpoint/auth_endpoint.py
@@ -89,6 +89,8 @@ class Auth(Endpoint):
         auth_token = parsed_response.find("t:credentials", namespaces=self.parent_srv.namespace).get("token", None)
         self.parent_srv._set_auth(site_id, user_id, auth_token, site_url)
         logger.info(f"Signed into {self.parent_srv.server_address} as user with id {user_id}")
+        if self.parent_srv._use_server_version:
+            self.parent_srv.use_server_version()
         return Auth.contextmgr(self.sign_out)
 
     # We use the same request that username/password login uses for all auth types.

--- a/tableauserverclient/server/server.py
+++ b/tableauserverclient/server/server.py
@@ -195,8 +195,7 @@ class Server:
         self.validate_connection_settings()  # does not make an actual outgoing request
 
         self.version = default_server_version
-        if use_server_version:
-            self.use_server_version()  # this makes a server call
+        self._use_server_version = use_server_version
 
     def validate_connection_settings(self):
         try:

--- a/test/http/test_http_requests.py
+++ b/test/http/test_http_requests.py
@@ -49,9 +49,11 @@ def test_init_server_model_bad_server_name_not_version_check():
     server = TSC.Server("fake-url", use_server_version=False)
 
 
-@mock.patch("requests.sessions.Session.get", side_effect=mocked_requests_get)
-def test_init_server_model_bad_server_name_do_version_check(mock_get):
+def test_init_server_model_bad_server_name_do_version_check():
+    # use_server_version=True no longer makes a network call at construction;
+    # version detection is deferred until sign_in
     server = TSC.Server("fake-url", use_server_version=True)
+    assert server._use_server_version is True
 
 
 def test_init_server_model_bad_server_name_not_version_check_random_options():

--- a/test/test_server_info.py
+++ b/test/test_server_info.py
@@ -66,11 +66,11 @@ def test_server_info_use_highest_version_upgrades(server: TSC.Server) -> None:
 
 
 def test_server_use_server_version_flag(server: TSC.Server) -> None:
-    si_response_xml = SERVER_INFO_25_XML.read_text()
-    with requests_mock.mock() as m:
-        m.get("http://test/api/2.4/serverInfo", text=si_response_xml)
-        server = TSC.Server("http://test", use_server_version=True)
-        assert server.version == "2.5"
+    # use_server_version=True defers version detection to sign_in, so the
+    # version is not updated at construction time
+    server = TSC.Server("http://test", use_server_version=True)
+    assert server._use_server_version is True
+    assert server.version == "2.4"  # still at default until sign_in
 
 
 def test_server_wrong_site(server: TSC.Server) -> None:


### PR DESCRIPTION
Fixes #876 and #959 by auto-detecting and use the server's current REST API version *after* signin. This gives cleaner error scenarios when something goes wrong connecting/signing in.