### PR TITLE
security: add environment gate to production PyPI publish job

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -75,6 +75,7 @@ jobs:
     needs: smoke-test-pypi
     if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Adds `environment: pypi` to the `publish-pypi` job in `.github/workflows/publish-pypi.yml`.

Without this, any repo write holder can push a tag matching `v*.*.*`, trigger `workflow_dispatch`, or publish a release and the production PyPI publish runs immediately with no human checkpoint. The `pypi` GitHub Environment is already configured on this repo with required reviewers (`tableau/devplat`), `can_admins_bypass: false`, and `prevent_self_review: true` — this change wires the job to it.

No logic changes — one line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)