### PR TITLE
[tabcmd] fix: preserve case of customSubscriptionEmail and customSubscriptionFooter (#1849)

### DIFF
--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -733,13 +733,13 @@ class SiteRequest:
                 site_item.custom_subscription_email_enabled
             ).lower()
         if site_item.custom_subscription_email is not None:
-            site_element.attrib["customSubscriptionEmail"] = str(site_item.custom_subscription_email).lower()
+            site_element.attrib["customSubscriptionEmail"] = str(site_item.custom_subscription_email)
         if site_item.custom_subscription_footer_enabled is not None:
             site_element.attrib["customSubscriptionFooterEnabled"] = str(
                 site_item.custom_subscription_footer_enabled
             ).lower()
         if site_item.custom_subscription_footer is not None:
-            site_element.attrib["customSubscriptionFooter"] = str(site_item.custom_subscription_footer).lower()
+            site_element.attrib["customSubscriptionFooter"] = str(site_item.custom_subscription_footer)
         if site_item.ask_data_mode is not None:
             site_element.attrib["askDataMode"] = str(site_item.ask_data_mode)
         if site_item.named_sharing_enabled is not None:
@@ -837,13 +837,13 @@ class SiteRequest:
                 site_item.custom_subscription_email_enabled
             ).lower()
         if site_item.custom_subscription_email is not None:
-            site_element.attrib["customSubscriptionEmail"] = str(site_item.custom_subscription_email).lower()
+            site_element.attrib["customSubscriptionEmail"] = str(site_item.custom_subscription_email)
         if site_item.custom_subscription_footer_enabled is not None:
             site_element.attrib["customSubscriptionFooterEnabled"] = str(
                 site_item.custom_subscription_footer_enabled
             ).lower()
         if site_item.custom_subscription_footer is not None:
-            site_element.attrib["customSubscriptionFooter"] = str(site_item.custom_subscription_footer).lower()
+            site_element.attrib["customSubscriptionFooter"] = str(site_item.custom_subscription_footer)
         if site_item.ask_data_mode is not None:
             site_element.attrib["askDataMode"] = str(site_item.ask_data_mode)
         if site_item.named_sharing_enabled is not None:

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -205,6 +205,36 @@ def test_update_missing_id(server: TSC.Server) -> None:
         server.sites.update(single_site)
 
 
+def test_update_subscription_email_and_footer_preserve_case() -> None:
+    # Regression for #1849: RequestFactory used to .lower() customSubscriptionEmail
+    # and customSubscriptionFooter, silently mangling caller intent. Footer
+    # especially, since it is displayed verbatim in outgoing subscription emails.
+    site = TSC.SiteItem(name="X", content_url="x")
+    site.custom_subscription_email = "Sales@Company.com"
+    site.custom_subscription_footer = "Sent by Tableau -- Confidential. See https://Example.com/Legal"
+
+    xml_bytes = RequestFactory.Site.update_req(site)
+    xml_text = xml_bytes.decode("utf-8")
+
+    assert 'customSubscriptionEmail="Sales@Company.com"' in xml_text, xml_text
+    assert (
+        'customSubscriptionFooter="Sent by Tableau -- Confidential. See https://Example.com/Legal"' in xml_text
+    ), xml_text
+
+
+def test_create_subscription_email_and_footer_preserve_case() -> None:
+    # Same regression for the create-site path.
+    site = TSC.SiteItem(name="X", content_url="x")
+    site.custom_subscription_email = "Support@Company.com"
+    site.custom_subscription_footer = "COMPANY, Inc. -- All Rights Reserved."
+
+    xml_bytes = RequestFactory.Site.create_req(site)
+    xml_text = xml_bytes.decode("utf-8")
+
+    assert 'customSubscriptionEmail="Support@Company.com"' in xml_text, xml_text
+    assert 'customSubscriptionFooter="COMPANY, Inc. -- All Rights Reserved."' in xml_text, xml_text
+
+
 def test_null_site_quota(server: TSC.Server) -> None:
     test_site = TSC.SiteItem("testname", "testcontenturl", tier_explorer_capacity=1, user_quota=None)
     assert test_site.tier_explorer_capacity == 1

