### PR TITLE
Add "stale" action to help manage issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'good first issue,Design Proposal,in-progress'
+          exempt-pr-labels: 'in-progress'
+
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+
+          close-issue-reason: 'not_planned'
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this is still relevant, please comment to keep it open.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this is still active work, please comment or push a new commit to keep it open.
+          close-issue-message: >
+            Closing due to inactivity. If this is still relevant, please reopen or file a new issue.
+          close-pr-message: >
+            Closing due to inactivity. Feel free to reopen if you'd like to continue this work.


### PR DESCRIPTION
Adds the "stale" action to monitor issues and pull requests that are old and going stale. See the issue for longer discussion of the config values we'll start with.

Closes #1680