### PR TITLE
security: bump urllib3 floor to 2.6.3 for CVE-2026-21441

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,16 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "development"
+    # Security advisories fire independently of the weekly schedule as long
+    # as the repo has "Dependabot security updates" enabled under
+    # Settings -> Code security. Weekly = non-security updates.
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "development"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 ## Unreleased
 
+* Bumped the urllib3 floor to 2.6.3 to pick up the fix for CVE-2026-21441
+  (GHSA-38jv-5279-wg99, 8.9 High): urllib3's streaming decompression
+  safeguards were bypassed when HTTP redirects were followed. TSC's manual
+  redirect walker (#1848) disables urllib3's built-in follower on new code
+  paths, but downstream callers using urllib3 directly (and TSC endpoints
+  that predate #1848) still relied on the built-in path, so the floor bump
+  closes the gap for all callers. The existing `<3` upper bound is unchanged.
 * Added `Projects.get_by_path(path)` to look up a project by its slash-separated
   hierarchy path (e.g. `"Marketing/Q1 Reports"`). The walk is performed level by
   level using the REST API name filter, so a path with *n* components issues *n*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     'defusedxml>=0.7.1',  # latest as at 7/31/23
     'packaging>=23.1',   # latest as at 7/31/23
     'requests>=2.32',  # latest as at 7/31/23
-    'urllib3>=2.6.0,<3',
+    'urllib3>=2.6.3,<3',
     'typing_extensions>=4.0',
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

FOSSA flagged **CVE-2026-21441** ([GHSA-38jv-5279-wg99](https://github.com/advisories/GHSA-38jv-5279-wg99), 8.9 High) against urllib3 2.6.0. The fix landed in urllib3 **2.6.3**: streaming decompression safeguards were bypassed when HTTP redirects were followed.

The existing `urllib3>=2.6.0,<3` specifier in `pyproject.toml` already permits 2.6.3, but because 2.6.0 remains a resolvable install, Dependabot did not open a range-bump PR, and the repo did not have Dependabot's security-updates side expressed in its config either. This PR closes that gap.

## Changes

- **`pyproject.toml`** — raise the urllib3 floor to `urllib3>=2.6.3,<3` so fresh resolves cannot land on a vulnerable release. The `<3` upper bound is unchanged; this is a floor bump within the existing supported range.
- **`.github/dependabot.yml`** — add `open-pull-requests-limit: 10` to both the pip and github-actions ecosystems so security PRs are not squeezed out by the default cap of 5. Add a comment on the pip block noting that security advisories fire independently of the weekly schedule as long as "Dependabot security updates" is enabled under Settings -> Code security.
- **`CHANGELOG.md`** — add an `## Unreleased` bullet naming the CVE, the GHSA, and the reason for the bump.

## Notes

TSC's manual redirect walker (#1848) disables urllib3's built-in follower on new code paths, but downstream callers using urllib3 directly (and TSC endpoints that predate #1848) still relied on the built-in path — so the floor bump closes the gap for all callers rather than only the paths already touched by #1848.

## Test plan

- [x] `python -c "import tomllib; tomllib.loads(open('pyproject.toml', 'rb').read().decode())"` parses.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses.
- [x] CI green on the PR.

Generated with [Claude Code](https://claude.com/claude-code)