### PR TITLE
feat: add operator parameter to vf() for range filters

### DIFF
--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -349,7 +349,7 @@ class _DataExportOptions(RequestOptionsBase):
         self._append_view_filters(params)
         return params
 
-    def vf(self, name: str, value: str) -> Self:
+    def vf(self, name: str, value: str, operator: str | None = None) -> Self:
         """Apply a filter based on a column within the view.
         Note that when filtering on a boolean type field, the only valid values are 'true' and 'false'
 
@@ -363,12 +363,18 @@ class _DataExportOptions(RequestOptionsBase):
         value: str
             The value to filter on
 
+        operator: str, optional
+            A comparison operator from RequestOptions.Operator (e.g. 'gt', 'lte').
+            When provided the filter is encoded as ``operator:value``.
+            Defaults to an exact-match filter when omitted.
+
         Returns
         -------
         Self
             The current object
         """
-        self.view_filters.append((name, value))
+        encoded_value = f"{operator}:{value}" if operator else value
+        self.view_filters.append((name, encoded_value))
         return self
 
     def parameter(self, name: str, value: str) -> Self:

--- a/test/test_request_option.py
+++ b/test/test_request_option.py
@@ -238,6 +238,23 @@ def test_vf(server: TSC.Server) -> None:
     assert "tabloid" in query_string["type"]
 
 
+def test_vf_with_operator(server: TSC.Server) -> None:
+    server.version = "3.23"
+    with requests_mock.mock() as m:
+        m.get(requests_mock.ANY)
+        url = server.workbooks.baseurl + "/456/data"
+        opts = TSC.PDFRequestOptions()
+        opts.vf("Sales", "1000", operator=TSC.RequestOptions.Operator.GreaterThan)
+        opts.vf("Region", "West")
+
+        resp = server.workbooks.get_request(url, request_object=opts)
+        query_string = parse_qs(resp.request.query)
+    assert "vf_sales" in query_string
+    assert "gt:1000" in query_string["vf_sales"]
+    assert "vf_region" in query_string
+    assert "west" in query_string["vf_region"]
+
+
 # Test req_options for versions below 3.7
 def test_vf_legacy(server: TSC.Server) -> None:
     server.version = "3.6"


### PR DESCRIPTION
## Summary
- Adds optional `operator` parameter to `RequestOptions.vf()` (and by inheritance `PDFRequestOptions`, `ImageRequestOptions`, etc.)
- When provided, encodes the filter as `operator:value` (e.g. `gt:1000`) matching the REST API's range filter syntax
- Backwards-compatible: omitting `operator` preserves existing exact-match behaviour

Closes #1752

## Test plan
- [ ] `test_vf_with_operator` in `test/test_request_option.py` verifies `gt:1000` encoding
- [ ] Existing `vf` tests continue to pass (exact-match unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)