### PR TITLE
docs+fix: clarify xml/defusedxml split; harden metric_item parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 
 dependencies = [
-    'defusedxml>=0.7.1',  # latest as at 7/31/23
+    'defusedxml>=0.7.1',  # latest as at 7/31/23; use for all XML parsing — stdlib xml is unsafe against XXE. XML building (Element/SubElement/tostring) still uses stdlib as defusedxml has no equivalents.
     'packaging>=23.1',   # latest as at 7/31/23
     'requests>=2.32',  # latest as at 7/31/23
     'urllib3>=2.6.0,<3',

--- a/tableauserverclient/models/collection_item.py
+++ b/tableauserverclient/models/collection_item.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import Element  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 from typing_extensions import Self

--- a/tableauserverclient/models/collection_item.py
+++ b/tableauserverclient/models/collection_item.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from xml.etree.ElementTree import Element  # building XML request bodies only; use defusedxml for parsing
+from xml.etree.ElementTree import Element  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 from typing_extensions import Self

--- a/tableauserverclient/models/data_freshness_policy_item.py
+++ b/tableauserverclient/models/data_freshness_policy_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from tableauserverclient.models.property_decorators import property_is_enum, property_not_nullable
 from .interval_item import IntervalItem

--- a/tableauserverclient/models/data_freshness_policy_item.py
+++ b/tableauserverclient/models/data_freshness_policy_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from tableauserverclient.models.property_decorators import property_is_enum, property_not_nullable
 from .interval_item import IntervalItem

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,6 +1,6 @@
 import copy
 import datetime
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/datasource_item.py
+++ b/tableauserverclient/models/datasource_item.py
@@ -1,6 +1,6 @@
 import copy
 import datetime
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/extract_item.py
+++ b/tableauserverclient/models/extract_item.py
@@ -1,5 +1,5 @@
 from defusedxml.ElementTree import fromstring
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 
 class ExtractItem:

--- a/tableauserverclient/models/extract_item.py
+++ b/tableauserverclient/models/extract_item.py
@@ -1,5 +1,5 @@
 from defusedxml.ElementTree import fromstring
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 
 class ExtractItem:

--- a/tableauserverclient/models/flow_item.py
+++ b/tableauserverclient/models/flow_item.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import copy
 import datetime
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/flow_item.py
+++ b/tableauserverclient/models/flow_item.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import copy
 import datetime
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/groupset_item.py
+++ b/tableauserverclient/models/groupset_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 from typing_extensions import Self

--- a/tableauserverclient/models/groupset_item.py
+++ b/tableauserverclient/models/groupset_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 from typing_extensions import Self

--- a/tableauserverclient/models/location_item.py
+++ b/tableauserverclient/models/location_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 
 class LocationItem:

--- a/tableauserverclient/models/location_item.py
+++ b/tableauserverclient/models/location_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 
 class LocationItem:

--- a/tableauserverclient/models/metric_item.py
+++ b/tableauserverclient/models/metric_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from datetime import datetime
 
 from tableauserverclient.datetime_helpers import parse_datetime

--- a/tableauserverclient/models/metric_item.py
+++ b/tableauserverclient/models/metric_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+from defusedxml.ElementTree import fromstring  # parsing server responses; defusedxml protects against XML attacks
 from datetime import datetime
 
 from tableauserverclient.datetime_helpers import parse_datetime
@@ -127,7 +127,7 @@ class MetricItem:
         ns,
     ) -> list["MetricItem"]:
         all_metric_items = list()
-        parsed_response = ET.fromstring(resp)
+        parsed_response = fromstring(resp)
         all_metric_xml = parsed_response.findall(".//t:metric", namespaces=ns)
         for metric_xml in all_metric_xml:
             all_metric_items.append(cls.from_xml(metric_xml, ns))

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/permissions_item.py
+++ b/tableauserverclient/models/permissions_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 from typing import overload
 
 from defusedxml.ElementTree import fromstring

--- a/tableauserverclient/models/project_item.py
+++ b/tableauserverclient/models/project_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from typing import overload
 
 from defusedxml.ElementTree import fromstring

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from datetime import datetime
 from typing import TYPE_CHECKING
 

--- a/tableauserverclient/models/schedule_item.py
+++ b/tableauserverclient/models/schedule_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 from datetime import datetime
 from typing import TYPE_CHECKING
 

--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-import xml  # for xml.etree.ElementTree.ParseError exception type only; defusedxml raises this same class
+from xml.etree.ElementTree import ParseError  # exception class only; defusedxml raises this same class
 
 from defusedxml.ElementTree import fromstring
 from tableauserverclient.helpers.logging import logger
@@ -61,7 +61,7 @@ class ServerInfoItem:
     def from_response(cls, resp, ns):
         try:
             parsed_response = fromstring(resp)
-        except xml.etree.ElementTree.ParseError as error:
+        except ParseError as error:
             logger.exception(f"Unexpected response for ServerInfo: {resp}")
             return cls("Unknown", "Unknown", "Unknown")
         except Exception as error:

