### PR TITLE
fix: use tmp_path fixture in download tests to avoid cwd pollution

### DIFF
--- a/test/test_datasource.py
+++ b/test/test_datasource.py
@@ -608,15 +608,14 @@ def test_delete(server) -> None:
         server.datasources.delete("9dbd2263-16b5-46e1-9c43-a76bb8ab65fb")
 
 
-def test_download(server) -> None:
+def test_download(server, tmp_path) -> None:
     with requests_mock.mock() as m:
         m.get(
             server.datasources.baseurl + "/9dbd2263-16b5-46e1-9c43-a76bb8ab65fb/content",
             headers={"Content-Disposition": 'name="tableau_datasource"; filename="Sample datasource.tds"'},
         )
-        file_path = server.datasources.download("9dbd2263-16b5-46e1-9c43-a76bb8ab65fb")
+        file_path = server.datasources.download("9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", filepath=tmp_path)
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
 def test_download_object(server) -> None:
@@ -630,7 +629,7 @@ def test_download_object(server) -> None:
             assert isinstance(file_path, BytesIO)
 
 
-def test_download_sanitizes_name(server) -> None:
+def test_download_sanitizes_name(server, tmp_path) -> None:
     filename = "Name,With,Commas.tds"
     disposition = f'name="tableau_workbook"; filename="{filename}"'
     with requests_mock.mock() as m:
@@ -638,13 +637,12 @@ def test_download_sanitizes_name(server) -> None:
             server.datasources.baseurl + "/1f951daf-4061-451a-9df1-69a8062664f2/content",
             headers={"Content-Disposition": disposition},
         )
-        file_path = server.datasources.download("1f951daf-4061-451a-9df1-69a8062664f2")
+        file_path = server.datasources.download("1f951daf-4061-451a-9df1-69a8062664f2", filepath=tmp_path)
         assert os.path.basename(file_path) == "NameWithCommas.tds"
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
-def test_download_extract_only(server) -> None:
+def test_download_extract_only(server, tmp_path) -> None:
     # Pretend we're 2.5 for 'extract_only'
     server.version = "2.5"
 
@@ -654,12 +652,13 @@ def test_download_extract_only(server) -> None:
             headers={"Content-Disposition": 'name="tableau_datasource"; filename="Sample datasource.tds"'},
             complete_qs=True,
         )
-        file_path = server.datasources.download("9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", include_extract=False)
+        file_path = server.datasources.download(
+            "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", include_extract=False, filepath=tmp_path
+        )
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
-def test_download_no_extract_emits_deprecation_warning(server) -> None:
+def test_download_no_extract_emits_deprecation_warning(server, tmp_path) -> None:
     """no_extract=True should emit a DeprecationWarning and map to includeExtract=False."""
     server.version = "2.5"
 
@@ -670,9 +669,10 @@ def test_download_no_extract_emits_deprecation_warning(server) -> None:
             complete_qs=True,
         )
         with pytest.warns(DeprecationWarning, match="deprecated and will be removed"):
-            file_path = server.datasources.download("9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", no_extract=True)
+            file_path = server.datasources.download(
+                "9dbd2263-16b5-46e1-9c43-a76bb8ab65fb", no_extract=True, filepath=tmp_path
+            )
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
 def test_update_missing_id(server) -> None:

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -33,15 +33,14 @@ def server():
     return server
 
 
-def test_download(server: TSC.Server) -> None:
+def test_download(server: TSC.Server, tmp_path: Path) -> None:
     with requests_mock.mock() as m:
         m.get(
             server.flows.baseurl + "/587daa37-b84d-4400-a9a2-aa90e0be7837/content",
             headers={"Content-Disposition": 'name="tableau_flow"; filename="FlowOne.tfl"'},
         )
-        file_path = server.flows.download("587daa37-b84d-4400-a9a2-aa90e0be7837")
+        file_path = server.flows.download("587daa37-b84d-4400-a9a2-aa90e0be7837", filepath=tmp_path)
         assert os.path.exists(file_path) is True
