### PR TITLE
fix: correct wheel packaging and add release safety checks

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,9 +1,7 @@
 name: Publish to PyPi
 
-# This will build a package with a version set by versioneer from the most recent tag matching v____
-# It will publish to TestPyPi, and to real Pypi *if* run on master where head has a release tag
-# For a live run, this should only need to be triggered by a newly published repo release. 
-# This can also be run manually for testing
+# Builds the package, checks wheel structure, publishes to TestPyPI, runs smoke
+# tests against TestPyPI, then publishes to real PyPI only if all prior steps pass.
 on:
   release:
     types: [published]
@@ -13,8 +11,8 @@ on:
       - 'v*.*.*'
 
 jobs:
-  build-n-publish:
-    name: Build dist files for PyPi
+  build:
+    name: Build and check wheel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,22 +20,67 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.13'
       - name: Build dist files
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[test] build
           python -m build
           git describe --tag --dirty --always
-          
-      - name: Publish distribution 📦 to Test PyPI  # always run
+      - name: Check wheel structure
+        run: python -m pytest test/test_packaging.py -m packaging -v
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-test-pypi:
+    name: Publish to Test PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1  # license BSD-2
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          
-      - name: Publish distribution 📦 to PyPI
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+          skip_existing: true
+
+  smoke-test-pypi:
+    name: Smoke test from Test PyPI
+    needs: publish-test-pypi
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.x']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install from Test PyPI
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ tableauserverclient
+      - name: Smoke test
+        run: |
+          python -c "import tableauserverclient as TSC; server = TSC.Server('http://example.com', use_server_version=False)"
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: smoke-test-pypi
+    if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1  # license BSD-2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-smoke-tests.yml
+++ b/.github/workflows/pypi-smoke-tests.yml
@@ -5,6 +5,8 @@ name: Pypi smoke tests
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   schedule:
     - cron: 0 11 * * * # Every day at 11AM UTC (7AM EST)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ tableauserverclient = ["*"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["tableauserverclient*"]
+exclude = ["test*", "samples*", "test_e2e*", "docs*", "dist*", "build*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "versioneer.get_version"}
@@ -68,7 +68,10 @@ exclude = ['/bin/']
 [tool.pytest.ini_options]
 testpaths = ["test"]
 addopts = "--junitxml=./test.junit.xml -n auto"
-markers = ["e2e: mark test as end-to-end (requires a real Tableau server)"]
+markers = [
+    "e2e: mark test as end-to-end (requires a real Tableau server)",
+    "packaging: mark test as requiring a built wheel in dist/",
+]
 
 [tool.versioneer]
 VCS = "git"

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -1,0 +1,19 @@
+import zipfile
+from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.packaging
+
+
+def _find_wheel():
+    wheels = list(Path("dist").glob("tableauserverclient-*.whl"))
+    if not wheels:
+        pytest.skip("No wheel in dist/ -- run 'python -m build --wheel' first")
+    return max(wheels, key=lambda p: p.stat().st_mtime)
+
+
+def test_wheel_only_tableauserverclient_at_root():
+    with zipfile.ZipFile(_find_wheel()) as whl:
+        top_dirs = {n.split("/")[0] for n in whl.namelist() if "/" in n}
+    non_dist_info = {d for d in top_dirs if not d.endswith(".dist-info") and not d.endswith(".data")}
+    assert non_dist_info == {"tableauserverclient"}, f"Unexpected top-level entries: {non_dist_info}"


### PR DESCRIPTION
## Summary

- Fixes broken wheel structure caused by `include=[\"tableauserverclient*\"]` in `[tool.setuptools.packages.find]`, which on setuptools 80.10.2 doubles all subpackages as bare top-level entries in the wheel zip (e.g. `models/`, `server/`, `helpers/` alongside `tableauserverclient/`). Switched to an `exclude`-based approach which is robust across setuptools versions.
- Adds `test/test_packaging.py` with a wheel structure test that checks the zip root contains only `tableauserverclient/` — catches both this bug and the v0.39 regression where the package itself was missing entirely.
- Updates `publish-pypi.yml` to split into four sequential jobs: build + check wheel → publish to TestPyPI → smoke test from TestPyPI (Linux/macOS/Windows) → publish to real PyPI. Real PyPI is now unreachable unless the TestPyPI smoke test passes.
- Updates `pypi-smoke-tests.yml` to also trigger on `release: published`, not just the daily schedule.

Closes #1751.

## Test plan

- [ ] Trigger `publish-pypi.yml` manually via `workflow_dispatch` on this branch to verify build, wheel check, TestPyPI publish, and smoke test jobs run correctly (real PyPI publish will be skipped on non-master)
- [ ] Confirm `pytest test/test_packaging.py -m packaging` passes after `python -m build`
- [ ] Confirm `pytest test/test_packaging.py -m packaging` fails against the broken wheel built from `development` without this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)