--- a/tableauserverclient/models/server_info_item.py
+++ b/tableauserverclient/models/server_info_item.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-import xml
+import xml  # for xml.etree.ElementTree.ParseError exception type only; defusedxml raises this same class
 
 from defusedxml.ElementTree import fromstring
 from tableauserverclient.helpers.logging import logger

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,5 +1,5 @@
 import warnings
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/site_item.py
+++ b/tableauserverclient/models/site_item.py
@@ -1,5 +1,5 @@
 import warnings
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/tag_item.py
+++ b/tableauserverclient/models/tag_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/tag_item.py
+++ b/tableauserverclient/models/tag_item.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -1,5 +1,5 @@
 import io
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 from datetime import datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING

--- a/tableauserverclient/models/user_item.py
+++ b/tableauserverclient/models/user_item.py
@@ -1,5 +1,5 @@
 import io
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from datetime import datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING

--- a/tableauserverclient/models/virtual_connection_item.py
+++ b/tableauserverclient/models/virtual_connection_item.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from typing import Callable
 from collections.abc import Iterable
-from xml.etree.ElementTree import Element  # building XML request bodies only; use defusedxml for parsing
+from xml.etree.ElementTree import Element  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/virtual_connection_item.py
+++ b/tableauserverclient/models/virtual_connection_item.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from typing import Callable
 from collections.abc import Iterable
-from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import Element  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/webhook_item.py
+++ b/tableauserverclient/models/webhook_item.py
@@ -1,5 +1,5 @@
 import re
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/webhook_item.py
+++ b/tableauserverclient/models/webhook_item.py
@@ -1,5 +1,5 @@
 import re
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 
 from defusedxml.ElementTree import fromstring
 

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import uuid
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from typing import Callable, overload
 
 from defusedxml.ElementTree import fromstring

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import uuid
-import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
+import xml.etree.ElementTree as ET  # type annotation only; parsing uses defusedxml
 from typing import Callable, overload
 
 from defusedxml.ElementTree import fromstring

--- a/tableauserverclient/server/endpoint/endpoint.py
+++ b/tableauserverclient/server/endpoint/endpoint.py
@@ -8,7 +8,7 @@ from tableauserverclient import datetime_helpers as datetime
 import abc
 from packaging.version import Version
 from functools import wraps
-from xml.etree.ElementTree import ParseError
+from xml.etree.ElementTree import ParseError  # exception type only; defusedxml raises this same class
 from typing import (
     Any,
     Callable,

--- a/tableauserverclient/server/request_factory.py
+++ b/tableauserverclient/server/request_factory.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # building XML request bodies only; use defusedxml for parsing
 from typing import Any, Callable, TypeVar, TYPE_CHECKING
 from collections.abc import Iterable
 


### PR DESCRIPTION
## Motivation

TSC uses both `xml.etree.ElementTree` (stdlib) and `defusedxml.ElementTree`
across the codebase, and the pattern isn't obvious from a fresh reading.
Frontier AI's recent security analysis of all OSS Salesforce repos flagged
these stdlib `xml.etree.ElementTree` imports as a potential XXE concern.

The audit uncovered a real defect: `metric_item.MetricItem.from_response`
was parsing untrusted server bytes with stdlib
`xml.etree.ElementTree.fromstring`, which is XXE-exposed. It now uses
`defusedxml.ElementTree.fromstring`, matching every other `from_response`
/ `from_xml` parsing site in the codebase.

`server_info_item.py` also had a fragile coupling: its `except
xml.etree.ElementTree.ParseError` branch only worked because
`defusedxml.ElementTree` transitively imports `xml.etree` for side
effects. It now uses an explicit `from xml.etree.ElementTree import
ParseError`.

Elsewhere, stdlib `xml.etree.ElementTree` is retained only for building
outbound request bodies (`Element` / `SubElement` / `tostring`) and as a
type annotation for already-parsed inputs. defusedxml doesn't provide a
builder equivalent, so we can't simplify by using it everywhere.

Inline comments on each import site answer the security-analysis
question locally, so future audits can confirm the intent without
re-tracing every usage, and so a well-meaning "swap stdlib for
defusedxml" cleanup doesn't accidentally break outbound XML building.

## Changes

- **Hardening**: `metric_item.py` - `MetricItem.from_response` now
  parses server responses with `defusedxml.ElementTree.fromstring`.
  Untrusted-input parsing is now XXE-safe here.
- **Cleanup**: `server_info_item.py` - explicit `from
  xml.etree.ElementTree import ParseError`, removing the fragile
  transitive-import dependency.
- **Docs**: One inline comment on every `import xml.etree.ElementTree`
  line (21 files) explaining the intent. Expanded comment on the
  `defusedxml` line in `pyproject.toml` describing the split.

## Test plan

- [x] Full suite passes, mypy + `black --check` clean.

Generated with [Claude Code](https://claude.com/claude-code)