### PR TITLE
docs: prep CHANGELOG for v0.42 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,14 @@
   hops (default 30). Refuses HTTPS -> HTTP scheme downgrades and raises
   `RedirectError` with a clear message on missing `Location` headers or hop
   overflow. Fixes #1127 and #1828.
-* Fixed `Filter` serialization for `datetime`, `date`, and `bool` values.
-  Datetimes now emit ISO-8601 UTC (`2023-01-01T00:00:00Z`) instead of
-  `str(dt)`'s space-separated form, and booleans emit lowercase
-  `true`/`false` rather than Python's capitalized `True`/`False`. Both
-  previously produced 400s from the REST API on fields like `isCertified`,
-  `hasExtracts`, and any `createdAt` / `updatedAt` filter. Naive datetimes
-  now raise `ValueError` up front rather than silently producing a
-  wrong-timezone value. Fixes #1025.
+* Fixed `Filter` serialization for `datetime` and `bool` values. Datetimes
+  now emit ISO-8601 UTC (`2023-01-01T00:00:00Z`) instead of `str(dt)`'s
+  space-separated form, and booleans emit lowercase `true`/`false` rather
+  than Python's capitalized `True`/`False`. Both previously produced 400s
+  from the REST API on fields like `isCertified`, `hasExtracts`, and any
+  `createdAt` / `updatedAt` filter. Naive datetimes now raise `ValueError`
+  up front rather than silently producing a wrong-timezone value. Fixes
+  #1025.
 * `UserItem.CSVImport.create_user_from_line` no longer
   lowercases the entire CSV line before parsing. Previously the whole line,
   including the username, display name, fullname, and email fields, was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   hops (default 30). Refuses HTTPS -> HTTP scheme downgrades and raises
   `RedirectError` with a clear message on missing `Location` headers or hop
   overflow. Fixes #1127 and #1828.
+* Fixed `Filter` serialization for `datetime`, `date`, and `bool` values.
+  Datetimes now emit ISO-8601 UTC (`2023-01-01T00:00:00Z`) instead of
+  `str(dt)`'s space-separated form, and booleans emit lowercase
+  `true`/`false` rather than Python's capitalized `True`/`False`. Both
+  previously produced 400s from the REST API on fields like `isCertified`,
+  `hasExtracts`, and any `createdAt` / `updatedAt` filter. Naive datetimes
+  now raise `ValueError` up front rather than silently producing a
+  wrong-timezone value. Fixes #1025.
 * `UserItem.CSVImport.create_user_from_line` no longer
   lowercases the entire CSV line before parsing. Previously the whole line,
   including the username, display name, fullname, and email fields, was
@@ -30,6 +38,13 @@
   lookups keyed on `user.name`, or assertions against lowercased values --
   need to update. This unblocks CSV imports for LDAP and other case-sensitive
   auth backends where mixed-case usernames must be preserved.
+* `SiteItem.custom_subscription_email` and `custom_subscription_footer` now
+  serialize verbatim in create and update requests. Previously
+  `RequestFactory.Site` lowercased both values before sending, which
+  mangled the customer-facing footer that ships in outgoing subscription
+  emails (removing company-name casing, sentence capitalization, and brand
+  terms). The paired `*_enabled` boolean fields still serialize as
+  `"true"`/`"false"`. Fixes #1849.
 * `UserItem.CSVImport._validate_attribute_value` and the too-many-columns
   branch of `_validate_import_line_or_throw` now raise `ValueError` instead
   of `AttributeError` for invalid CSV input. `AttributeError` was the wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.42 (2026-08-25)
+
 * Bumped the urllib3 floor to 2.6.3 to pick up the fix for CVE-2026-21441
   (GHSA-38jv-5279-wg99, 8.9 High): urllib3's streaming decompression
   safeguards were bypassed when HTTP redirects were followed. TSC's manual


### PR DESCRIPTION
## Summary

Prepares CHANGELOG.md for the v0.42 release. Two things:

1. Adds two missing entries to what was `## Unreleased`:
   - **#1805** — `Filter` now serializes `datetime` and `bool` values in
     the wire format the REST API accepts (ISO-8601 UTC for datetime,
     lowercase `true`/`false` for bool). Previously produced 400s on
     `createdAt` / `updatedAt` / `isCertified` / `hasExtracts` filters.
   - **#1851** — `SiteItem.custom_subscription_email` and
     `custom_subscription_footer` no longer lowercased on serialize. The
     footer ships verbatim in outgoing subscription emails, so lowercasing
     mangled brand terms and sentence capitalization.
2. Renames `## Unreleased` to `## v0.42 (2026-08-25)` and adds a fresh empty
   `## Unreleased` section above it, so master can be tagged after this
   merges.

## Testing

- [x] Confirmed the two new bullets against the actual merged diffs
  (`94ab761` for #1805, `1f76444` for #1851). Caught and corrected one
  inaccuracy on the Filter bullet — the `isinstance` check is for
  `datetime.datetime`, not `datetime.date`, so bare `date` objects fall
  through to `str()`. Bullet now says "datetime and bool", not
  "datetime, date, and bool".
- [x] Cross-checked `git log v0.41..development --after=2026-06-25` — 24
  commits, 7 user-facing. All 7 are in the `## v0.42` section. Remaining
  17 are CI/dev-tooling (dependabot bumps, stale-action config, setup
  actions), docs-only (PR template, docstrings), or internal refactors
  (`_decompose_site_role`, `DownloadableMixin` extraction, mypy fixes,
  CRLF normalization) with no caller-observable change.
- [x] Verified against the v0.41 GitHub Release notes that pre-existing
  compare noise (parallel-merged history from before the v0.41 tag) is
  already covered by the v0.41 Release body.

## Note on CHANGELOG history

`CHANGELOG.md` currently jumps from this section straight to
`## 0.18.0 (2022)`. Every release from 0.19 through 0.41 wrote notes
directly in the GitHub Release body and skipped `CHANGELOG.md`. v0.42 is
the first release in years to use the file for its intended purpose. Not
fixing the historical gap here; file a follow-up if we want it backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)