-    os.remove(file_path)
 
 
 def test_download_object(server: TSC.Server) -> None:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -339,7 +339,7 @@ def test_download_object(server: TSC.Server) -> None:
             assert isinstance(file_path, BytesIO)
 
 
-def test_download_sanitizes_name(server: TSC.Server) -> None:
+def test_download_sanitizes_name(server: TSC.Server, tmp_path: Path) -> None:
     filename = "Name,With,Commas.twbx"
     disposition = f'name="tableau_workbook"; filename="{filename}"'
     with requests_mock.mock() as m:
@@ -347,13 +347,12 @@ def test_download_sanitizes_name(server: TSC.Server) -> None:
             server.workbooks.baseurl + "/1f951daf-4061-451a-9df1-69a8062664f2/content",
             headers={"Content-Disposition": disposition},
         )
-        file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2")
+        file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2", filepath=tmp_path)
         assert os.path.basename(file_path) == "NameWithCommas.twbx"
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
-def test_download_extract_only(server: TSC.Server) -> None:
+def test_download_extract_only(server: TSC.Server, tmp_path: Path) -> None:
     # Pretend we're 2.5 for 'extract_only'
     server.version = "2.5"
 
@@ -364,12 +363,13 @@ def test_download_extract_only(server: TSC.Server) -> None:
             complete_qs=True,
         )
         # Technically this shouldn't download a twbx, but we are interested in the qs, not the file
-        file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2", include_extract=False)
+        file_path = server.workbooks.download(
+            "1f951daf-4061-451a-9df1-69a8062664f2", include_extract=False, filepath=tmp_path
+        )
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
-def test_download_no_extract_emits_deprecation_warning(server: TSC.Server) -> None:
+def test_download_no_extract_emits_deprecation_warning(server: TSC.Server, tmp_path: Path) -> None:
     """no_extract=True should emit a DeprecationWarning and map to includeExtract=False."""
     server.version = "2.5"
 
@@ -380,9 +380,10 @@ def test_download_no_extract_emits_deprecation_warning(server: TSC.Server) -> No
             complete_qs=True,
         )
         with pytest.warns(DeprecationWarning, match="deprecated and will be removed"):
-            file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2", no_extract=True)
+            file_path = server.workbooks.download(
+                "1f951daf-4061-451a-9df1-69a8062664f2", no_extract=True, filepath=tmp_path
+            )
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
 def test_download_missing_id(server: TSC.Server) -> None:

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -318,15 +318,14 @@ def test_update_tags(server: TSC.Server) -> None:
     assert single_workbook._initial_tags == updated_workbook._initial_tags
 
 
-def test_download(server: TSC.Server) -> None:
+def test_download(server: TSC.Server, tmp_path: Path) -> None:
     with requests_mock.mock() as m:
         m.get(
             server.workbooks.baseurl + "/1f951daf-4061-451a-9df1-69a8062664f2/content",
             headers={"Content-Disposition": 'name="tableau_workbook"; filename="RESTAPISample.twbx"'},
         )
-        file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2")
+        file_path = server.workbooks.download("1f951daf-4061-451a-9df1-69a8062664f2", filepath=tmp_path)
         assert os.path.exists(file_path)
-    os.remove(file_path)
 
 
 def test_download_object(server: TSC.Server) -> None:


### PR DESCRIPTION
## Summary

- Replaces manual `os.remove(file_path)` cleanup with pytest's built-in `tmp_path` fixture across all download tests in `test_workbook.py`, `test_datasource.py`, and `test_flow.py`.
- Passes `filepath=tmp_path` to each download call so files are written to a worker-isolated temp directory instead of the current working directory.
- Fixes test failures in parallel (`-n auto`) runs where workers writing to cwd could conflict.

## Test plan

- [x] All 9 affected tests pass locally
- [x] CI passes with `-n auto` parallel execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)