### PR TITLE
ci: shield issues with an open PR from the stale bot

### DIFF
--- a/.github/workflows/link-issues-to-prs.yml
+++ b/.github/workflows/link-issues-to-prs.yml
@@ -1,0 +1,72 @@
+name: Mark linked issues in-progress
+
+# When an open PR references an issue with Closes/Fixes/Resolves, apply the
+# 'in-progress' label to that issue so the stale bot leaves it alone (the
+# stale workflow already exempts 'in-progress'). Remove the label when the
+# PR closes without merging, so a genuinely abandoned PR does not keep its
+# referenced issues shielded forever.
+#
+# actions/stale looks at issue-level events only; a PR that references an
+# issue does not reset the issue's stale timer or move it off the stale
+# label. This workflow bridges that gap.
+#
+# Security note: the script only reads pr.body, extracts decimal issue
+# numbers via a fixed regex, and passes those numbers to the REST API.
+# Body content is never expanded into a run: command or a shell.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review, closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const nums = [...new Set([...body.matchAll(re)].map(m => Number(m[1])))];
+            if (nums.length === 0) {
+              core.info('No Closes/Fixes/Resolves references found; nothing to do.');
+              return;
+            }
+
+            // Apply the label while the PR is open. Remove it when the PR
+            // closes without merging (merged PRs also close, but the issue
+            // will be auto-closed by GitHub once the merge lands, so the
+            // in-progress label on it is harmless).
+            const shouldLabel = pr.state === 'open';
+            const shouldUnlabel = pr.state === 'closed' && !pr.merged;
+
+            for (const n of nums) {
+              try {
+                if (shouldLabel) {
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: n,
+                    labels: ['in-progress'],
+                  });
+                  core.info(`#${n}: added in-progress`);
+                } else if (shouldUnlabel) {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: n,
+                    name: 'in-progress',
+                  }).catch(err => {
+                    // 404 just means the label was not present; not an error.
+                    if (err.status !== 404) throw err;
+                  });
+                  core.info(`#${n}: removed in-progress (PR closed unmerged)`);
+                }
+              } catch (err) {
+                // Do not fail the whole run on one bad reference; log and continue.
+                core.warning(`#${n}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/link-issues-to-prs.yml
+++ b/.github/workflows/link-issues-to-prs.yml
@@ -32,41 +32,73 @@ jobs:
             const pr = context.payload.pull_request;
             const body = pr.body || '';
             const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-            const nums = [...new Set([...body.matchAll(re)].map(m => Number(m[1])))];
-            if (nums.length === 0) {
-              core.info('No Closes/Fixes/Resolves references found; nothing to do.');
-              return;
+            // Cross-repo references (owner/repo#123) are intentionally skipped;
+            // this workflow only labels issues in the current repo.
+            const MAX_REFS = 50; // cap runaway PR bodies from forks (pull_request_target).
+            const extract = (text) => [...new Set(
+              [...(text || '').matchAll(re)].map(m => Number(m[1]))
+            )].slice(0, MAX_REFS);
+
+            const current = extract(body);
+
+            // On `edited`, compute which references were REMOVED so their
+            // labels come off. Without this, a PR that once said "Closes #42"
+            // and no longer does would leave #42 shielded indefinitely.
+            let removed = [];
+            if (context.payload.action === 'edited') {
+              const prevBody = context.payload.changes?.body?.from;
+              if (prevBody !== undefined) {
+                const previous = extract(prevBody);
+                const now = new Set(current);
+                removed = previous.filter(n => !now.has(n));
+              }
             }
 
             // Apply the label while the PR is open. Remove it when the PR
             // closes without merging (merged PRs also close, but the issue
             // will be auto-closed by GitHub once the merge lands, so the
-            // in-progress label on it is harmless).
+            // in-progress label on it is harmless). Also remove on `edited`
+            // when a reference was deleted from the body.
             const shouldLabel = pr.state === 'open';
-            const shouldUnlabel = pr.state === 'closed' && !pr.merged;
+            const closeUnlabel = pr.state === 'closed' && !pr.merged ? current : [];
+            const toUnlabel = [...new Set([...removed, ...closeUnlabel])];
 
-            for (const n of nums) {
-              try {
-                if (shouldLabel) {
+            if (current.length === 0 && toUnlabel.length === 0) {
+              core.info('No Closes/Fixes/Resolves references to process; nothing to do.');
+              return;
+            }
+
+            const removeLabelSafe = async (n) => {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: n,
+                name: 'in-progress',
+              }).catch(err => {
+                // 404 just means the label was not present; not an error.
+                if (err.status !== 404) throw err;
+              });
+              core.info(`#${n}: removed in-progress`);
+            };
+
+            if (shouldLabel) {
+              for (const n of current) {
+                try {
                   await github.rest.issues.addLabels({
                     ...context.repo,
                     issue_number: n,
                     labels: ['in-progress'],
                   });
                   core.info(`#${n}: added in-progress`);
-                } else if (shouldUnlabel) {
-                  await github.rest.issues.removeLabel({
-                    ...context.repo,
-                    issue_number: n,
-                    name: 'in-progress',
-                  }).catch(err => {
-                    // 404 just means the label was not present; not an error.
-                    if (err.status !== 404) throw err;
-                  });
-                  core.info(`#${n}: removed in-progress (PR closed unmerged)`);
+                } catch (err) {
+                  core.warning(`#${n}: ${err.message}`);
                 }
+              }
+            }
+
+            for (const n of toUnlabel) {
+              try {
+                await removeLabelSafe(n);
               } catch (err) {
-                // Do not fail the whole run on one bad reference; log and continue.
                 core.warning(`#${n}: ${err.message}`);
               }
             }


### PR DESCRIPTION
Companion to #1841.

## Motivation

`actions/stale` looks at issue-level events only when deciding to mark or close. A PR that references an issue via `Closes #NNN` / `Fixes #NNN` doesn't reset the issue's stale timer or remove the `stale` label, so an issue can auto-close by the bot even while a PR that closes it is in review. Concrete recent example: issues #993, #1067, #1200, #1127, #1135 all had open PRs referencing them via `Closes/Fixes` when the bot marked them stale on 2026-08-06.

## What this does

Adds `.github/workflows/link-issues-to-prs.yml`. When a PR is opened/edited/reopened/synchronized/marked-ready, it scans the body for `Closes`/`Fixes`/`Resolves` references and adds the `in-progress` label to each referenced issue. When a PR closes without being merged, the label is removed. The existing stale workflow already exempts `in-progress`, so no change to `stale.yml` is needed.

Merged PRs also fire the `closed` event, but GitHub auto-closes the referenced issue on merge, so leaving the label on a closed issue is harmless.

## Why `pull_request_target`

`pull_request` from a fork does not carry write permissions, and this workflow needs `issues: write`. `pull_request_target` runs with the base repo's permissions and is the standard pattern for labelers.

The typical `pull_request_target` risk is that untrusted PR content reaches a `run:` step or a shell. The script only reads `pr.body`, extracts decimal issue numbers with a fixed regex, and passes those numbers to the REST API. Body content never touches a shell. Reviewers should focus on that guarantee.

## Behavior change

- New file, ~72 lines including comments.
- No change to `stale.yml`, which continues to exempt `in-progress`.
- No change to existing issues; the labeler acts on PR events going forward. Existing stale-with-open-PR issues have been relabeled manually as a one-time backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)