### PR TITLE
docs: note vf() view filters are exact-match only

### DIFF
--- a/docs/api-ref.md
+++ b/docs/api-ref.md
@@ -5580,6 +5580,8 @@ You can use the `Sort` and `RequestOptions` classes to filter and sort the follo
 
 You can use the `ImageRequestOptions` and `PDFRequestOptions` to set options for views returned as images and PDF files.
 
+**Note**: View filters set via `vf()` on `CSVRequestOptions`, `ImageRequestOptions`, or `PDFRequestOptions` apply exact-match only. Operators like greater-than, less-than, contains, or value ranges are not supported by the underlying REST endpoint. See the Tableau REST API [filtering documentation](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm) for the server-side detail. If you need range filtering for exports, expose the range bounds as workbook parameters and use `.parameter()` to set them.
+
 For more information about filtering and sorting, see [Filter and Sort](filter-sort).
 
 


### PR DESCRIPTION
Adds a note near the shared `ImageRequestOptions` / `PDFRequestOptions` / `CSVRequestOptions` section explaining that `vf()` view filters are exact-match only, with a pointer to the Tableau REST API docs and mentioning the workbook-parameter workaround for range filtering.

Followup to closed PR #1813, which had tried to add operator support (`gt:`, `lt:` etc.) to `vf()` client-side — verified against server code that the `vf_*` REST endpoint parses values by data type with no operator recognition, silently dropping filters like `vf_sales=gt:1000`. The client can't fix this; a note is the right response.

## Test plan

- [x] visual review of the rendered section — sits between the "You can use `ImageRequestOptions` and `PDFRequestOptions`..." intro and the "For more information about filtering and sorting..." link
- [ ] once merged, links resolve on tableau.github.io/server-client-python