### PR TITLE
Fix CONTRIBUTORS.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To see sample code that works directly with the REST API (in Java, Python, or Po
 For more information on installing and using TSC, see the documentation:
 <https://tableau.github.io/server-client-python/docs/>
  
-To contribute, see our [Developer Guide](https://tableau.github.io/server-client-python/docs/dev-guide). A list of all our contributors to date is in [CONTRIBUTORS.md].
+To contribute, see our [Developer Guide](https://tableau.github.io/server-client-python/docs/dev-guide). A list of all our contributors to date is in [CONTRIBUTORS.md](CONTRIBUTORS.md).
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftableau%2Fserver-client-python.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftableau%2Fserver-client-python?ref=badge_large)


### PR DESCRIPTION
The README says "A list of all our contributors to date is in [CONTRIBUTORS.md]." — a reference-style link with no matching definition anywhere in the file, so GitHub renders it as literal bracketed text rather than a link. This makes it an inline link to `CONTRIBUTORS.md`, which exists at the repository root.

**Verification:** `pip install -e ".[test]"` + `python -m pytest test` pass locally (866 passed, 1 skipped; Python 3.14, macOS arm64).

Prepared with AI assistance (Claude); the missing definition and the target file's existence were both verified.