### PR TITLE
ci: exempt Server-Side Enhancement label from stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'good first issue,Design Proposal,in-progress'
+          exempt-issue-labels: 'good first issue,Design Proposal,in-progress,server-side-gap'
           exempt-pr-labels: 'in-progress'
 
           days-before-issue-stale: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'good first issue,Design Proposal,in-progress,server-side-gap'
+          exempt-issue-labels: 'good first issue,Design Proposal,in-progress,Server-Side Enhancement'
           exempt-pr-labels: 'in-progress'
 
           days-before-issue-stale: 60


### PR DESCRIPTION
## Motivation

Some issues in this repo are legitimately blocked on Tableau server REST
API work, not on anything this client can fix. Without an exemption they
flap between "labeled stale" and "manually rescued" every 60 days,
because the user has no client-side activity they can add. Exempting the
existing `Server-Side Enhancement` label lets those stay open as a live
tracker.

Alternative considered: let stale close them and have the docs list
point to both open and closed bugs under the label. Chose this direction
so the label doubles as a live tracker rather than a historical index.

Companion to #1842 which adds a "Known server-side limitations" section
to `docs/api-ref.md` and points readers at this label.

## Behavior change

`.github/workflows/stale.yml` gains `Server-Side Enhancement` in the
`exempt-issue-labels` list. Existing exempt labels (`good first issue`,
`Design Proposal`, `in-progress`) are preserved.

Once merged, the next `workflow_dispatch` run removes the `stale` label
from any issue that also has `Server-Side Enhancement` -- currently
#1716, #1658, #1537, #1508.

## Test plan

- [x] YAML syntax valid
- [x] Existing exempt labels preserved
- [ ] Post-merge: manually trigger the workflow and confirm the four
  currently-stale server-side issues get their labels removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)