### PR TITLE
Improve the stale actions config now that it's been running for a bit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Mark stale issues and pull requests
+name: Stale issues and pull requests
 
 on:
   schedule:
@@ -8,6 +8,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   stale:
@@ -24,6 +25,8 @@ jobs:
           days-before-issue-close: 14
           days-before-pr-stale: 90
           days-before-pr-close: 14
+
+          operations-per-run: 300
 
           close-issue-reason: 'not_planned'
 


### PR DESCRIPTION
- increase operations-per-run beyond the default 30
- add permission for action to write its cache

Taken together, these should let the action run on the oldest issues and PRs we have.