### PR TITLE
Extract download streaming logic into DownloadableMixin

### DIFF
--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "DataAlerts",
     "Databases",
     "Datasources",
+    "DownloadableMixin",
     "QuerysetEndpoint",
     "MissingRequiredFieldError",
     "Endpoint",

--- a/tableauserverclient/server/endpoint/__init__.py
+++ b/tableauserverclient/server/endpoint/__init__.py
@@ -4,7 +4,7 @@ from tableauserverclient.server.endpoint.data_acceleration_report_endpoint impor
 from tableauserverclient.server.endpoint.data_alert_endpoint import DataAlerts
 from tableauserverclient.server.endpoint.databases_endpoint import Databases
 from tableauserverclient.server.endpoint.datasources_endpoint import Datasources
-from tableauserverclient.server.endpoint.endpoint import Endpoint, QuerysetEndpoint
+from tableauserverclient.server.endpoint.endpoint import Endpoint, QuerysetEndpoint, DownloadableMixin
 from tableauserverclient.server.endpoint.exceptions import ServerResponseError, MissingRequiredFieldError
 from tableauserverclient.server.endpoint.extensions_endpoint import Extensions
 from tableauserverclient.server.endpoint.favorites_endpoint import Favorites

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -42,9 +42,7 @@ from tableauserverclient.models import (
 )
 from tableauserverclient.server import RequestFactory, RequestOptions
 
-io_types = (io.BytesIO, io.BufferedReader)
 io_types_r = (io.BytesIO, io.BufferedReader)
-io_types_w = (io.BytesIO, io.BufferedWriter)
 
 FilePath = str | os.PathLike
 FileObject = io.BufferedReader | io.BytesIO

--- a/tableauserverclient/server/endpoint/datasources_endpoint.py
+++ b/tableauserverclient/server/endpoint/datasources_endpoint.py
@@ -1,10 +1,8 @@
-from email.message import Message
 import copy
 import json
 import io
 import os
 
-from contextlib import closing
 from pathlib import Path
 from typing import Literal, TYPE_CHECKING, TypedDict, TypeVar, overload
 from collections.abc import Iterable, Sequence
@@ -18,7 +16,7 @@ if TYPE_CHECKING:
     from .schedules_endpoint import AddResponse
 
 from tableauserverclient.server.endpoint.dqw_endpoint import _DataQualityWarningEndpoint
