### PR TITLE
docs: add pull-request template with Motivation / Behavior / Test plan

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Delete sections that don't apply. The prompts are here to make review
+faster, not to add ceremony -- one sentence per section is often enough.
+-->
+
+## Motivation
+
+<!--
+Why now. Link the issue, incident, user report, or parent PR. If this
+is preparation for another change, name it. If it's cleanup, say what
+prompted it.
+-->
+
+## Behavior change
+
+<!--
+For users of the library or CLI: what changes in observable behavior?
+"None -- refactor only" is a valid answer. If a public symbol, endpoint
+signature, exception type, or return value shape changes, call it out
+here and in the CHANGELOG so downstream code isn't surprised.
+-->
+
+## Test plan
+
+<!--
+What's exercised by the tests in this PR. If any behavior claim in the
+description ISN'T covered by a test (e.g. "verified manually against a
+live server", "matches server behavior at REST endpoint X"), say so
+explicitly so reviewers know what's on trust vs. what regression tests
+will catch.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!--
 Delete sections that don't apply. The prompts are here to make review
-faster, not to add ceremony -- one sentence per section is often enough.
+faster, not to add ceremony - one sentence per section is often enough.
+See contributing.md for background; add a bullet to CHANGELOG.md under
+Unreleased for any user-visible behavior change.
 -->
 
 ## Motivation
@@ -15,7 +17,7 @@ prompted it.
 
 <!--
 For users of the library or CLI: what changes in observable behavior?
-"None -- refactor only" is a valid answer. If a public symbol, endpoint
+"None - refactor only" is a valid answer. If a public symbol, endpoint
 signature, exception type, or return value shape changes, call it out
 here and in the CHANGELOG so downstream code isn't surprised.
 -->


### PR DESCRIPTION
## Motivation

Multiple recent reviews on this repo have surfaced the same three
questions across unrelated PRs: "why now?", "does anything change for
downstream users?", and "which claims in the body are covered by tests
vs. verified manually?" Answering them once per PR beats being asked
each time.

## Behavior change

None -- adds `.github/PULL_REQUEST_TEMPLATE.md`. GitHub picks this up
automatically when opening a new PR against the repo.

## Test plan

None -- docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)