### PR TITLE
Add Schedules.get_subscriptions_by_schedule to list a schedule's subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Unreleased
 
+* Added `Schedules.get_subscriptions_by_schedule(schedule_id)` to list the
+  subscriptions attached to a server schedule. The REST API has no per-schedule
+  subscriptions endpoint (only extract refresh tasks have one), so this pages
+  through the site's subscriptions and returns those whose `schedule_id`
+  matches, mirroring `get_extract_refresh_tasks`. Closes #1250.
 * Added `Projects.get_by_path(path)` to look up a project by its slash-separated
   hierarchy path (e.g. `"Marketing/Q1 Reports"`). The walk is performed level by
   level using the REST API name filter, so a path with *n* components issues *n*

--- a/tableauserverclient/server/endpoint/schedules_endpoint.py
+++ b/tableauserverclient/server/endpoint/schedules_endpoint.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 from .endpoint import Endpoint, api, parameter_added_in
 from .exceptions import MissingRequiredFieldError
 from tableauserverclient.server import RequestFactory
+from tableauserverclient.server.pager import Pager
 from tableauserverclient.models import PaginationItem, ScheduleItem, TaskItem, ExtractItem
 from tableauserverclient.models.schedule_item import parse_batch_schedule_state
 
@@ -18,7 +19,7 @@ OK = AddResponse(result=True, error=None, warnings=None, task_created=None)
 
 if TYPE_CHECKING:
     from ..request_options import RequestOptions
-    from ...models import DatasourceItem, WorkbookItem, FlowItem
+    from ...models import DatasourceItem, WorkbookItem, FlowItem, SubscriptionItem
 
 
 class Schedules(Endpoint):
@@ -281,6 +282,35 @@ class Schedules(Endpoint):
         extract_items = ExtractItem.from_response(server_response.content, self.parent_srv.namespace)
 
         return extract_items, pagination_item
+
+    @api(version="2.3")
+    def get_subscriptions_by_schedule(self, schedule_id: str) -> list["SubscriptionItem"]:
+        """
+        Returns the subscriptions that run on the specified server schedule.
+
+        Unlike extract refresh tasks, the REST API has no per-schedule
+        subscriptions endpoint, so this pages through the site's subscriptions
+        and keeps the ones whose schedule matches. On a site with many
+        subscriptions this issues one request per page.
+
+        REST API: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_subscriptions.htm#query_subscriptions
+
+        Parameters
+        ----------
+        schedule_id : str
+            The ID of the schedule to list subscriptions for.
+
+        Returns
+        -------
+        list[SubscriptionItem]
+            The subscriptions attached to the given schedule.
+        """
+        if not schedule_id:
+            error = "Schedule ID undefined"
+            raise ValueError(error)
+
+        logger.info(f"Querying subscriptions for schedule (ID: {schedule_id})")
+        return [sub for sub in Pager(self.parent_srv.subscriptions) if sub.schedule_id == schedule_id]
 
     @overload
     def batch_update_state(

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -28,6 +28,7 @@ ADD_DATASOURCE_TO_SCHEDULE = TEST_ASSET_DIR / "schedule_add_datasource.xml"
 ADD_FLOW_TO_SCHEDULE = TEST_ASSET_DIR / "schedule_add_flow.xml"
 GET_EXTRACT_TASKS_XML = TEST_ASSET_DIR / "schedule_get_extract_refresh_tasks.xml"
 BATCH_UPDATE_STATE = TEST_ASSET_DIR / "schedule_batch_update_state.xml"
+SUBSCRIPTION_GET_XML = TEST_ASSET_DIR / "subscription_get.xml"
 
 WORKBOOK_GET_BY_ID_XML = TEST_ASSET_DIR / "workbook_get_by_id.xml"
 DATASOURCE_GET_BY_ID_XML = TEST_ASSET_DIR / "datasource_get_by_id.xml"
@@ -437,6 +438,40 @@ def test_get_extract_refresh_tasks(server: TSC.Server) -> None:
         assert isinstance(extracts[0], list)
         assert 2 == len(extracts[0])
         assert "task1" == extracts[0][0].id
+
+
+def test_get_subscriptions_by_schedule(server: TSC.Server) -> None:
+    server.version = "2.3"
+
+    response_xml = SUBSCRIPTION_GET_XML.read_text()
+    with requests_mock.mock() as m:
+        # The two subscriptions in the asset sit on different schedules.
+        schedule_id = "7617c389-cdca-4940-a66e-69956fcebf3e"
+        m.get(server.subscriptions.baseurl, text=response_xml)
+
+        subscriptions = server.schedules.get_subscriptions_by_schedule(schedule_id)
+
+    assert isinstance(subscriptions, list)
+    assert 1 == len(subscriptions)
+    assert "382e9a6e-0c08-4a95-b6c1-c14df7bac3e4" == subscriptions[0].id
+    assert schedule_id == subscriptions[0].schedule_id
+
+
+def test_get_subscriptions_by_schedule_no_match(server: TSC.Server) -> None:
+    server.version = "2.3"
+
+    response_xml = SUBSCRIPTION_GET_XML.read_text()
+    with requests_mock.mock() as m:
+        m.get(server.subscriptions.baseurl, text=response_xml)
+
+        subscriptions = server.schedules.get_subscriptions_by_schedule("no-such-schedule")
+
+    assert [] == subscriptions
+
+
+def test_get_subscriptions_by_schedule_empty_id(server: TSC.Server) -> None:
+    with pytest.raises(ValueError):
+        server.schedules.get_subscriptions_by_schedule("")
 
 
 def test_batch_update_state_items(server: TSC.Server) -> None:


### PR DESCRIPTION
## Motivation

Closes #1250. TSC wraps extract refresh tasks per schedule with `get_extract_refresh_tasks(schedule_id)`, but there was no way to ask "which subscriptions run on this schedule?", which is what the issue asks for (monitoring the tasks in a schedule against a whitelist).

I went looking for a `/schedules/{id}/subscriptions` endpoint to mirror the extracts one, but the REST API doesn't have it. Subscriptions are only listable at the site level via [Query Subscriptions](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_subscriptions.htm#query_subscriptions), and each subscription already carries its schedule id. So this filters that list client side.

## Behavior change

Adds one public method:

```python
subs = server.schedules.get_subscriptions_by_schedule(schedule_id)  # -> list[SubscriptionItem]
```

It pages through the site subscriptions and returns the ones whose `schedule_id` matches, so on a busy site it costs one request per page. Nothing else changes. I put it on `Schedules` next to `get_extract_refresh_tasks` so the two task-listing calls live together. Because there's no server-side filter, this is a plain `list`, not a `(list, PaginationItem)` tuple like `get()`. Documented the per-page cost and the "no per-schedule endpoint" caveat in the docstring, and added a CHANGELOG entry.

## Test plan

- `test_get_subscriptions_by_schedule` reuses the existing `subscription_get.xml` asset (its two subscriptions are on different schedules) and asserts only the matching one comes back.
- `test_get_subscriptions_by_schedule_no_match` asserts an unknown schedule id yields `[]`.
- `test_get_subscriptions_by_schedule_empty_id` asserts an empty id raises `ValueError`, matching the other schedule methods.
- Full suite: 908 passed, 1 skipped. `black --check` and `mypy` clean.

One thing on trust rather than a regression test: I couldn't hit a live server, so the client-side-filter approach rests on the documented fact that Query Subscriptions returns every subscription with its `<schedule id=...>`, which the existing `SubscriptionItem` parsing already relies on.