-from tableauserverclient.server.endpoint.endpoint import QuerysetEndpoint, api, parameter_added_in
+from tableauserverclient.server.endpoint.endpoint import DownloadableMixin, QuerysetEndpoint, api, parameter_added_in
 from tableauserverclient.server.endpoint.exceptions import (
     DUPLICATE_EXTRACT_JOB_CODE,
     InternalServerError,
@@ -30,10 +28,8 @@ from tableauserverclient.server.endpoint.resource_tagger import TaggingMixin
 
 from tableauserverclient.config import ALLOWED_FILE_EXTENSIONS, BYTES_PER_MB, config
 from tableauserverclient.filesys_helpers import (
-    make_download_path,
     get_file_type,
     get_file_object_size,
-    to_filename,
 )
 from tableauserverclient.helpers.logging import logger
 from tableauserverclient.models import (
@@ -101,7 +97,7 @@ HyperAction = HyperActionTable | HyperActionRow
 _UNSET = object()
 
 
-class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]):
+class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem], DownloadableMixin):
     def __init__(self, parent_srv: "Server") -> None:
         super().__init__(parent_srv)
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
@@ -1061,22 +1057,7 @@ class Datasources(QuerysetEndpoint[DatasourceItem], TaggingMixin[DatasourceItem]
         if not include_extract:
             url += "?includeExtract=False"
 
-        with closing(self.get_request(url, parameters={"stream": True})) as server_response:
-            m = Message()
-            m["Content-Disposition"] = server_response.headers["Content-Disposition"]
-            filename = m.get_filename(failobj="")
-            if isinstance(filepath, io_types_w):
-                for chunk in server_response.iter_content(1024):  # 1KB
-                    filepath.write(chunk)
-                return_path = filepath
-            else:
-                filename = to_filename(os.path.basename(filename))
-                download_path = make_download_path(filepath, filename)
-                with open(download_path, "wb") as f:
-                    for chunk in server_response.iter_content(1024):  # 1KB
-                        f.write(chunk)
-                return_path = os.path.abspath(download_path)
-
+        return_path = self._download_content(url, filepath)
         logger.info(f"Downloaded datasource revision {revision_number} to {return_path} (ID: {datasource_id})")
         return return_path
 

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -1,3 +1,7 @@
+from email.message import Message
+import io
+import os
+from contextlib import closing
 from typing_extensions import Concatenate, ParamSpec
 from tableauserverclient import datetime_helpers as datetime
 
@@ -18,6 +22,7 @@ from typing_extensions import Self
 
 from tableauserverclient.models.pagination_item import PaginationItem
 from tableauserverclient.server.request_options import RequestOptions
+from tableauserverclient.filesys_helpers import to_filename, make_download_path
 
 from tableauserverclient.server.endpoint.exceptions import (
     FailedSignInError,
@@ -322,6 +327,58 @@ def parameter_added_in(**params: str) -> Callable[[Callable[Concatenate[E, P], R
 
 
 T = TypeVar("T")
+
+_io_types_w = (io.BytesIO, io.BufferedWriter)
+
+FilePath = str | os.PathLike
+FileObjectW = io.BufferedWriter | io.BytesIO
+PathOrFileW = FilePath | FileObjectW
+
+
+class DownloadableMixin:
+    """Mixin for endpoints whose resources can be downloaded as binary files.
+
+    Provides a single private helper that streams a server response to a file
+    path or writable file object, avoiding copy-paste of the identical streaming
+    loop in Workbooks, Datasources, and Flows.
+    """
+
+    def _download_content(
+        self,
+        url: str,
+        filepath: PathOrFileW | None,
+    ) -> PathOrFileW:
+        """Stream content at url to filepath and return the resolved path.
+
+        Parameters
+        ----------
+        url : str
+            Fully-qualified URL whose response body should be saved.
+        filepath : PathOrFileW | None
+            Destination file path or writable file object.  When None the file
+            is saved to the current working directory using the server-supplied
+            filename from the Content-Disposition header.
+
+        Returns
+        -------
+        PathOrFileW
+            The absolute file path written, or the caller-supplied file object.
+        """
+        with closing(self.get_request(url, parameters={"stream": True})) as server_response:  # type: ignore[attr-defined]
+            m = Message()
+            m["Content-Disposition"] = server_response.headers["Content-Disposition"]
+            filename = m.get_filename(failobj="")
+            if isinstance(filepath, _io_types_w):
+                for chunk in server_response.iter_content(1024):  # 1KB
+                    filepath.write(chunk)
+                return filepath
+            else:
+                filename = to_filename(os.path.basename(filename))
+                download_path = make_download_path(filepath, filename)
+                with open(download_path, "wb") as f:
+                    for chunk in server_response.iter_content(1024):  # 1KB
+                        f.write(chunk)
+                return os.path.abspath(download_path)
 
 
 class QuerysetEndpoint(Endpoint, Generic[T]):

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -25,10 +25,6 @@ from tableauserverclient.filesys_helpers import (
 from tableauserverclient.server.query import QuerySet
 
 io_types_r = (io.BytesIO, io.BufferedReader)
-io_types_w = (io.BytesIO, io.BufferedWriter)
-
-io_types_r = (io.BytesIO, io.BufferedReader)
-io_types_w = (io.BytesIO, io.BufferedWriter)
 
 # The maximum size of a file that can be published in a single request is 64MB
 FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB

--- a/tableauserverclient/server/endpoint/flows_endpoint.py
+++ b/tableauserverclient/server/endpoint/flows_endpoint.py
@@ -1,15 +1,13 @@
-from email.message import Message
 import copy
 import io
 import logging
 import os
-from contextlib import closing
 from pathlib import Path
 from typing import TYPE_CHECKING
 from collections.abc import Iterable
 
 from tableauserverclient.server.endpoint.dqw_endpoint import _DataQualityWarningEndpoint
-from tableauserverclient.server.endpoint.endpoint import QuerysetEndpoint, api
+from tableauserverclient.server.endpoint.endpoint import DownloadableMixin, QuerysetEndpoint, api
 from tableauserverclient.server.endpoint.exceptions import (
     DUPLICATE_EXTRACT_JOB_CODE,
     InternalServerError,
@@ -21,8 +19,6 @@ from tableauserverclient.server.endpoint.resource_tagger import _ResourceTagger,
 from tableauserverclient.models import FlowItem, PaginationItem, ConnectionItem, JobItem
 from tableauserverclient.server import RequestFactory
 from tableauserverclient.filesys_helpers import (
-    to_filename,
-    make_download_path,
     get_file_type,
     get_file_object_size,
 )
@@ -55,7 +51,7 @@ PathOrFileR = FilePath | FileObjectR
 PathOrFileW = FilePath | FileObjectW
 
 
-class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem]):
+class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem], DownloadableMixin):
     def __init__(self, parent_srv):
         super().__init__(parent_srv)
         self._resource_tagger = _ResourceTagger(parent_srv)
@@ -227,22 +223,7 @@ class Flows(QuerysetEndpoint[FlowItem], TaggingMixin[FlowItem]):
             raise ValueError(error)
         url = f"{self.baseurl}/{flow_id}/content"
 
-        with closing(self.get_request(url, parameters={"stream": True})) as server_response:
-            m = Message()
-            m["Content-Disposition"] = server_response.headers["Content-Disposition"]
-            filename = m.get_filename(failobj="")
-            if isinstance(filepath, io_types_w):
-                for chunk in server_response.iter_content(1024):  # 1KB
-                    filepath.write(chunk)
-                return_path = filepath
-            else:
-                filename = to_filename(os.path.basename(filename))
-                download_path = make_download_path(filepath, filename)
-                with open(download_path, "wb") as f:
-                    for chunk in server_response.iter_content(1024):  # 1KB
-                        f.write(chunk)
-                return_path = os.path.abspath(download_path)
-
+        return_path = self._download_content(url, filepath)
         logger.info(f"Downloaded flow to {return_path} (ID: {flow_id})")
         return return_path
 

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from tableauserverclient.server.endpoint.schedules_endpoint import AddResponse
 
 io_types_r = (io.BytesIO, io.BufferedReader)
-io_types_w = (io.BytesIO, io.BufferedWriter)
 
 # The maximum size of a file that can be published in a single request is 64MB
 FILESIZE_LIMIT = 1024 * 1024 * 64  # 64MB

--- a/tableauserverclient/server/endpoint/workbooks_endpoint.py
+++ b/tableauserverclient/server/endpoint/workbooks_endpoint.py
@@ -1,15 +1,13 @@
-from email.message import Message
 import copy
 import io
 import logging
 import os
-from contextlib import closing
 from pathlib import Path
 
 from tableauserverclient.models.permissions_item import PermissionsRule
 from tableauserverclient.server.query import QuerySet
 
-from tableauserverclient.server.endpoint.endpoint import QuerysetEndpoint, api, parameter_added_in
+from tableauserverclient.server.endpoint.endpoint import DownloadableMixin, QuerysetEndpoint, api, parameter_added_in
 from tableauserverclient.server.endpoint.exceptions import (
     DUPLICATE_EXTRACT_JOB_CODE,
     InternalServerError,
@@ -21,8 +19,6 @@ from tableauserverclient.server.endpoint.permissions_endpoint import _Permission
 from tableauserverclient.server.endpoint.resource_tagger import TaggingMixin
 
 from tableauserverclient.filesys_helpers import (
-    to_filename,
-    make_download_path,
     get_file_type,
     get_file_object_size,
 )
@@ -67,7 +63,7 @@ PathOrFileW = FilePath | FileObjectW
 _UNSET = object()
 
 
-class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
+class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem], DownloadableMixin):
     def __init__(self, parent_srv: "Server") -> None:
         super().__init__(parent_srv)
         self._permissions = _PermissionsEndpoint(parent_srv, lambda: self.baseurl)
@@ -1123,22 +1119,7 @@ class Workbooks(QuerysetEndpoint[WorkbookItem], TaggingMixin[WorkbookItem]):
         if not include_extract:
             url += "?includeExtract=False"
 
-        with closing(self.get_request(url, parameters={"stream": True})) as server_response:
-            m = Message()
-            m["Content-Disposition"] = server_response.headers["Content-Disposition"]
-            filename = m.get_filename(failobj="")
-            if isinstance(filepath, io_types_w):
-                for chunk in server_response.iter_content(1024):  # 1KB
-                    filepath.write(chunk)
-                return_path = filepath
-            else:
-                filename = to_filename(os.path.basename(filename))
-                download_path = make_download_path(filepath, filename)
-                with open(download_path, "wb") as f:
-                    for chunk in server_response.iter_content(1024):  # 1KB
-                        f.write(chunk)
-                return_path = os.path.abspath(download_path)
-
+        return_path = self._download_content(url, filepath)
         logger.info(f"Downloaded workbook revision {revision_number} to {return_path} (ID: {workbook_id})")
         return return_path
 


### PR DESCRIPTION
## Summary
- Introduces `DownloadableMixin` in `endpoint.py` with a single private helper `_download_content(url, filepath)` that streams a server response to a file path or writable file object
- Applies the mixin to `Workbooks`, `Datasources`, and `Flows`, replacing three identical 15-line streaming blocks with a single shared implementation
- Removes now-dead `io_types_w` and duplicate `io_types` module-level variables from all three endpoint files
- Exports `DownloadableMixin` from the endpoint package `__all__`

## Schema compliance
Download endpoints return raw binary bodies outside the XML schema scope. All response handling (Content-Disposition header parsing, chunked streaming, octet-stream bodies) is implemented at the HTTP layer identically to the pre-refactor code. No schema-level gaps found.

## Test plan
- [x] Full suite: 843 passed, 1 skipped -- no regressions
- [x] mypy: no issues
- [x] Verify `server.workbooks.download(id, filepath=tmp_path)` writes a file and returns an absolute path
- [x] Verify `server.workbooks.download(id, filepath=io.BytesIO())` writes to the buffer and returns the buffer object
- [x] Verify `server.datasources.download` behaves identically
- [x] Confirm `from tableauserverclient.server.endpoint import DownloadableMixin` is importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)