--- a/test/test_site.py
+++ b/test/test_site.py
@@ -213,13 +213,12 @@ def test_update_subscription_email_and_footer_preserve_case() -> None:
     site.custom_subscription_email = "Sales@Company.com"
     site.custom_subscription_footer = "Sent by Tableau -- Confidential. See https://Example.com/Legal"
 
-    xml_bytes = RequestFactory.Site.update_req(site)
-    xml_text = xml_bytes.decode("utf-8")
-
-    assert 'customSubscriptionEmail="Sales@Company.com"' in xml_text, xml_text
-    assert (
-        'customSubscriptionFooter="Sent by Tableau -- Confidential. See https://Example.com/Legal"' in xml_text
-    ), xml_text
+    site_elem = ET.fromstring(RequestFactory.Site.update_req(site)).find(".//site")
+    assert site_elem is not None
+    assert site_elem.attrib["customSubscriptionEmail"] == "Sales@Company.com"
+    assert site_elem.attrib["customSubscriptionFooter"] == (
+        "Sent by Tableau -- Confidential. See https://Example.com/Legal"
+    )
 
 
 def test_create_subscription_email_and_footer_preserve_case() -> None:
@@ -228,11 +227,10 @@ def test_create_subscription_email_and_footer_preserve_case() -> None:
     site.custom_subscription_email = "Support@Company.com"
     site.custom_subscription_footer = "COMPANY, Inc. -- All Rights Reserved."
 
-    xml_bytes = RequestFactory.Site.create_req(site)
-    xml_text = xml_bytes.decode("utf-8")
-
-    assert 'customSubscriptionEmail="Support@Company.com"' in xml_text, xml_text
-    assert 'customSubscriptionFooter="COMPANY, Inc. -- All Rights Reserved."' in xml_text, xml_text
+    site_elem = ET.fromstring(RequestFactory.Site.create_req(site)).find(".//site")
+    assert site_elem is not None
+    assert site_elem.attrib["customSubscriptionEmail"] == "Support@Company.com"
+    assert site_elem.attrib["customSubscriptionFooter"] == "COMPANY, Inc. -- All Rights Reserved."
 
 
 def test_null_site_quota(server: TSC.Server) -> None:


### PR DESCRIPTION
Closes #1849.

## Motivation

`RequestFactory.Site.update_req` and `create_req` called `str(value).lower()`
on `customSubscriptionEmail` and `customSubscriptionFooter` when serializing.
Email was cosmetic (SMTP is case-insensitive in practice) but footer was
functionally broken -- the footer text is displayed verbatim in outgoing
subscription emails, so lowercasing removed company-name casing, sentence
capitalization, brand terms. Any TSC caller setting a customer-facing footer
got a mangled result with no workaround short of the web UI.

Discovered while implementing tabcmd editsite parity
(tableau/tabcmd#437, tableau/tabcmd#452).

## Behavior change

**For users:** `customSubscriptionEmail` and `customSubscriptionFooter` now
serialize verbatim rather than lowercased. If any downstream test or script
asserts against the lowercased-value bug, it will need updating. The paired
`*Enabled` boolean attributes still get `.lower()`'d (they need to serialize
as `"true"`/`"false"`).

**Verification against server:** Read the server-side write chain to confirm
the server does not itself lowercase these fields.
`RestApiSiteParamsBuilder.setCustomEmail` / `setCustomEmailFooter` pass the
values through verbatim into `SiteParams.withCustom*` and thence to
`Site.setCustomReplyToEmail` (JPA column `custom_subscription_email`). No
`toLowerCase()` anywhere in the write chain. `SiteParamsValidator.java:170`
validates the email is well-formed; does not modify case. Footer has no
validation. Cross-checked against tabcmd Classic, which sends both strings
verbatim as multipart form parts.

## Test plan

- [x] Two new regression tests in `test/test_site.py` -- one for `update_req`,
  one for `create_req`, asserting exact case survives to XML request body
- [x] Full `test_site.py` suite: 28 passed
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)